### PR TITLE
Fix the agent ID handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 .idea/
 .vscode/
 

--- a/dev-tools/package/Dockerfile
+++ b/dev-tools/package/Dockerfile
@@ -45,7 +45,7 @@ from buildenv as builder
 
 # Build the binary, use ldflags to minimize executable size
 ARG LDFLAGS
-RUN --mount=type=cache,target=/root/.cache/go-build go build -trimpath -ldflags="$LDFLAGS" -o /go/bin/fleet .
+RUN --mount=type=cache,target=/root/.cache/go-build go build -trimpath -ldflags="$LDFLAGS" -o /go/bin/fleet-server .
 
 COPY ./fleet-server.yml /go/bin/fleet-server.yml
 
@@ -61,7 +61,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /etc/passwd /etc/passwd
 
 # Copy our static executable
-COPY --from=builder /go/bin/fleet /go/bin/fleet
+COPY --from=builder /go/bin/fleet-server /go/bin/fleet-server
 COPY --from=builder /go/bin/fleet-server.yml /go/bin/fleet-server.yml
 
 # Use an unprivileged user.
@@ -71,7 +71,7 @@ USER appuser
 WORKDIR "/go/bin/"
 
 # Run the fleet binary.
-ENTRYPOINT ["./fleet"]
+ENTRYPOINT ["./fleet-server"]
 
 ############################
 # STEP 2 rpmbuild
@@ -82,12 +82,12 @@ FROM goreleaser/nfpm as rpmbuild
 COPY . .
 
 # Copy our static executables
-COPY --from=builder /go/bin/fleet ./bin/fleet
+COPY --from=builder /go/bin/fleet-server ./bin/fleet-server
 
 env APP_VERSION=${VERSION}
 env APP_RELEASE=${COMMIT}
 
-RUN /nfpm pkg --config ./build/rpm/nfpm.yaml --target out.rpm
+RUN nfpm pkg --config ./dev-tools/rpm/nfpm.yaml --target out.rpm
 
 ############################
 # STEP 5 rpm

--- a/dev-tools/package/Dockerfile
+++ b/dev-tools/package/Dockerfile
@@ -45,7 +45,7 @@ from buildenv as builder
 
 # Build the binary, use ldflags to minimize executable size
 ARG LDFLAGS
-RUN --mount=type=cache,target=/root/.cache/go-build go build -trimpath -ldflags="$LDFLAGS" -o /go/bin/fleet-server .
+RUN --mount=type=cache,target=/root/.cache/go-build go build -trimpath -ldflags="$LDFLAGS" -o /go/bin/fleet .
 
 COPY ./fleet-server.yml /go/bin/fleet-server.yml
 
@@ -61,7 +61,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /etc/passwd /etc/passwd
 
 # Copy our static executable
-COPY --from=builder /go/bin/fleet-server /go/bin/fleet-server
+COPY --from=builder /go/bin/fleet /go/bin/fleet
 COPY --from=builder /go/bin/fleet-server.yml /go/bin/fleet-server.yml
 
 # Use an unprivileged user.
@@ -71,7 +71,7 @@ USER appuser
 WORKDIR "/go/bin/"
 
 # Run the fleet binary.
-ENTRYPOINT ["./fleet-server"]
+ENTRYPOINT ["./fleet"]
 
 ############################
 # STEP 2 rpmbuild
@@ -82,7 +82,7 @@ FROM goreleaser/nfpm as rpmbuild
 COPY . .
 
 # Copy our static executables
-COPY --from=builder /go/bin/fleet-server ./bin/fleet-server
+COPY --from=builder /go/bin/fleet ./bin/fleet
 
 env APP_VERSION=${VERSION}
 env APP_RELEASE=${COMMIT}

--- a/dev-tools/rpm/nfpm.yaml
+++ b/dev-tools/rpm/nfpm.yaml
@@ -11,8 +11,8 @@ description: Elastic Fleet
 vendor: "Elastic NV"
 homepage: "http://www.elastic.co/"
 contents:
-  - src: ./bin/fleet-server
-    dst: /usr/bin/fleet-server
+  - src: ./bin/fleet
+    dst: /usr/bin/fleet
 
   - src: ./systemd/fleet.service
     dst: /usr/lib/systemd/system/fleet.service

--- a/dev-tools/rpm/nfpm.yaml
+++ b/dev-tools/rpm/nfpm.yaml
@@ -10,9 +10,15 @@ maintainer: "devops@endgame.com"
 description: Elastic Fleet
 vendor: "Elastic NV"
 homepage: "http://www.elastic.co/"
-files:
-  ./bin/fleet: "/usr/bin/fleet"
-config_files:
-  ./systemd/fleet.service: "/usr/lib/systemd/system/fleet.service"
-  ./fleet-server.yml: "/usr/share/fleet/fleet-server.yml"
+contents:
+  - src: ./bin/fleet-server
+    dst: /usr/bin/fleet-server
+
+  - src: ./systemd/fleet.service
+    dst: /usr/lib/systemd/system/fleet.service
+    type: config
+
+  - src: ./fleet-server.yml
+    dst: /usr/share/fleet/fleet-server.yml
+    type: config
 

--- a/fleet-server.yml
+++ b/fleet-server.yml
@@ -1,8 +1,8 @@
 output:
   elasticsearch:
-    hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'
-    username: '${ELASTICSEARCH_USERNAME:}'
-    password: '${ELASTICSEARCH_PASSWORD:}'
+    hosts: '${ELASTICSEARCH_HOSTS:localhost:9200}'
+    username: '${ELASTICSEARCH_USERNAME:elastic}'
+    password: '${ELASTICSEARCH_PASSWORD:changeme}'
 
 fleet:
   agent:

--- a/systemd/fleet.service
+++ b/systemd/fleet.service
@@ -4,7 +4,7 @@ After=network.target
 Requires=network.target
 
 [Service]
-ExecStart=/usr/bin/fleet -c /usr/share/fleet/fleet-server.yml
+ExecStart=/usr/bin/fleet-server -c /usr/share/fleet/fleet-server.yml
 Type=simple
 Restart=always
 RestartSec=3


### PR DESCRIPTION
## What does this PR do?

Sets the correct agent id in the local meta upon enrollment if the agent id was provided. Does modify the local meta if the agent was not provided. 
Eventually the agent id in the local meta should not be used and the doc id value on the agent document should be used everywhere instead.

The related horde fix for the agent ID was done here https://github.com/elastic/horde/pull/23

