### PR TITLE
Add fleet X-elastic-product-origin header

### DIFF
--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -216,6 +216,11 @@ func TestConfig(t *testing.T) {
 				}
 			} else {
 				require.NoError(t, err)
+				if test.cfg.Output.Elasticsearch.Headers == nil {
+					test.cfg.Output.Elasticsearch.Headers = map[string]string{
+						"X-elastic-product-origin": "fleet",
+					}
+				}
 				if !assert.True(t, cmp.Equal(test.cfg, cfg)) {
 					diff := cmp.Diff(test.cfg, cfg)
 					if diff != "" {

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -216,11 +216,6 @@ func TestConfig(t *testing.T) {
 				}
 			} else {
 				require.NoError(t, err)
-				if test.cfg.Output.Elasticsearch.Headers == nil {
-					test.cfg.Output.Elasticsearch.Headers = map[string]string{
-						"X-elastic-product-origin": "fleet",
-					}
-				}
 				if !assert.True(t, cmp.Equal(test.cfg, cfg)) {
 					diff := cmp.Diff(test.cfg, cfg)
 					if diff != "" {

--- a/internal/pkg/config/output.go
+++ b/internal/pkg/config/output.go
@@ -48,6 +48,12 @@ func (c *Elasticsearch) InitDefaults() {
 	c.MaxRetries = 3
 	c.MaxConnPerHost = 128
 	c.BulkFlushInterval = 250 * time.Millisecond
+
+	// Set special header "X-elastic-product-origin" for .fleet-* indices based on the latest conversation with ES team
+	// This eliminates the warning while accessing the system index
+	c.Headers = map[string]string{
+		"X-elastic-product-origin": "fleet",
+	}
 }
 
 // Validate ensures that the configuration is valid.

--- a/internal/pkg/config/output.go
+++ b/internal/pkg/config/output.go
@@ -122,7 +122,7 @@ func (c *Elasticsearch) ToESConfig() (elasticsearch.Config, error) {
 
 	// Set special header "X-elastic-product-origin" for .fleet-* indices based on the latest conversation with ES team
 	// This eliminates the warning while accessing the system index
-	c.Headers["X-elastic-product-origin"] = "fleet"
+	h.Set("X-elastic-product-origin", "fleet")
 
 	return elasticsearch.Config{
 		Addresses:  addrs,

--- a/internal/pkg/config/output.go
+++ b/internal/pkg/config/output.go
@@ -122,9 +122,7 @@ func (c *Elasticsearch) ToESConfig() (elasticsearch.Config, error) {
 
 	// Set special header "X-elastic-product-origin" for .fleet-* indices based on the latest conversation with ES team
 	// This eliminates the warning while accessing the system index
-	c.Headers = map[string]string{
-		"X-elastic-product-origin": "fleet",
-	}
+	c.Headers["X-elastic-product-origin"] = "fleet"
 
 	return elasticsearch.Config{
 		Addresses:  addrs,

--- a/internal/pkg/config/output.go
+++ b/internal/pkg/config/output.go
@@ -48,12 +48,6 @@ func (c *Elasticsearch) InitDefaults() {
 	c.MaxRetries = 3
 	c.MaxConnPerHost = 128
 	c.BulkFlushInterval = 250 * time.Millisecond
-
-	// Set special header "X-elastic-product-origin" for .fleet-* indices based on the latest conversation with ES team
-	// This eliminates the warning while accessing the system index
-	c.Headers = map[string]string{
-		"X-elastic-product-origin": "fleet",
-	}
 }
 
 // Validate ensures that the configuration is valid.
@@ -124,6 +118,12 @@ func (c *Elasticsearch) ToESConfig() (elasticsearch.Config, error) {
 	h := http.Header{}
 	for key, val := range c.Headers {
 		h.Set(key, val)
+	}
+
+	// Set special header "X-elastic-product-origin" for .fleet-* indices based on the latest conversation with ES team
+	// This eliminates the warning while accessing the system index
+	c.Headers = map[string]string{
+		"X-elastic-product-origin": "fleet",
 	}
 
 	return elasticsearch.Config{

--- a/internal/pkg/config/output_test.go
+++ b/internal/pkg/config/output_test.go
@@ -173,6 +173,7 @@ func TestToESConfig(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			res, err := test.cfg.ToESConfig()
 			require.NoError(t, err)
+			test.result.Header.Set("X-elastic-product-origin", "fleet")
 			if !assert.True(t, cmp.Equal(test.result, res, copts...)) {
 				diff := cmp.Diff(test.result, res, copts...)
 				if diff != "" {


### PR DESCRIPTION
## What does this PR do?

Adds X-elastic-product-origin header to all the requests to elasticsearch.
This eliminates the Warning header from Elasticsearch responses while querying against .fleet-* indices, 
where otherwise you would get:
```
299 Elasticsearch-8.0.0-SNAPSHOT-5859c4d6e62606428c2e49a181c7f845cadabecb "this request accesses system indices: [.fleet-actions], but in a future major version, direct access to system indices will be prevented by default"
```
