### PR TITLE
Fix policy monitor, add test

### DIFF
--- a/internal/pkg/policy/monitor.go
+++ b/internal/pkg/policy/monitor.go
@@ -83,7 +83,7 @@ func NewMonitor(bulker bulk.Bulk, monitor monitor.Monitor, throttle time.Duratio
 		log:           log.With().Str("ctx", "policy agent manager").Logger(),
 		bulker:        bulker,
 		monitor:       monitor,
-		kickCh:        make(chan struct{}),
+		kickCh:        make(chan struct{}, 1),
 		policies:      make(map[string]policyT),
 		throttle:      throttle,
 		policyF:       dl.QueryLatestPolicies,
@@ -317,7 +317,6 @@ func (m *monitorT) Subscribe(agentId string, policyId string, revisionIdx int64,
 		if !ok {
 			p = policyT{subs: make(map[uint64]subT)}
 			m.policies[policyId] = p
-
 			select {
 			case m.kickCh <- struct{}{}:
 			default:


### PR DESCRIPTION
## What does this PR do?

This addresses the policy monitor defect that lead to intermittent failures in CI environment as described in 
https://github.com/elastic/fleet-server/issues/48 

Enabled the test `TestMonitor_NewPolicyExists` back and added the test coverage for repro case.

## Screenshots
Tests before the change, that shows the problem with delay in the monitor running go routine start:
<img width="1247" alt="Screen Shot 2021-01-04 at 7 38 39 PM" src="https://user-images.githubusercontent.com/872351/103593979-51a19580-4ec5-11eb-8fbf-4dd5ef161ea7.png">

Tests after the change:
<img width="1246" alt="Screen Shot 2021-01-04 at 7 39 01 PM" src="https://user-images.githubusercontent.com/872351/103594042-844b8e00-4ec5-11eb-863d-d2e3a49b0bb7.png">

