### PR TITLE
[Fleet] Fix api key format for agent policy

### DIFF
--- a/cmd/fleet/handleCheckin.go
+++ b/cmd/fleet/handleCheckin.go
@@ -282,7 +282,7 @@ func parsePolicy(ctx context.Context, bulker bulk.Bulk, agentId string, p model.
 		if err != nil {
 			return nil, err
 		}
-		agent.DefaultApiKey = defaultOutputApiKey.Config()
+		agent.DefaultApiKey = defaultOutputApiKey.Agent()
 		agent.DefaultApiKeyId = defaultOutputApiKey.Id
 
 		log.Info().Str("agentId", agentId).Msg("Rewriting full agent record to pick up default output key.")

--- a/cmd/fleet/handleCheckin.go
+++ b/cmd/fleet/handleCheckin.go
@@ -282,7 +282,7 @@ func parsePolicy(ctx context.Context, bulker bulk.Bulk, agentId string, p model.
 		if err != nil {
 			return nil, err
 		}
-		agent.DefaultApiKey = defaultOutputApiKey.Token()
+		agent.DefaultApiKey = defaultOutputApiKey.Config()
 		agent.DefaultApiKeyId = defaultOutputApiKey.Id
 
 		log.Info().Str("agentId", agentId).Msg("Rewriting full agent record to pick up default output key.")

--- a/cmd/fleet/handleEnroll.go
+++ b/cmd/fleet/handleEnroll.go
@@ -205,7 +205,7 @@ func _enroll(ctx context.Context, bulker bulk.Bulk, c cache.Cache, req EnrollReq
 		LocalMetadata:   localMeta,
 		AccessApiKeyId:  accessApiKey.Id,
 		DefaultApiKeyId: defaultOutputApiKey.Id,
-		DefaultApiKey:   defaultOutputApiKey.Token(),
+		DefaultApiKey:   defaultOutputApiKey.Config(),
 	}
 
 	err = createFleetAgent(ctx, bulker, agentId, agentData)

--- a/cmd/fleet/handleEnroll.go
+++ b/cmd/fleet/handleEnroll.go
@@ -205,7 +205,7 @@ func _enroll(ctx context.Context, bulker bulk.Bulk, c cache.Cache, req EnrollReq
 		LocalMetadata:   localMeta,
 		AccessApiKeyId:  accessApiKey.Id,
 		DefaultApiKeyId: defaultOutputApiKey.Id,
-		DefaultApiKey:   defaultOutputApiKey.Config(),
+		DefaultApiKey:   defaultOutputApiKey.Agent(),
 	}
 
 	err = createFleetAgent(ctx, bulker, agentId, agentData)

--- a/internal/pkg/apikey/apikey.go
+++ b/internal/pkg/apikey/apikey.go
@@ -58,7 +58,7 @@ func (k ApiKey) Token() string {
 	return base64.StdEncoding.EncodeToString([]byte(s))
 }
 
-func (k ApiKey) Config() string {
+func (k ApiKey) Agent() string {
 	return fmt.Sprintf("%s:%s", k.Id, k.Key)
 }
 

--- a/internal/pkg/apikey/apikey.go
+++ b/internal/pkg/apikey/apikey.go
@@ -58,6 +58,10 @@ func (k ApiKey) Token() string {
 	return base64.StdEncoding.EncodeToString([]byte(s))
 }
 
+func (k ApiKey) Config() string {
+	return fmt.Sprintf("%s:%s", k.Id, k.Key)
+}
+
 func ExtractAPIKey(r *http.Request) (*ApiKey, error) {
 	s, ok := r.Header[AuthKey]
 	if !ok {


### PR DESCRIPTION
## Description 

The API key in the policy should be in the format `keyId:key` not base64 encoded this PR fix that.

