### PR TITLE
Improve index monitor logic. Add integration tests.

### DIFF
--- a/internal/pkg/monitor/monitor_integration_test.go
+++ b/internal/pkg/monitor/monitor_integration_test.go
@@ -1,0 +1,118 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build integration
+
+package monitor
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	"fleet/internal/pkg/bulk"
+	"fleet/internal/pkg/es"
+	"fleet/internal/pkg/model"
+	ftesting "fleet/internal/pkg/testing"
+)
+
+const testMonitorIntervalMS = 100
+
+func setupIndex(ctx context.Context, t *testing.T) (string, bulk.Bulk) {
+	index, bulker := ftesting.SetupIndexWithBulk(ctx, t, es.MappingAction)
+	return index, bulker
+}
+
+func TestMonitorEmptyIndex(t *testing.T) {
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+
+	index, bulker := setupIndex(ctx, t)
+	runMonitorTest(t, ctx, index, bulker)
+}
+
+func TestMonitorNonEmptyIndex(t *testing.T) {
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+
+	index, bulker, _ := ftesting.SetupActions(ctx, t, 1, 12)
+	runMonitorTest(t, ctx, index, bulker)
+}
+
+func runMonitorTest(t *testing.T, ctx context.Context, index string, bulker bulk.Bulk) {
+	readyCh := make(chan error)
+	mon, err := New(index, bulker.Client(),
+		WithCheckInterval(testMonitorIntervalMS*time.Millisecond),
+		WithReadyChan(readyCh),
+	)
+	require.NoError(t, err)
+
+	// Start monitor
+	var wg sync.WaitGroup
+	mctx, mcn := context.WithCancel(ctx)
+	var merr error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		merr = mon.Run(mctx)
+		if merr == context.Canceled {
+			merr = nil
+		}
+	}()
+
+	// Wait until monitor is running
+	err = <-readyCh
+	require.NoError(t, err)
+
+	// Create random actions
+	actions, err := ftesting.StoreRandomActions(ctx, bulker, index, 1, 7)
+	require.NoError(t, err)
+
+	var gotActions []model.Action
+	// Listen monitor updates
+	var mwg sync.WaitGroup
+	mwg.Add(1)
+	go func() {
+		defer mwg.Done()
+		for {
+			select {
+			case hits := <-mon.Output():
+				for _, hit := range hits {
+					var action model.Action
+					er := hit.Unmarshal(&action)
+					require.NoError(t, er)
+					gotActions = append(gotActions, action)
+					if len(gotActions) == len(actions) {
+						return
+					}
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	mwg.Wait()
+
+	// Need to set the seqno that are known only after the documents where indexed
+	// in order to compare the slices of structs as a whole
+	for i, a := range gotActions {
+		actions[i].SeqNo = a.SeqNo
+	}
+
+	// The documents should be the same and in the same order
+	diff := cmp.Diff(actions, gotActions)
+	if diff != "" {
+		t.Fatal(diff)
+	}
+
+	// Stop monitor and wait for clean exit
+	mcn()
+	wg.Wait()
+	require.NoError(t, merr)
+
+}

--- a/internal/pkg/testing/actions.go
+++ b/internal/pkg/testing/actions.go
@@ -1,0 +1,100 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build integration
+
+package testing
+
+import (
+	"context"
+	"encoding/json"
+	"fleet/internal/pkg/bulk"
+	"fleet/internal/pkg/es"
+	"fleet/internal/pkg/model"
+	"fleet/internal/pkg/rnd"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/rs/xid"
+)
+
+func CreateRandomActions(min, max int) ([]model.Action, error) {
+	r := rnd.New()
+
+	sz := r.Int(min, max)
+	agentIds := make([]string, sz)
+	for i := 0; i < sz; i++ {
+		agentIds[i] = uuid.Must(uuid.NewV4()).String()
+	}
+
+	sz = r.Int(4, 9)
+
+	now := time.Now().UTC()
+
+	actions := make([]model.Action, sz)
+
+	for i := 0; i < sz; i++ {
+		start := r.Int(0, len(agentIds))
+		end := start + r.Int(0, len(agentIds)-start)
+
+		payload := map[string]interface{}{
+			uuid.Must(uuid.NewV4()).String(): uuid.Must(uuid.NewV4()).String(),
+		}
+
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+
+		aid := agentIds[start:end]
+		if len(aid) == 0 {
+			aid = nil
+		}
+		action := model.Action{
+			ESDocument: model.ESDocument{
+				Id: xid.New().String(),
+			},
+			ActionId:   uuid.Must(uuid.NewV4()).String(),
+			Timestamp:  r.Time(now, 2, 5, time.Second, rnd.TimeBefore).Format(time.RFC3339),
+			Expiration: r.Time(now, 12, 25, time.Minute, rnd.TimeAfter).Format(time.RFC3339),
+			Type:       "APP_ACTION",
+			InputId:    "osquery",
+			Agents:     aid,
+			Data:       data,
+		}
+
+		actions[i] = action
+	}
+	return actions, nil
+}
+
+func StoreRandomActions(ctx context.Context, bulker bulk.Bulk, index string, min, max int) ([]model.Action, error) {
+	actions, err := CreateRandomActions(min, max)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, action := range actions {
+		body, err := json.Marshal(action)
+		if err != nil {
+			return nil, err
+		}
+		_, err = bulker.Create(ctx, index, action.Id, body, bulk.WithRefresh())
+		if err != nil {
+			return nil, err
+		}
+	}
+	return actions, err
+}
+
+func SetupActions(ctx context.Context, t *testing.T, min, max int) (string, bulk.Bulk, []model.Action) {
+	index, bulker := SetupIndexWithBulk(ctx, t, es.MappingAction)
+	actions, err := StoreRandomActions(ctx, bulker, index, min, max)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return index, bulker, actions
+}


### PR DESCRIPTION
## What does this PR do?

* Improve monitor: check the global checkpoint stats only when the
  changes detected. Before it was checking global checkpoint first. Now
  it executes the small query on the index to detect that the new
  documents were indexed first. If the new document is detected then it
  checks for the global checkpoint. After that the documents are
  queried as before, capped by the global checkpoint value. This is
  better that pulling large index stats document every second.
* Create integration tests for the monitor.
* Move the helpers for random actions creation/initialization into
  "testing" package since, they are now shared between actions
  integration tests and the monitor integration tests.

