### PR TITLE
Add enrollment API key definition into the schema

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -170,6 +170,10 @@ func (f *FleetServer) runServer(ctx context.Context, cfg *config.Config) (err er
 	if err != nil {
 		return err
 	}
+	err = esboot.Migrate(ctx, sv, es.Bulk())
+	if err != nil {
+		return err
+	}
 
 	var funcs []runner.RunFunc
 	var wg sync.WaitGroup

--- a/cmd/fleet/server.go
+++ b/cmd/fleet/server.go
@@ -25,7 +25,7 @@ func diagConn(c net.Conn, s http.ConnState) {
 		Msg("connection state change")
 }
 
-func runServer(ctx context.Context, router *httprouter.Router, cfg *config.Server, errCh chan<- error) error {
+func runServer(ctx context.Context, router *httprouter.Router, cfg *config.Server) error {
 
 	addr := cfg.BindAddress()
 	rdto := cfg.Timeouts.Read
@@ -79,11 +79,9 @@ func runServer(ctx context.Context, router *httprouter.Router, cfg *config.Serve
 		return server.ServeTLS(ln, certFile, keyFile)
 	}
 
-	go func(ln net.Listener) {
-		if err := server.Serve(ln); err != nil && err != context.Canceled {
-			errCh <- err
-		}
-	}(ln)
+	if err := server.Serve(ln); err != nil && err != context.Canceled {
+		return err
+	}
 
 	return nil
 }

--- a/cmd/fleet/server_test.go
+++ b/cmd/fleet/server_test.go
@@ -45,7 +45,7 @@ func TestRunServer(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		err = runServer(ctx, router, cfg, errCh)
+		err = runServer(ctx, router, cfg)
 		wg.Done()
 	}()
 	var errFromChan error

--- a/internal/pkg/dl/constants.go
+++ b/internal/pkg/dl/constants.go
@@ -6,8 +6,9 @@ package dl
 
 // Indices names
 const (
-	FleetActions = ".fleet-actions"
-	FleetAgents  = ".fleet-agents"
+	FleetActions           = ".fleet-actions"
+	FleetAgents            = ".fleet-agents"
+	FleetEnrollmentAPIKeys = ".fleet-enrollment-api-keys"
 )
 
 // Query fields

--- a/internal/pkg/dl/enrollment_api_key.go
+++ b/internal/pkg/dl/enrollment_api_key.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package dl
 
 import "fleet/internal/pkg/dsl"

--- a/internal/pkg/dl/enrollment_api_key.go
+++ b/internal/pkg/dl/enrollment_api_key.go
@@ -1,0 +1,17 @@
+package dl
+
+import "fleet/internal/pkg/dsl"
+
+// PrepareQueryAllAPIKeys prepares a query. For migration only.
+func PrepareQueryAllAPIKeys(size uint64) ([]byte, error) {
+	tmpl := dsl.NewTmpl()
+
+	root := dsl.NewRoot()
+	root.Size(size)
+
+	err := tmpl.Resolve(root)
+	if err != nil {
+		return nil, err
+	}
+	return tmpl.Render(nil)
+}

--- a/internal/pkg/es/client.go
+++ b/internal/pkg/es/client.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 
 	"fleet/internal/pkg/bulk"
 	"fleet/internal/pkg/config"
@@ -74,36 +73,6 @@ func (c *Client) Info(ctx context.Context) (*InfoResponse, error) {
 // Bulk returns the hulk interface to perform bulk operations.
 func (c *Client) Bulk() bulk.Bulk {
 	return c.blk
-}
-
-// Reload reloads the client with the updated configuration.
-func (c *Client) Reload(ctx context.Context, cfg *config.Config) error {
-	if !reflect.DeepEqual(c.cfg.Output.Elasticsearch, cfg.Output.Elasticsearch) {
-		// reload the ES client
-		escfg, err := cfg.Output.Elasticsearch.ToESConfig()
-		if err != nil {
-			return err
-		}
-		es, err := elasticsearch.NewClient(escfg)
-		if err != nil {
-			return err
-		}
-		resp, err := info(ctx, es)
-		if err != nil {
-			return err
-		}
-
-		// replace the transport
-		// as that is only thing that was changed
-		c.Client.Transport = es.Transport
-		log.Info().
-			Str("name", resp.ClusterName).
-			Str("uuid", resp.ClusterUUID).
-			Str("vers", resp.Version.Number).
-			Msg("Cluster Info")
-	}
-	c.cfg = cfg
-	return nil
 }
 
 type InfoResponse struct {

--- a/internal/pkg/esboot/bootstrap.go
+++ b/internal/pkg/esboot/bootstrap.go
@@ -18,12 +18,13 @@ type indexConfig struct {
 }
 
 var indexConfigs = map[string]indexConfig{
-	".fleet-servers":         {mapping: MappingServer},
-	".fleet-policies":        {mapping: MappingPolicy},
-	".fleet-policies-leader": {mapping: MappingPolicyLeader},
-	".fleet-agents":          {mapping: MappingAgent},
-	".fleet-actions":         {mapping: MappingAction},
-	".fleet-actions-results": {mapping: MappingActionResult, datastream: true},
+	".fleet-actions":             {mapping: MappingAction},
+	".fleet-actions-results":     {mapping: MappingActionResult, datastream: true},
+	".fleet-agents":              {mapping: MappingAgent},
+	".fleet-enrollment-api-keys": {mapping: MappingEnrollmentApiKey},
+	".fleet-policies":            {mapping: MappingPolicy},
+	".fleet-policies-leader":     {mapping: MappingPolicyLeader},
+	".fleet-servers":             {mapping: MappingServer},
 }
 
 // Bootstrap creates .fleet-actions data stream

--- a/internal/pkg/esboot/mapping.go
+++ b/internal/pkg/esboot/mapping.go
@@ -133,6 +133,36 @@ const (
 	}
 }`
 
+	// EnrollmentApiKey An Elastic Agent enrollment API key
+	MappingEnrollmentApiKey = `{
+	"properties": {
+		"active": {
+			"type": "boolean"
+		},
+		"api_key": {
+			"type": "keyword"
+		},
+		"api_key_id": {
+			"type": "keyword"
+		},
+		"created_at": {
+			"type": "date"
+		},
+		"expire_at": {
+			"type": "date"
+		},
+		"name": {
+			"type": "keyword"
+		},
+		"policy_id": {
+			"type": "keyword"
+		},
+		"updated_at": {
+			"type": "date"
+		}		
+	}
+}`
+
 	// HostMetadata The host metadata for the Elastic Agent
 	MappingHostMetadata = `{
 	"properties": {

--- a/internal/pkg/esboot/migrate.go
+++ b/internal/pkg/esboot/migrate.go
@@ -1,0 +1,104 @@
+package esboot
+
+import (
+	"context"
+	"encoding/json"
+	"fleet/internal/pkg/bulk"
+	"fleet/internal/pkg/dl"
+	"fleet/internal/pkg/model"
+	"fleet/internal/pkg/saved"
+)
+
+type enrollmentApiKey struct {
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	ApiKey    string `json:"api_key" saved:"encrypt"`
+	ApiKeyId  string `json:"api_key_id"`
+	PolicyId  string `json:"policy_id"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+	ExpireAt  string `json:"expire_at"`
+	Active    bool   `json:"active"`
+}
+
+// Data migration
+// This is for development only (1 instance of fleet)
+// Not safe for multiple instances of fleet
+// Initially needed to migrate the enrollment-api-keys that kibana creates
+func Migrate(ctx context.Context, sv saved.CRUD, bulker bulk.Bulk) error {
+	return MigrateEnrollmentAPIKeys(ctx, sv, bulker)
+}
+
+func MigrateEnrollmentAPIKeys(ctx context.Context, sv saved.CRUD, bulker bulk.Bulk) error {
+
+	// Query all enrollment keys from the new schema
+	raw, err := dl.PrepareQueryAllAPIKeys(1000)
+	if err != nil {
+		return err
+	}
+
+	var recs []model.EnrollmentApiKey
+	res, err := bulker.Search(ctx, []string{dl.FleetEnrollmentAPIKeys}, raw, bulk.WithRefresh())
+	if err != nil {
+		return err
+	}
+
+	for _, hit := range res.Hits {
+		var rec model.EnrollmentApiKey
+		err := json.Unmarshal(hit.Source, &rec)
+		if err != nil {
+			return err
+		}
+		recs = append(recs, rec)
+	}
+
+	// Query enrollment keys from kibana saved objects
+	query := saved.NewQuery("fleet-enrollment-api-keys")
+
+	hits, err := sv.FindByNode(ctx, query)
+	if err != nil {
+		return err
+	}
+
+	for _, hit := range hits {
+		var rec enrollmentApiKey
+		if err := sv.Decode(hit, &rec); err != nil {
+			return err
+		}
+		if _, ok := findExistingEnrollmentAPIKey(recs, rec); !ok {
+			newRec := translateEnrollmentAPIKey(rec)
+			b, err := json.Marshal(newRec)
+			if err != nil {
+				return err
+			}
+			_, err = bulker.Create(ctx, dl.FleetEnrollmentAPIKeys, "", b, bulk.WithRefresh())
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func findExistingEnrollmentAPIKey(hay []model.EnrollmentApiKey, needle enrollmentApiKey) (*model.EnrollmentApiKey, bool) {
+	for _, rec := range hay {
+		if rec.ApiKeyId == needle.ApiKey {
+			return &rec, true
+		}
+	}
+	return nil, false
+}
+
+func translateEnrollmentAPIKey(src enrollmentApiKey) model.EnrollmentApiKey {
+	return model.EnrollmentApiKey{
+		Active:    src.Active,
+		ApiKey:    src.ApiKey,
+		ApiKeyId:  src.ApiKeyId,
+		CreatedAt: src.CreatedAt,
+		ExpireAt:  src.ExpireAt,
+		Name:      src.Name,
+		PolicyId:  src.PolicyId,
+		UpdatedAt: src.UpdatedAt,
+	}
+}

--- a/internal/pkg/esboot/migrate.go
+++ b/internal/pkg/esboot/migrate.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package esboot
 
 import (

--- a/internal/pkg/model/schema.go
+++ b/internal/pkg/model/schema.go
@@ -121,6 +121,26 @@ type AgentMetadata struct {
 type Data struct {
 }
 
+// EnrollmentApiKey An Elastic Agent enrollment API key
+type EnrollmentApiKey struct {
+
+	// True when the key is active
+	Active bool `json:"active,omitempty"`
+
+	// Api key
+	ApiKey string `json:"api_key"`
+
+	// The unique identifier for the enrollment key, currently xid
+	ApiKeyId  string `json:"api_key_id"`
+	CreatedAt string `json:"created_at,omitempty"`
+	ExpireAt  string `json:"expire_at,omitempty"`
+
+	// Enrollment key name
+	Name      string `json:"name,omitempty"`
+	PolicyId  string `json:"policy_id,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
 // HostMetadata The host metadata for the Elastic Agent
 type HostMetadata struct {
 

--- a/internal/pkg/profile/profile.go
+++ b/internal/pkg/profile/profile.go
@@ -36,12 +36,11 @@ func RunProfiler(ctx context.Context, addr string) error {
 		BaseContext: bctx,
 	}
 
-	go func() {
-		log.Info().Str("bind", addr).Msg("Installing profiler")
-		if err := server.ListenAndServe(); err != nil {
-			log.Error().Err(err).Str("bind", addr).Msg("Fail install profiler")
-		}
-	}()
+	log.Info().Str("bind", addr).Msg("Installing profiler")
+	if err := server.ListenAndServe(); err != nil {
+		log.Error().Err(err).Str("bind", addr).Msg("Fail install profiler")
+		return err
+	}
 
 	return nil
 }

--- a/internal/pkg/runner/runner.go
+++ b/internal/pkg/runner/runner.go
@@ -1,0 +1,85 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package runner
+
+import (
+	"context"
+	"sync"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+type RunFunc func(context.Context) error
+type DoneFunc func(err error)
+
+func Start(ctx context.Context, wg *sync.WaitGroup, runfn RunFunc, donefn DoneFunc) {
+	wg.Add(1)
+
+	go func() {
+		err := runfn(ctx)
+		wg.Done()
+		if donefn != nil {
+			donefn(err)
+		}
+	}()
+}
+
+func StartGroup(ctx context.Context, ownerwg *sync.WaitGroup, runfns []RunFunc, donefn DoneFunc) {
+
+	log.Debug().Msg("Start group")
+	ctx, cn := context.WithCancel(ctx)
+
+	sz := len(runfns)
+
+	ech := make(chan error, sz)
+
+	if ownerwg != nil {
+		ownerwg.Add(1)
+	}
+
+	var wg sync.WaitGroup
+	for _, runfn := range runfns {
+		Start(ctx, &wg, runfn, func(er error) {
+			if er != nil {
+				select {
+				case ech <- er:
+				default:
+				}
+			}
+		})
+	}
+
+	go func() {
+		var err error
+		select {
+		case er := <-ech:
+			err = er
+		case <-ctx.Done():
+		}
+		cn()
+		wg.Wait()
+		ownerwg.Done()
+		log.Debug().Msg("Group is stopped")
+
+		if donefn != nil {
+			donefn(err)
+		}
+	}()
+}
+
+func LoggedRunFunc(tag string, runfn RunFunc) RunFunc {
+	return func(ctx context.Context) error {
+		log.Debug().Msg(tag + " started")
+		err := runfn(ctx)
+		var ev *zerolog.Event
+		if err != nil {
+			log.Error().Err(err)
+		}
+		ev = log.Debug()
+		ev.Msg(tag + " exited")
+		return err
+	}
+}

--- a/model/schema.json
+++ b/model/schema.json
@@ -337,6 +337,48 @@
         "enrolled_at",
         "updated_at"
       ]
+    },
+    "enrollment_api_key": {
+      "title": "Enrollment API key",
+      "description": "An Elastic Agent enrollment API key",
+      "type": "object",
+      "properties": {
+        "active": {
+          "description": "True when the key is active",
+          "type": "boolean"
+        },
+        "api_key_id": {
+          "description": "The unique identifier for the enrollment key, currently xid",
+          "type": "string"
+        },
+        "api_key": {
+          "description": "Api key",
+          "type": "string"
+        },
+        "name": {
+          "description": "Enrollment key name",
+          "type": "string"
+        },
+        "policy_id": {
+          "type": "string"
+        },
+        "expire_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": [
+        "api_key_id",
+        "api_key"
+      ]
     }
   },
   "checkin": {


### PR DESCRIPTION
## What does this PR do?
* Add enrollment API key definition into the schema
* Add migration code for development that migrates the keys from .kibana
  index into .fleet-enrollment-api-keys index


This PR is based on my previous PR that is still pending review, so this one contains the commit from that PR. So only commits after the first one are directly related to this change. 