### PR TITLE
[CI] Enable integration tests

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
   environment {
     REPO="fleet-server"
     BASE_DIR="src/github.com/elastic/${env.REPO}"
+    DOCKER_COMPOSE_VERSION = '1.25.5'
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     PIPELINE_LOG_LEVEL='INFO'
   }
@@ -59,6 +60,7 @@ pipeline {
         cleanup()
         withGoEnv(){
           dir("${BASE_DIR}"){
+            retryWithSleep(retries: 2, seconds: 5, backoff: true){ sh(label: "Install Docker", script: '.ci/scripts/install-docker-compose.sh') }
             sh(label: 'test', script: 'make test')
           }
         }

--- a/.ci/scripts/install-docker-compose.sh
+++ b/.ci/scripts/install-docker-compose.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+MSG="environment variable missing: DOCKER_COMPOSE_VERSION."
+DOCKER_COMPOSE_VERSION=${DOCKER_COMPOSE_VERSION:?$MSG}
+HOME=${HOME:?$MSG}
+
+if command -v docker-compose
+then
+    echo "Found docker-compose. Checking version.."
+    FOUND_DOCKER_COMPOSE_VERSION=$(docker-compose --version|awk '{print $3}'|sed s/\,//)
+    if [ "$FOUND_DOCKER_COMPOSE_VERSION" == "$DOCKER_COMPOSE_VERSION" ]
+    then
+        echo "Versions match. No need to install docker-compose. Exiting."
+        exit 0
+    fi
+fi
+
+echo "UNMET DEP: Installing docker-compose"
+
+DC_CMD="${HOME}/bin/docker-compose"
+
+mkdir -p "${HOME}/bin"
+
+curl -sSLo "${DC_CMD}" "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)"
+chmod +x "${DC_CMD}"

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ check-no-changes:
 .PHONY: test
 test:  ## - Run all tests
 	@$(MAKE) test-unit 
-	# @$(MAKE) test-int
+	@$(MAKE) test-int
 
 .PHONY: test-unit 
 test-unit: ## - Run unit tests only

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ export $(shell sed 's/=.*//' ./dev-tools/integration/.env)
 # Start ES with docker without waiting
 .PHONY: int-docker-start-async
 int-docker-start-async:
+	docker-compose --version
 	@docker-compose -f ./dev-tools/integration/docker-compose.yml --env-file ./dev-tools/integration/.env up  -d --remove-orphans elasticsearch
 
 # Wait for ES to be ready

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,6 @@ export $(shell sed 's/=.*//' ./dev-tools/integration/.env)
 # Start ES with docker without waiting
 .PHONY: int-docker-start-async
 int-docker-start-async:
-	docker-compose --version
 	@docker-compose -f ./dev-tools/integration/docker-compose.yml --env-file ./dev-tools/integration/.env up  -d --remove-orphans elasticsearch
 
 # Wait for ES to be ready


### PR DESCRIPTION
## What does this PR do?

Enable the ITs in the CI

## Why is it important?

It was commented since there was a dependency to upgrade the required docker-composer version in the CI workers.
