### PR TITLE
Fix new agent sequence number

### DIFF
--- a/cmd/fleet/handleEnroll.go
+++ b/cmd/fleet/handleEnroll.go
@@ -206,6 +206,7 @@ func _enroll(ctx context.Context, bulker bulk.Bulk, c cache.Cache, req EnrollReq
 		AccessApiKeyId:  accessApiKey.Id,
 		DefaultApiKeyId: defaultOutputApiKey.Id,
 		DefaultApiKey:   defaultOutputApiKey.Token(),
+		ActionSeqNo:     dl.UndefinedSeqNo,
 	}
 
 	err = createFleetAgent(ctx, bulker, agentId, agentData)


### PR DESCRIPTION
## What does this PR do?

Set -1 for the newly create agent action_seq_no.

## Why is it important?

This covers the case of the very first agent action in the systen with doc seq_no 0, that would go undetected if the newly create agents start with the action_seq_no == 0.

