### PR TITLE
Make Fleet Server components resilient if the indices do not exist

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -212,7 +212,7 @@ func (f *FleetServer) runServer(ctx context.Context, cfg *config.Config) (err er
 	if err != nil {
 		return err
 	}
-	err = migrate.Migrate(ctx, sv, bulker)
+	err = migrate.Migrate(ctx, log.Logger, sv, bulker)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/coordinator/monitor.go
+++ b/internal/pkg/coordinator/monitor.go
@@ -6,6 +6,7 @@ package coordinator
 
 import (
 	"context"
+	"errors"
 	"net"
 	"os"
 	"runtime"
@@ -184,7 +185,11 @@ func (m *monitorT) ensureLeadership(ctx context.Context) error {
 	leaders := map[string]model.PolicyLeader{}
 	policies, err := dl.QueryLatestPolicies(ctx, m.bulker, dl.WithIndexName(m.policiesIndex))
 	if err != nil {
-		return err
+		if errors.Is(err, es.ErrIndexNotFound) {
+			err = nil
+		} else {
+			return err
+		}
 	}
 	if len(policies) > 0 {
 		ids := make([]string, len(policies))
@@ -193,7 +198,11 @@ func (m *monitorT) ensureLeadership(ctx context.Context) error {
 		}
 		leaders, err = dl.SearchPolicyLeaders(ctx, m.bulker, ids, dl.WithIndexName(m.leadersIndex))
 		if err != nil {
-			return err
+			if errors.Is(err, es.ErrIndexNotFound) {
+				err = nil
+			} else {
+				return err
+			}
 		}
 	}
 

--- a/internal/pkg/coordinator/monitor.go
+++ b/internal/pkg/coordinator/monitor.go
@@ -186,10 +186,10 @@ func (m *monitorT) ensureLeadership(ctx context.Context) error {
 	policies, err := dl.QueryLatestPolicies(ctx, m.bulker, dl.WithIndexName(m.policiesIndex))
 	if err != nil {
 		if errors.Is(err, es.ErrIndexNotFound) {
-			err = nil
-		} else {
-			return err
+			m.log.Debug().Str("index", m.policiesIndex).Msg(es.ErrIndexNotFound.Error())
+			return nil
 		}
+		return err
 	}
 	if len(policies) > 0 {
 		ids := make([]string, len(policies))
@@ -199,10 +199,10 @@ func (m *monitorT) ensureLeadership(ctx context.Context) error {
 		leaders, err = dl.SearchPolicyLeaders(ctx, m.bulker, ids, dl.WithIndexName(m.leadersIndex))
 		if err != nil {
 			if errors.Is(err, es.ErrIndexNotFound) {
-				err = nil
-			} else {
-				return err
+				m.log.Debug().Str("index", m.leadersIndex).Msg(es.ErrIndexNotFound.Error())
+				return nil
 			}
+			return err
 		}
 	}
 

--- a/internal/pkg/esboot/bootstrap.go
+++ b/internal/pkg/esboot/bootstrap.go
@@ -6,7 +6,6 @@ package esboot
 
 import (
 	"context"
-	"github.com/elastic/fleet-server/v7/internal/pkg/es"
 
 	"github.com/elastic/go-elasticsearch/v8"
 )
@@ -20,13 +19,15 @@ type indexConfig struct {
 }
 
 var indexConfigs = map[string]indexConfig{
-	".fleet-actions":             {mapping: es.MappingAction},
-	".fleet-actions-results":     {mapping: es.MappingActionResult, datastream: true},
-	".fleet-agents":              {mapping: es.MappingAgent},
-	".fleet-enrollment-api-keys": {mapping: es.MappingEnrollmentApiKey},
-	".fleet-policies":            {mapping: es.MappingPolicy},
-	".fleet-policies-leader":     {mapping: es.MappingPolicyLeader},
-	".fleet-servers":             {mapping: es.MappingServer},
+	// Commenting out the boostrapping for now here, just in case if it needs to be "enabled" again.
+	// Will remove all the boostrapping code completely later once all is fully integrated
+	// ".fleet-actions":             {mapping: es.MappingAction},
+	// ".fleet-actions-results":     {mapping: es.MappingActionResult, datastream: true},
+	// ".fleet-agents":              {mapping: es.MappingAgent},
+	// ".fleet-enrollment-api-keys": {mapping: es.MappingEnrollmentApiKey},
+	// ".fleet-policies":            {mapping: es.MappingPolicy},
+	// ".fleet-policies-leader":     {mapping: es.MappingPolicyLeader},
+	// ".fleet-servers":             {mapping: es.MappingServer},
 }
 
 // Bootstrap creates .fleet-actions data stream

--- a/internal/pkg/monitor/monitor.go
+++ b/internal/pkg/monitor/monitor.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"sync/atomic"
 	"time"
 
@@ -291,7 +292,14 @@ func (m *simpleMonitorT) search(ctx context.Context, tmpl *dsl.Tmpl, params map[
 	}
 
 	if res.IsError() {
-		return nil, es.TranslateError(res.StatusCode, esres.Error)
+		err = es.TranslateError(res.StatusCode, esres.Error)
+	}
+
+	if err != nil {
+		if errors.Is(err, es.ErrIndexNotFound) {
+			return nil, nil
+		}
+		return nil, err
 	}
 
 	return esres.Hits.Hits, nil

--- a/internal/pkg/monitor/monitor.go
+++ b/internal/pkg/monitor/monitor.go
@@ -297,6 +297,7 @@ func (m *simpleMonitorT) search(ctx context.Context, tmpl *dsl.Tmpl, params map[
 
 	if err != nil {
 		if errors.Is(err, es.ErrIndexNotFound) {
+			m.log.Debug().Str("index", m.index).Msg(es.ErrIndexNotFound.Error())
 			return nil, nil
 		}
 		return nil, err

--- a/internal/pkg/policy/monitor.go
+++ b/internal/pkg/policy/monitor.go
@@ -127,9 +127,8 @@ func (m *monitorT) process(ctx context.Context) error {
 	policies, err := m.policyF(ctx, m.bulker, dl.WithIndexName(m.policiesIndex))
 	if err != nil {
 		if errors.Is(err, es.ErrIndexNotFound) {
-			err = nil
-		} else {
-			err = nil
+			m.log.Debug().Str("index", m.policiesIndex).Msg(es.ErrIndexNotFound.Error())
+			return nil
 		}
 		return err
 	}

--- a/internal/pkg/policy/monitor.go
+++ b/internal/pkg/policy/monitor.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
+	"github.com/elastic/fleet-server/v7/internal/pkg/es"
 	"github.com/elastic/fleet-server/v7/internal/pkg/model"
 	"github.com/elastic/fleet-server/v7/internal/pkg/monitor"
 )
@@ -125,6 +126,11 @@ LOOP:
 func (m *monitorT) process(ctx context.Context) error {
 	policies, err := m.policyF(ctx, m.bulker, dl.WithIndexName(m.policiesIndex))
 	if err != nil {
+		if errors.Is(err, es.ErrIndexNotFound) {
+			err = nil
+		} else {
+			err = nil
+		}
 		return err
 	}
 	if len(policies) == 0 {


### PR DESCRIPTION
## What does this PR do?

The new package based approach installs the indices templates and ILM policies, but doesn't create the indexes. This change allows the fleet server to run if indexes do not exists without exiting with error.

The bootstrapping code is commented out now, expecting the bootstrap to happen from the integration package.
https://github.com/elastic/integrations/pull/544
