### PR TITLE
Hide old bootstrap logic behind FLEET_ES_BOOT environment variable

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -208,13 +208,20 @@ func (f *FleetServer) runServer(ctx context.Context, cfg *config.Config) (err er
 
 	// Initial indices bootstrapping, needed for agents actions development
 	// TODO: remove this after the indices bootstrapping logic implemented in ES plugin
-	err = esboot.EnsureESIndices(ctx, es)
-	if err != nil {
-		return err
-	}
-	err = migrate.Migrate(ctx, log.Logger, sv, bulker)
-	if err != nil {
-		return err
+	bootFlag := env.GetStr(
+		"FLEET_ES_BOOT",
+		"",
+	)
+	if bootFlag == "1" {
+		log.Debug().Msg("FLEET_ES_BOOT is set to true, perform bootstrap")
+		err = esboot.EnsureESIndices(ctx, es)
+		if err != nil {
+			return err
+		}
+		err = migrate.Migrate(ctx, log.Logger, sv, bulker)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Replacing to errgroup context

--- a/internal/pkg/esboot/bootstrap.go
+++ b/internal/pkg/esboot/bootstrap.go
@@ -7,6 +7,7 @@ package esboot
 import (
 	"context"
 
+	"github.com/elastic/fleet-server/v7/internal/pkg/es"
 	"github.com/elastic/go-elasticsearch/v8"
 )
 
@@ -21,13 +22,13 @@ type indexConfig struct {
 var indexConfigs = map[string]indexConfig{
 	// Commenting out the boostrapping for now here, just in case if it needs to be "enabled" again.
 	// Will remove all the boostrapping code completely later once all is fully integrated
-	// ".fleet-actions":             {mapping: es.MappingAction},
-	// ".fleet-actions-results":     {mapping: es.MappingActionResult, datastream: true},
-	// ".fleet-agents":              {mapping: es.MappingAgent},
-	// ".fleet-enrollment-api-keys": {mapping: es.MappingEnrollmentApiKey},
-	// ".fleet-policies":            {mapping: es.MappingPolicy},
-	// ".fleet-policies-leader":     {mapping: es.MappingPolicyLeader},
-	// ".fleet-servers":             {mapping: es.MappingServer},
+	".fleet-actions":             {mapping: es.MappingAction},
+	".fleet-actions-results":     {mapping: es.MappingActionResult, datastream: true},
+	".fleet-agents":              {mapping: es.MappingAgent},
+	".fleet-enrollment-api-keys": {mapping: es.MappingEnrollmentApiKey},
+	".fleet-policies":            {mapping: es.MappingPolicy},
+	".fleet-policies-leader":     {mapping: es.MappingPolicyLeader},
+	".fleet-servers":             {mapping: es.MappingServer},
 }
 
 // Bootstrap creates .fleet-actions data stream


### PR DESCRIPTION
## What does this PR do?

Hide old bootstrap logic behind FLEET_ES_BOOT environment variable

There are still cases during development when you want to boostrap everything by the fleet, then should run the fleet-server with the flag.
```
FLEET_ES_BOOT=1 ./bin/fleet-server
```

