### PR TITLE
Add notes around encryption key usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin/
 build/
 
 fleet-server
+fleet-server.dev.yml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 [![Build Status](https://beats-ci.elastic.co/job/Ingest-manager/job/fleet-server/job/master/badge/icon)](https://beats-ci.elastic.co/job/Ingest-manager/job/fleet-server/job/master/)
 
 # Fleet Server implementation
+
+## Development
+
+fleet-server is under development. The following are notes to help developers onboarding to the project to quickly get running. These notes might change at any time.
+
+### Startup fleet-server
+
+Currently to startup fleet-server, the Kibana encryption key is needed. There are two options for this.
+
+Either the key `a...` is used in the kibana config as this is the default:
+
+```
+xpack.encryptedSavedObjects.encryptionKey: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+```
+
+The alternative is to use `ES_SAVED_KEY` and pass it to fleet-server during setup with the value of the encryption key used in Kibana.


### PR DESCRIPTION
This adds a note on how to pass in the encryption key to fleet-server to connect it to Elasticsearch. This is only temporary until changes were made in Kibana.

Additionaly the fleet-server.dev.yml was added to gitignore. This allows to have a local config file which is not checked in.
