### PR TITLE
Remove agent saved object from enrollment code completely

### DIFF
--- a/cmd/fleet/handleCheckin.go
+++ b/cmd/fleet/handleCheckin.go
@@ -222,7 +222,7 @@ func (ct *CheckinT) resolveSeqNo(ctx context.Context, req CheckinRequest, agent 
 		sn, err = ct.tr.Resolve(ctx, ackToken)
 		if err != nil {
 			if errors.Is(err, dl.ErrNotFound) {
-				log.Debug().Str("token", ackToken).Str("agent_id", agent.Id).Msg("Token not found")
+				log.Debug().Str("token", ackToken).Str("agent_id", agent.Id).Msg("Action token not found")
 				err = nil
 			} else {
 				return

--- a/cmd/fleet/schema.go
+++ b/cmd/fleet/schema.go
@@ -9,9 +9,7 @@ import (
 )
 
 const (
-	AGENT_SAVED_OBJECT_TYPE               = "fleet-agents"
-	ENROLLMENT_API_KEYS_SAVED_OBJECT_TYPE = "fleet-enrollment-api-keys"
-	AGENT_ACTION_SAVED_OBJECT_TYPE        = "fleet-agent-actions"
+	AGENT_ACTION_SAVED_OBJECT_TYPE = "fleet-agent-actions"
 )
 
 const (


### PR DESCRIPTION
## What does this PR do?

Remove agent saved object from enrollment code completely. With this change the agent is not going to appear in kibana upon enrollment anymore until kibana switched to the new indexes.

## Why is it important?

This allows to test at scale fairly (without double saving into .kibana as before)