### PR TITLE
Add communication to Elastic Agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,10 @@
 .vscode/
 
 bin/
-*.rpm
 build/
 
 fleet-server
 fleet_server
 fleet-server.dev.yml
+*.log
+*.log.*

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -250,6 +250,239 @@ License Version 2.0.
 
 
 --------------------------------------------------------------------------------
+Dependency : github.com/elastic/elastic-agent-client/v7
+Version: v7.0.0-20200709172729-d43b7ad5833a
+Licence type (autodetected): Elastic
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-client/v7@v7.0.0-20200709172729-d43b7ad5833a/LICENSE.txt:
+
+ELASTIC LICENSE AGREEMENT
+
+PLEASE READ CAREFULLY THIS ELASTIC LICENSE AGREEMENT (THIS "AGREEMENT"), WHICH
+CONSTITUTES A LEGALLY BINDING AGREEMENT AND GOVERNS ALL OF YOUR USE OF ALL OF
+THE ELASTIC SOFTWARE WITH WHICH THIS AGREEMENT IS INCLUDED ("ELASTIC SOFTWARE")
+THAT IS PROVIDED IN OBJECT CODE FORMAT, AND, IN ACCORDANCE WITH SECTION 2 BELOW,
+CERTAIN OF THE ELASTIC SOFTWARE THAT IS PROVIDED IN SOURCE CODE FORMAT. BY
+INSTALLING OR USING ANY OF THE ELASTIC SOFTWARE GOVERNED BY THIS AGREEMENT, YOU
+ARE ASSENTING TO THE TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE
+WITH SUCH TERMS AND CONDITIONS, YOU MAY NOT INSTALL OR USE THE ELASTIC SOFTWARE
+GOVERNED BY THIS AGREEMENT. IF YOU ARE INSTALLING OR USING THE SOFTWARE ON
+BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL
+AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF
+SUCH ENTITY.
+
+Posted Date: April 20, 2018
+
+This Agreement is entered into by and between Elasticsearch BV ("Elastic") and
+You, or the legal entity on behalf of whom You are acting (as applicable,
+"You").
+
+1. OBJECT CODE END USER LICENSES, RESTRICTIONS AND THIRD PARTY OPEN SOURCE
+SOFTWARE
+
+  1.1 Object Code End User License. Subject to the terms and conditions of
+  Section 1.2 of this Agreement, Elastic hereby grants to You, AT NO CHARGE and
+  for so long as you are not in breach of any provision of this Agreement, a
+  License to the Basic Features and Functions of the Elastic Software.
+
+  1.2 Reservation of Rights; Restrictions. As between Elastic and You, Elastic
+  and its licensors own all right, title and interest in and to the Elastic
+  Software, and except as expressly set forth in Sections 1.1, and 2.1 of this
+  Agreement, no other license to the Elastic Software is granted to You under
+  this Agreement, by implication, estoppel or otherwise. You agree not to: (i)
+  reverse engineer or decompile, decrypt, disassemble or otherwise reduce any
+  Elastic Software provided to You in Object Code, or any portion thereof, to
+  Source Code, except and only to the extent any such restriction is prohibited
+  by applicable law, (ii) except as expressly permitted in this Agreement,
+  prepare derivative works from, modify, copy or use the Elastic Software Object
+  Code or the Commercial Software Source Code in any manner; (iii) except as
+  expressly permitted in Section 1.1 above, transfer, sell, rent, lease,
+  distribute, sublicense, loan or otherwise transfer, Elastic Software Object
+  Code, in whole or in part, to any third party; (iv) use Elastic Software
+  Object Code for providing time-sharing services, any software-as-a-service,
+  service bureau services or as part of an application services provider or
+  other service offering (collectively, "SaaS Offering") where obtaining access
+  to the Elastic Software or the features and functions of the Elastic Software
+  is a primary reason or substantial motivation for users of the SaaS Offering
+  to access and/or use the SaaS Offering ("Prohibited SaaS Offering"); (v)
+  circumvent the limitations on use of Elastic Software provided to You in
+  Object Code format that are imposed or preserved by any License Key, or (vi)
+  alter or remove any Marks and Notices in the Elastic Software. If You have any
+  question as to whether a specific SaaS Offering constitutes a Prohibited SaaS
+  Offering, or are interested in obtaining Elastic's permission to engage in
+  commercial or non-commercial distribution of the Elastic Software, please
+  contact elastic_license@elastic.co.
+
+  1.3 Third Party Open Source Software. The Commercial Software may contain or
+  be provided with third party open source libraries, components, utilities and
+  other open source software (collectively, "Open Source Software"), which Open
+  Source Software may have applicable license terms as identified on a website
+  designated by Elastic. Notwithstanding anything to the contrary herein, use of
+  the Open Source Software shall be subject to the license terms and conditions
+  applicable to such Open Source Software, to the extent required by the
+  applicable licensor (which terms shall not restrict the license rights granted
+  to You hereunder, but may contain additional rights). To the extent any
+  condition of this Agreement conflicts with any license to the Open Source
+  Software, the Open Source Software license will govern with respect to such
+  Open Source Software only. Elastic may also separately provide you with
+  certain open source software that is licensed by Elastic. Your use of such
+  Elastic open source software will not be governed by this Agreement, but by
+  the applicable open source license terms.
+
+2. COMMERCIAL SOFTWARE SOURCE CODE
+
+  2.1 Limited License. Subject to the terms and conditions of Section 2.2 of
+  this Agreement, Elastic hereby grants to You, AT NO CHARGE and for so long as
+  you are not in breach of any provision of this Agreement, a limited,
+  non-exclusive, non-transferable, fully paid up royalty free right and license
+  to the Commercial Software in Source Code format, without the right to grant
+  or authorize sublicenses, to prepare Derivative Works of the Commercial
+  Software, provided You (i) do not hack the licensing mechanism, or otherwise
+  circumvent the intended limitations on the use of Elastic Software to enable
+  features other than Basic Features and Functions or those features You are
+  entitled to as part of a Subscription, and (ii) use the resulting object code
+  only for reasonable testing purposes.
+
+  2.2 Restrictions. Nothing in Section 2.1 grants You the right to (i) use the
+  Commercial Software Source Code other than in accordance with Section 2.1
+  above, (ii) use a Derivative Work of the Commercial Software outside of a
+  Non-production Environment, in any production capacity, on a temporary or
+  permanent basis, or (iii) transfer, sell, rent, lease, distribute, sublicense,
+  loan or otherwise make available the Commercial Software Source Code, in whole
+  or in part, to any third party. Notwithstanding the foregoing, You may
+  maintain a copy of the repository in which the Source Code of the Commercial
+  Software resides and that copy may be publicly accessible, provided that you
+  include this Agreement with Your copy of the repository.
+
+3. TERMINATION
+
+  3.1 Termination. This Agreement will automatically terminate, whether or not
+  You receive notice of such Termination from Elastic, if You breach any of its
+  provisions.
+
+  3.2 Post Termination. Upon any termination of this Agreement, for any reason,
+  You shall promptly cease the use of the Elastic Software in Object Code format
+  and cease use of the Commercial Software in Source Code format. For the
+  avoidance of doubt, termination of this Agreement will not affect Your right
+  to use Elastic Software, in either Object Code or Source Code formats, made
+  available under the Apache License Version 2.0.
+
+  3.3 Survival. Sections 1.2, 2.2. 3.3, 4 and 5 shall survive any termination or
+  expiration of this Agreement.
+
+4. DISCLAIMER OF WARRANTIES AND LIMITATION OF LIABILITY
+
+  4.1 Disclaimer of Warranties. TO THE MAXIMUM EXTENT PERMITTED UNDER APPLICABLE
+  LAW, THE ELASTIC SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+  AND ELASTIC AND ITS LICENSORS MAKE NO WARRANTIES WHETHER EXPRESSED, IMPLIED OR
+  STATUTORY REGARDING OR RELATING TO THE ELASTIC SOFTWARE. TO THE MAXIMUM EXTENT
+  PERMITTED UNDER APPLICABLE LAW, ELASTIC AND ITS LICENSORS SPECIFICALLY
+  DISCLAIM ALL IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+  PURPOSE AND NON-INFRINGEMENT WITH RESPECT TO THE ELASTIC SOFTWARE, AND WITH
+  RESPECT TO THE USE OF THE FOREGOING. FURTHER, ELASTIC DOES NOT WARRANT RESULTS
+  OF USE OR THAT THE ELASTIC SOFTWARE WILL BE ERROR FREE OR THAT THE USE OF THE
+  ELASTIC SOFTWARE WILL BE UNINTERRUPTED.
+
+  4.2 Limitation of Liability. IN NO EVENT SHALL ELASTIC OR ITS LICENSORS BE
+  LIABLE TO YOU OR ANY THIRD PARTY FOR ANY DIRECT OR INDIRECT DAMAGES,
+  INCLUDING, WITHOUT LIMITATION, FOR ANY LOSS OF PROFITS, LOSS OF USE, BUSINESS
+  INTERRUPTION, LOSS OF DATA, COST OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY
+  SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES OF ANY KIND, IN CONNECTION WITH
+  OR ARISING OUT OF THE USE OR INABILITY TO USE THE ELASTIC SOFTWARE, OR THE
+  PERFORMANCE OF OR FAILURE TO PERFORM THIS AGREEMENT, WHETHER ALLEGED AS A
+  BREACH OF CONTRACT OR TORTIOUS CONDUCT, INCLUDING NEGLIGENCE, EVEN IF ELASTIC
+  HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+5. MISCELLANEOUS
+
+  This Agreement completely and exclusively states the entire agreement of the
+  parties regarding the subject matter herein, and it supersedes, and its terms
+  govern, all prior proposals, agreements, or other communications between the
+  parties, oral or written, regarding such subject matter. This Agreement may be
+  modified by Elastic from time to time, and any such modifications will be
+  effective upon the "Posted Date" set forth at the top of the modified
+  Agreement. If any provision hereof is held unenforceable, this Agreement will
+  continue without said provision and be interpreted to reflect the original
+  intent of the parties. This Agreement and any non-contractual obligation
+  arising out of or in connection with it, is governed exclusively by Dutch law.
+  This Agreement shall not be governed by the 1980 UN Convention on Contracts
+  for the International Sale of Goods. All disputes arising out of or in
+  connection with this Agreement, including its existence and validity, shall be
+  resolved by the courts with jurisdiction in Amsterdam, The Netherlands, except
+  where mandatory law provides for the courts at another location in The
+  Netherlands to have jurisdiction. The parties hereby irrevocably waive any and
+  all claims and defenses either might otherwise have in any such action or
+  proceeding in any of such courts based upon any alleged lack of personal
+  jurisdiction, improper venue, forum non conveniens or any similar claim or
+  defense. A breach or threatened breach, by You of Section 2 may cause
+  irreparable harm for which damages at law may not provide adequate relief, and
+  therefore Elastic shall be entitled to seek injunctive relief without being
+  required to post a bond. You may not assign this Agreement (including by
+  operation of law in connection with a merger or acquisition), in whole or in
+  part to any third party without the prior written consent of Elastic, which
+  may be withheld or granted by Elastic in its sole and absolute discretion.
+  Any assignment in violation of the preceding sentence is void. Notices to
+  Elastic may also be sent to legal@elastic.co.
+
+6. DEFINITIONS
+
+  The following terms have the meanings ascribed:
+
+  6.1 "Affiliate" means, with respect to a party, any entity that controls, is
+  controlled by, or which is under common control with, such party, where
+  "control" means ownership of at least fifty percent (50%) of the outstanding
+  voting shares of the entity, or the contractual right to establish policy for,
+  and manage the operations of, the entity.
+
+  6.2 "Basic Features and Functions" means those features and functions of the
+  Elastic Software that are eligible for use under a Basic license, as set forth
+  at https://www.elastic.co/subscriptions, as may be modified by Elastic from
+  time to time.
+
+  6.3 "Commercial Software" means the Elastic Software Source Code in any file
+  containing a header stating the contents are subject to the Elastic License or
+  which is contained in the repository folder labeled "x-pack", unless a LICENSE
+  file present in the directory subtree declares a different license.
+
+  6.4 "Derivative Work of the Commercial Software" means, for purposes of this
+  Agreement, any modification(s) or enhancement(s) to the Commercial Software,
+  which represent, as a whole, an original work of authorship.
+
+  6.5 "License" means a limited, non-exclusive, non-transferable, fully paid up,
+  royalty free, right and license, without the right to grant or authorize
+  sublicenses, solely for Your internal business operations to (i) install and
+  use the applicable Features and Functions of the Elastic Software in Object
+  Code, and (ii) permit Contractors and Your Affiliates to use the Elastic
+  software as set forth in (i) above, provided that such use by Contractors must
+  be solely for Your benefit and/or the benefit of Your Affiliates, and You
+  shall be responsible for all acts and omissions of such Contractors and
+  Affiliates in connection with their use of the Elastic software that are
+  contrary to the terms and conditions of this Agreement.
+
+  6.6 "License Key" means a sequence of bytes, including but not limited to a
+  JSON blob, that is used to enable certain features and functions of the
+  Elastic Software.
+
+  6.7 "Marks and Notices" means all Elastic trademarks, trade names, logos and
+  notices present on the Documentation as originally provided by Elastic.
+
+  6.8 "Non-production Environment" means an environment for development, testing
+  or quality assurance, where software is not used for production purposes.
+
+  6.9 "Object Code" means any form resulting from mechanical transformation or
+  translation of Source Code form, including but not limited to compiled object
+  code, generated documentation, and conversions to other media types.
+
+  6.10 "Source Code" means the preferred form of computer software for making
+  modifications, including but not limited to software source code,
+  documentation source, and configuration files.
+
+  6.11 "Subscription" means the right to receive Support Services and a License
+  to the Commercial Software.
+
+
+--------------------------------------------------------------------------------
 Dependency : github.com/elastic/go-elasticsearch/v8
 Version: v8.0.0-20200728144331-527225d8e836
 Licence type (autodetected): Apache-2.0
@@ -13936,239 +14169,6 @@ Contents of probable licence file $GOMODCACHE/github.com/elastic/ecs@v1.6.0/LICE
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
-
---------------------------------------------------------------------------------
-Dependency : github.com/elastic/elastic-agent-client/v7
-Version: v7.0.0-20200709172729-d43b7ad5833a
-Licence type (autodetected): Elastic
---------------------------------------------------------------------------------
-
-Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-client/v7@v7.0.0-20200709172729-d43b7ad5833a/LICENSE.txt:
-
-ELASTIC LICENSE AGREEMENT
-
-PLEASE READ CAREFULLY THIS ELASTIC LICENSE AGREEMENT (THIS "AGREEMENT"), WHICH
-CONSTITUTES A LEGALLY BINDING AGREEMENT AND GOVERNS ALL OF YOUR USE OF ALL OF
-THE ELASTIC SOFTWARE WITH WHICH THIS AGREEMENT IS INCLUDED ("ELASTIC SOFTWARE")
-THAT IS PROVIDED IN OBJECT CODE FORMAT, AND, IN ACCORDANCE WITH SECTION 2 BELOW,
-CERTAIN OF THE ELASTIC SOFTWARE THAT IS PROVIDED IN SOURCE CODE FORMAT. BY
-INSTALLING OR USING ANY OF THE ELASTIC SOFTWARE GOVERNED BY THIS AGREEMENT, YOU
-ARE ASSENTING TO THE TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE
-WITH SUCH TERMS AND CONDITIONS, YOU MAY NOT INSTALL OR USE THE ELASTIC SOFTWARE
-GOVERNED BY THIS AGREEMENT. IF YOU ARE INSTALLING OR USING THE SOFTWARE ON
-BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL
-AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF
-SUCH ENTITY.
-
-Posted Date: April 20, 2018
-
-This Agreement is entered into by and between Elasticsearch BV ("Elastic") and
-You, or the legal entity on behalf of whom You are acting (as applicable,
-"You").
-
-1. OBJECT CODE END USER LICENSES, RESTRICTIONS AND THIRD PARTY OPEN SOURCE
-SOFTWARE
-
-  1.1 Object Code End User License. Subject to the terms and conditions of
-  Section 1.2 of this Agreement, Elastic hereby grants to You, AT NO CHARGE and
-  for so long as you are not in breach of any provision of this Agreement, a
-  License to the Basic Features and Functions of the Elastic Software.
-
-  1.2 Reservation of Rights; Restrictions. As between Elastic and You, Elastic
-  and its licensors own all right, title and interest in and to the Elastic
-  Software, and except as expressly set forth in Sections 1.1, and 2.1 of this
-  Agreement, no other license to the Elastic Software is granted to You under
-  this Agreement, by implication, estoppel or otherwise. You agree not to: (i)
-  reverse engineer or decompile, decrypt, disassemble or otherwise reduce any
-  Elastic Software provided to You in Object Code, or any portion thereof, to
-  Source Code, except and only to the extent any such restriction is prohibited
-  by applicable law, (ii) except as expressly permitted in this Agreement,
-  prepare derivative works from, modify, copy or use the Elastic Software Object
-  Code or the Commercial Software Source Code in any manner; (iii) except as
-  expressly permitted in Section 1.1 above, transfer, sell, rent, lease,
-  distribute, sublicense, loan or otherwise transfer, Elastic Software Object
-  Code, in whole or in part, to any third party; (iv) use Elastic Software
-  Object Code for providing time-sharing services, any software-as-a-service,
-  service bureau services or as part of an application services provider or
-  other service offering (collectively, "SaaS Offering") where obtaining access
-  to the Elastic Software or the features and functions of the Elastic Software
-  is a primary reason or substantial motivation for users of the SaaS Offering
-  to access and/or use the SaaS Offering ("Prohibited SaaS Offering"); (v)
-  circumvent the limitations on use of Elastic Software provided to You in
-  Object Code format that are imposed or preserved by any License Key, or (vi)
-  alter or remove any Marks and Notices in the Elastic Software. If You have any
-  question as to whether a specific SaaS Offering constitutes a Prohibited SaaS
-  Offering, or are interested in obtaining Elastic's permission to engage in
-  commercial or non-commercial distribution of the Elastic Software, please
-  contact elastic_license@elastic.co.
-
-  1.3 Third Party Open Source Software. The Commercial Software may contain or
-  be provided with third party open source libraries, components, utilities and
-  other open source software (collectively, "Open Source Software"), which Open
-  Source Software may have applicable license terms as identified on a website
-  designated by Elastic. Notwithstanding anything to the contrary herein, use of
-  the Open Source Software shall be subject to the license terms and conditions
-  applicable to such Open Source Software, to the extent required by the
-  applicable licensor (which terms shall not restrict the license rights granted
-  to You hereunder, but may contain additional rights). To the extent any
-  condition of this Agreement conflicts with any license to the Open Source
-  Software, the Open Source Software license will govern with respect to such
-  Open Source Software only. Elastic may also separately provide you with
-  certain open source software that is licensed by Elastic. Your use of such
-  Elastic open source software will not be governed by this Agreement, but by
-  the applicable open source license terms.
-
-2. COMMERCIAL SOFTWARE SOURCE CODE
-
-  2.1 Limited License. Subject to the terms and conditions of Section 2.2 of
-  this Agreement, Elastic hereby grants to You, AT NO CHARGE and for so long as
-  you are not in breach of any provision of this Agreement, a limited,
-  non-exclusive, non-transferable, fully paid up royalty free right and license
-  to the Commercial Software in Source Code format, without the right to grant
-  or authorize sublicenses, to prepare Derivative Works of the Commercial
-  Software, provided You (i) do not hack the licensing mechanism, or otherwise
-  circumvent the intended limitations on the use of Elastic Software to enable
-  features other than Basic Features and Functions or those features You are
-  entitled to as part of a Subscription, and (ii) use the resulting object code
-  only for reasonable testing purposes.
-
-  2.2 Restrictions. Nothing in Section 2.1 grants You the right to (i) use the
-  Commercial Software Source Code other than in accordance with Section 2.1
-  above, (ii) use a Derivative Work of the Commercial Software outside of a
-  Non-production Environment, in any production capacity, on a temporary or
-  permanent basis, or (iii) transfer, sell, rent, lease, distribute, sublicense,
-  loan or otherwise make available the Commercial Software Source Code, in whole
-  or in part, to any third party. Notwithstanding the foregoing, You may
-  maintain a copy of the repository in which the Source Code of the Commercial
-  Software resides and that copy may be publicly accessible, provided that you
-  include this Agreement with Your copy of the repository.
-
-3. TERMINATION
-
-  3.1 Termination. This Agreement will automatically terminate, whether or not
-  You receive notice of such Termination from Elastic, if You breach any of its
-  provisions.
-
-  3.2 Post Termination. Upon any termination of this Agreement, for any reason,
-  You shall promptly cease the use of the Elastic Software in Object Code format
-  and cease use of the Commercial Software in Source Code format. For the
-  avoidance of doubt, termination of this Agreement will not affect Your right
-  to use Elastic Software, in either Object Code or Source Code formats, made
-  available under the Apache License Version 2.0.
-
-  3.3 Survival. Sections 1.2, 2.2. 3.3, 4 and 5 shall survive any termination or
-  expiration of this Agreement.
-
-4. DISCLAIMER OF WARRANTIES AND LIMITATION OF LIABILITY
-
-  4.1 Disclaimer of Warranties. TO THE MAXIMUM EXTENT PERMITTED UNDER APPLICABLE
-  LAW, THE ELASTIC SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
-  AND ELASTIC AND ITS LICENSORS MAKE NO WARRANTIES WHETHER EXPRESSED, IMPLIED OR
-  STATUTORY REGARDING OR RELATING TO THE ELASTIC SOFTWARE. TO THE MAXIMUM EXTENT
-  PERMITTED UNDER APPLICABLE LAW, ELASTIC AND ITS LICENSORS SPECIFICALLY
-  DISCLAIM ALL IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
-  PURPOSE AND NON-INFRINGEMENT WITH RESPECT TO THE ELASTIC SOFTWARE, AND WITH
-  RESPECT TO THE USE OF THE FOREGOING. FURTHER, ELASTIC DOES NOT WARRANT RESULTS
-  OF USE OR THAT THE ELASTIC SOFTWARE WILL BE ERROR FREE OR THAT THE USE OF THE
-  ELASTIC SOFTWARE WILL BE UNINTERRUPTED.
-
-  4.2 Limitation of Liability. IN NO EVENT SHALL ELASTIC OR ITS LICENSORS BE
-  LIABLE TO YOU OR ANY THIRD PARTY FOR ANY DIRECT OR INDIRECT DAMAGES,
-  INCLUDING, WITHOUT LIMITATION, FOR ANY LOSS OF PROFITS, LOSS OF USE, BUSINESS
-  INTERRUPTION, LOSS OF DATA, COST OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY
-  SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES OF ANY KIND, IN CONNECTION WITH
-  OR ARISING OUT OF THE USE OR INABILITY TO USE THE ELASTIC SOFTWARE, OR THE
-  PERFORMANCE OF OR FAILURE TO PERFORM THIS AGREEMENT, WHETHER ALLEGED AS A
-  BREACH OF CONTRACT OR TORTIOUS CONDUCT, INCLUDING NEGLIGENCE, EVEN IF ELASTIC
-  HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-
-5. MISCELLANEOUS
-
-  This Agreement completely and exclusively states the entire agreement of the
-  parties regarding the subject matter herein, and it supersedes, and its terms
-  govern, all prior proposals, agreements, or other communications between the
-  parties, oral or written, regarding such subject matter. This Agreement may be
-  modified by Elastic from time to time, and any such modifications will be
-  effective upon the "Posted Date" set forth at the top of the modified
-  Agreement. If any provision hereof is held unenforceable, this Agreement will
-  continue without said provision and be interpreted to reflect the original
-  intent of the parties. This Agreement and any non-contractual obligation
-  arising out of or in connection with it, is governed exclusively by Dutch law.
-  This Agreement shall not be governed by the 1980 UN Convention on Contracts
-  for the International Sale of Goods. All disputes arising out of or in
-  connection with this Agreement, including its existence and validity, shall be
-  resolved by the courts with jurisdiction in Amsterdam, The Netherlands, except
-  where mandatory law provides for the courts at another location in The
-  Netherlands to have jurisdiction. The parties hereby irrevocably waive any and
-  all claims and defenses either might otherwise have in any such action or
-  proceeding in any of such courts based upon any alleged lack of personal
-  jurisdiction, improper venue, forum non conveniens or any similar claim or
-  defense. A breach or threatened breach, by You of Section 2 may cause
-  irreparable harm for which damages at law may not provide adequate relief, and
-  therefore Elastic shall be entitled to seek injunctive relief without being
-  required to post a bond. You may not assign this Agreement (including by
-  operation of law in connection with a merger or acquisition), in whole or in
-  part to any third party without the prior written consent of Elastic, which
-  may be withheld or granted by Elastic in its sole and absolute discretion.
-  Any assignment in violation of the preceding sentence is void. Notices to
-  Elastic may also be sent to legal@elastic.co.
-
-6. DEFINITIONS
-
-  The following terms have the meanings ascribed:
-
-  6.1 "Affiliate" means, with respect to a party, any entity that controls, is
-  controlled by, or which is under common control with, such party, where
-  "control" means ownership of at least fifty percent (50%) of the outstanding
-  voting shares of the entity, or the contractual right to establish policy for,
-  and manage the operations of, the entity.
-
-  6.2 "Basic Features and Functions" means those features and functions of the
-  Elastic Software that are eligible for use under a Basic license, as set forth
-  at https://www.elastic.co/subscriptions, as may be modified by Elastic from
-  time to time.
-
-  6.3 "Commercial Software" means the Elastic Software Source Code in any file
-  containing a header stating the contents are subject to the Elastic License or
-  which is contained in the repository folder labeled "x-pack", unless a LICENSE
-  file present in the directory subtree declares a different license.
-
-  6.4 "Derivative Work of the Commercial Software" means, for purposes of this
-  Agreement, any modification(s) or enhancement(s) to the Commercial Software,
-  which represent, as a whole, an original work of authorship.
-
-  6.5 "License" means a limited, non-exclusive, non-transferable, fully paid up,
-  royalty free, right and license, without the right to grant or authorize
-  sublicenses, solely for Your internal business operations to (i) install and
-  use the applicable Features and Functions of the Elastic Software in Object
-  Code, and (ii) permit Contractors and Your Affiliates to use the Elastic
-  software as set forth in (i) above, provided that such use by Contractors must
-  be solely for Your benefit and/or the benefit of Your Affiliates, and You
-  shall be responsible for all acts and omissions of such Contractors and
-  Affiliates in connection with their use of the Elastic software that are
-  contrary to the terms and conditions of this Agreement.
-
-  6.6 "License Key" means a sequence of bytes, including but not limited to a
-  JSON blob, that is used to enable certain features and functions of the
-  Elastic Software.
-
-  6.7 "Marks and Notices" means all Elastic trademarks, trade names, logos and
-  notices present on the Documentation as originally provided by Elastic.
-
-  6.8 "Non-production Environment" means an environment for development, testing
-  or quality assurance, where software is not used for production purposes.
-
-  6.9 "Object Code" means any form resulting from mechanical transformation or
-  translation of Source Code form, including but not limited to compiled object
-  code, generated documentation, and conversions to other media types.
-
-  6.10 "Source Code" means the preferred form of computer software for making
-  modifications, including but not limited to software source code,
-  documentation source, and configuration files.
-
-  6.11 "Subscription" means the right to receive Support Services and a License
-  to the Commercial Software.
 
 
 --------------------------------------------------------------------------------

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -86,7 +86,9 @@ func getRunCommand(version string) func(cmd *cobra.Command, args []string) error
 				return err
 			}
 
-			return agent.Run(installSignalHandler())
+			err = agent.Run(installSignalHandler())
+			log.Err(err)
+			return err
 		} else {
 			cfgPath, err := cmd.Flags().GetString("config")
 			if err != nil {
@@ -115,7 +117,9 @@ func getRunCommand(version string) func(cmd *cobra.Command, args []string) error
 				return err
 			}
 
-			return srv.Run(installSignalHandler())
+			err = srv.Run(installSignalHandler())
+			log.Err(err)
+			return err
 		}
 	}
 }

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -88,6 +88,7 @@ func getRunCommand(version string) func(cmd *cobra.Command, args []string) error
 
 			err = agent.Run(installSignalHandler())
 			log.Err(err)
+			l.Sync()
 			return err
 		} else {
 			cfgPath, err := cmd.Flags().GetString("config")
@@ -107,7 +108,7 @@ func getRunCommand(version string) func(cmd *cobra.Command, args []string) error
 				return err
 			}
 
-			_, err = logger.Init(cfg)
+			l, err := logger.Init(cfg)
 			if err != nil {
 				return err
 			}
@@ -119,6 +120,7 @@ func getRunCommand(version string) func(cmd *cobra.Command, args []string) error
 
 			err = srv.Run(installSignalHandler())
 			log.Err(err)
+			l.Sync()
 			return err
 		}
 	}

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -505,7 +505,7 @@ func (f *FleetServer) runServer(ctx context.Context, cfg *config.Config) (err er
 	g.Go(loggedRunFunc(ctx, "Policy monitor", pm.Run))
 
 	// Policy self monitor
-	sm := policy.NewSelfMonitor(bulker, pim, cfg.Inputs[0].Policy.ID, f.reporter)
+	sm := policy.NewSelfMonitor(cfg.Fleet, bulker, pim, cfg.Inputs[0].Policy.ID, f.reporter)
 	g.Go(loggedRunFunc(ctx, "Policy self monitor", sm.Run))
 
 	// Actions monitoring

--- a/cmd/fleet/server.go
+++ b/cmd/fleet/server.go
@@ -71,7 +71,7 @@ func runServer(ctx context.Context, router *httprouter.Router, cfg *config.Serve
 
 	defer ln.Close()
 
-	// TODO: Use tls.Config to properly lock down tls connection
+	// TODO: Use tls.Config to properly mux down tls connection
 	keyFile := cfg.TLS.Key
 	certFile := cfg.TLS.Cert
 

--- a/cmd/fleet/server_integration_test.go
+++ b/cmd/fleet/server_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/elastic/fleet-server/v7/internal/pkg/status"
 	"io/ioutil"
 	"net/http"
 	"path"
@@ -81,7 +82,7 @@ func startTestServer(ctx context.Context) (*tserver, error) {
 	cfg.Inputs[0].Server = *srvcfg
 	log.Info().Uint16("port", port).Msg("Test fleet server")
 
-	srv, err := NewFleetServer(cfg, c, serverVersion)
+	srv, err := NewFleetServer(cfg, c, serverVersion, status.NewLog())
 	if err != nil {
 		return nil, err
 	}

--- a/dev-tools/integration/wait-for-elasticsearch.sh
+++ b/dev-tools/integration/wait-for-elasticsearch.sh
@@ -30,9 +30,9 @@ until [ "$health" = 'green' ]; do
     health="$(curl -fsSL "$host/_cat/health?h=status")"
     echo $health
     health="$(echo "$health" | tr -d '[:space:]')"
-    >&2 echo "Elastic Search is unavailable - sleeping"
+    >&2 echo "Elasticsearch is unavailable - sleeping"
     sleep 1
 done
 
->&2 echo "Elastic Search is up"
+>&2 echo "Elasticsearch is up"
 exec $cmd

--- a/fleet-server.yml
+++ b/fleet-server.yml
@@ -9,3 +9,6 @@ fleet:
     id: 1e4954ce-af37-4731-9f4a-407b08e69e42
     logging:
       level: '${LOG_LEVEL:INFO}'
+
+logging:
+  to_stderr: true

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aleksmaus/generate v0.0.0-20201213151810-c5bc68a6a42f
 	github.com/dgraph-io/ristretto v0.0.3
 	github.com/elastic/beats/v7 v7.10.0
+	github.com/elastic/elastic-agent-client/v7 v7.0.0-20200709172729-d43b7ad5833a
 	github.com/elastic/go-elasticsearch/v8 v8.0.0-20200728144331-527225d8e836
 	github.com/elastic/go-ucfg v0.8.3
 	github.com/gofrs/uuid v3.3.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,7 @@ github.com/eclipse/paho.mqtt.golang v1.2.1-0.20200121105743-0d940dd29fd2/go.mod 
 github.com/elastic/beats/v7 v7.10.0 h1:MpXREz0PzwuHpJnNAHcjmRoQRfVUnJFJvYQdzRjBZKg=
 github.com/elastic/beats/v7 v7.10.0/go.mod h1:GV6Gy80eRYpJ4Dk4MZcQFMxXbmOnWrj9ZPK5UhwCkhU=
 github.com/elastic/ecs v1.6.0/go.mod h1:pgiLbQsijLOJvFR8OTILLu0Ni/R/foUNg0L+T6mU9b4=
+github.com/elastic/elastic-agent-client/v7 v7.0.0-20200709172729-d43b7ad5833a h1:2NHgf1RUw+f240lpTnLrCp1aBNvq2wDi0E1A423/S1k=
 github.com/elastic/elastic-agent-client/v7 v7.0.0-20200709172729-d43b7ad5833a/go.mod h1:uh/Gj9a0XEbYoM4NYz4LvaBVARz3QXLmlNjsrKY9fTc=
 github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270/go.mod h1:Msl1pdboCbArMF/nSCDUXgQuWTeoMmE/z8607X+k7ng=
 github.com/elastic/go-concert v0.0.4/go.mod h1:9MtFarjXroUgmm0m6HY3NSe1XiKhdktiNRRj9hWvIaM=
@@ -228,6 +229,7 @@ github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:x
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
+github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -427,6 +429,7 @@ github.com/rs/zerolog v1.19.0/go.mod h1:IzD0RJ65iWH0w97OQQebJEvTZYvsCUm9WVLWBQrJ
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/samuel/go-parser v0.0.0-20130731160455-ca8abbf65d0e/go.mod h1:Sb6li54lXV0yYEjI4wX8cucdQ9gqUJV3+Ngg3l9g30I=
 github.com/samuel/go-thrift v0.0.0-20140522043831-2187045faa54/go.mod h1:Vrkh1pnjV9Bl8c3P9zH0/D4NlOHWP5d4/hF4YTULaec=
+github.com/sanathkr/go-yaml v0.0.0-20170819195128-ed9d249f429b h1:jUK33OXuZP/l6babJtnLo1qsGvq6G9so9KMflGAm4YA=
 github.com/sanathkr/go-yaml v0.0.0-20170819195128-ed9d249f429b/go.mod h1:8458kAagoME2+LN5//WxE71ysZ3B7r22fdgb7qVmXSY=
 github.com/sanathkr/yaml v0.0.0-20170819201035-0056894fa522/go.mod h1:tQTYKOQgxoH3v6dEmdHiz4JG+nbxWwM5fgPQUpSZqVQ=
 github.com/sanathkr/yaml v1.0.1-0.20170819201035-0056894fa522/go.mod h1:tQTYKOQgxoH3v6dEmdHiz4JG+nbxWwM5fgPQUpSZqVQ=
@@ -579,6 +582,7 @@ golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -634,6 +638,7 @@ golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -696,6 +701,7 @@ google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64/go.mod h1:DMBHOl98
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190911173649-1774047e7e51/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
 google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
+google.golang.org/genproto v0.0.0-20191230161307-f3c370f40bfb h1:ADPHZzpzM4tk4V4S5cnCrr5SwzvlrPRmqqCuJDB8UTs=
 google.golang.org/genproto v0.0.0-20191230161307-f3c370f40bfb/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
@@ -704,12 +710,14 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
+google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -5,7 +5,7 @@
 package config
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/elastic/go-ucfg"
 	"github.com/elastic/go-ucfg/flag"
@@ -36,11 +36,11 @@ func (c *Config) InitDefaults() {
 
 // Validate ensures that the configuration is valid.
 func (c *Config) Validate() error {
-	if c.Inputs == nil || len(c.Inputs) == 0 {
-		return fmt.Errorf("a fleet-server input must be defined")
+	if len(c.Inputs) == 0 {
+		return errors.New("a fleet-server input must be defined")
 	}
 	if len(c.Inputs) > 1 {
-		return fmt.Errorf("only 1 fleet-server input can be defined")
+		return errors.New("only 1 fleet-server input can be defined")
 	}
 	return nil
 }

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -56,3 +56,17 @@ func LoadFile(path string) (*Config, error) {
 	}
 	return cfg, nil
 }
+
+// LoadString take config as a string and return a new configuration.
+func LoadString(str string) (*Config, error) {
+	cfg := &Config{}
+	c, err := yaml.NewConfig([]byte(str), DefaultOptions...)
+	if err != nil {
+		return nil, err
+	}
+	err = c.Unpack(cfg, DefaultOptions...)
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -26,10 +26,8 @@ func TestConfig(t *testing.T) {
 			cfg: &Config{
 				Fleet: Fleet{
 					Agent: Agent{
-						ID: "1e4954ce-af37-4731-9f4a-407b08e69e42",
-						Logging: AgentLogging{
-							Level: "info",
-						},
+						ID:      "1e4954ce-af37-4731-9f4a-407b08e69e42",
+						Logging: AgentLogging{},
 					},
 				},
 				Output: Output{
@@ -61,6 +59,12 @@ func TestConfig(t *testing.T) {
 							Profile:           ServerProfile{Bind: "localhost:6060"},
 						},
 					},
+				},
+				Logging: Logging{
+					Level:    "info",
+					ToStderr: false,
+					ToFiles:  true,
+					Files:    nil,
 				},
 			},
 		},
@@ -104,16 +108,20 @@ func TestConfig(t *testing.T) {
 						},
 					},
 				},
+				Logging: Logging{
+					Level:    "info",
+					ToStderr: false,
+					ToFiles:  true,
+					Files:    nil,
+				},
 			},
 		},
 		"input": {
 			cfg: &Config{
 				Fleet: Fleet{
 					Agent: Agent{
-						ID: "1e4954ce-af37-4731-9f4a-407b08e69e42",
-						Logging: AgentLogging{
-							Level: "info",
-						},
+						ID:      "1e4954ce-af37-4731-9f4a-407b08e69e42",
+						Logging: AgentLogging{},
 					},
 				},
 				Output: Output{
@@ -146,16 +154,20 @@ func TestConfig(t *testing.T) {
 						},
 					},
 				},
+				Logging: Logging{
+					Level:    "info",
+					ToStderr: false,
+					ToFiles:  true,
+					Files:    nil,
+				},
 			},
 		},
 		"input-config": {
 			cfg: &Config{
 				Fleet: Fleet{
 					Agent: Agent{
-						ID: "1e4954ce-af37-4731-9f4a-407b08e69e42",
-						Logging: AgentLogging{
-							Level: "info",
-						},
+						ID:      "1e4954ce-af37-4731-9f4a-407b08e69e42",
+						Logging: AgentLogging{},
 					},
 				},
 				Output: Output{
@@ -188,6 +200,12 @@ func TestConfig(t *testing.T) {
 						},
 					},
 				},
+				Logging: Logging{
+					Level:    "info",
+					ToStderr: false,
+					ToFiles:  true,
+					Files:    nil,
+				},
 			},
 		},
 		"bad-input": {
@@ -201,12 +219,6 @@ func TestConfig(t *testing.T) {
 		},
 		"bad-output": {
 			err: "can only contain elasticsearch key",
-		},
-		"bad-no-output": {
-			err: "cannot connect to elasticsearch without username/password",
-		},
-		"bad-no-agent-id": {
-			err: "string value is not set",
 		},
 	}
 

--- a/internal/pkg/config/fleet.go
+++ b/internal/pkg/config/fleet.go
@@ -15,13 +15,13 @@ type AgentLogging struct {
 	Level string `config:"level"`
 }
 
-// InitDefaults initializes the defaults for the configuration.
-func (c *AgentLogging) InitDefaults() {
-	c.Level = "info"
-}
-
 // Validate ensures that the configuration is valid.
 func (c *AgentLogging) Validate() error {
+	if c.Level == "" {
+		// allowed to be empty because `agent.logging.level` is only
+		// an override of the logging level from `logging.level`
+		return nil
+	}
 	if _, err := strToLevel(c.Level); err != nil {
 		return err
 	}
@@ -36,7 +36,7 @@ func (c *AgentLogging) LogLevel() zerolog.Level {
 
 // Agent is the ID and logging configuration of the Agent running this Fleet Server.
 type Agent struct {
-	ID      string       `config:"id" validate:"required"`
+	ID      string       `config:"id"`
 	Version string       `config:"version"`
 	Logging AgentLogging `config:"logging"`
 }

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -10,6 +10,11 @@ import (
 	"time"
 )
 
+// Policy is the configuration policy to use.
+type Policy struct {
+	ID string `config:"id"`
+}
+
 // ServerTimeouts is the configuration for the server timeouts
 type ServerTimeouts struct {
 	Read  time.Duration `config:"read"`
@@ -75,6 +80,7 @@ func (c *Server) BindAddress() string {
 // Input is the input defined by Agent to run Fleet Server.
 type Input struct {
 	Type   string `config:"type"`
+	Policy Policy `config:"policy"`
 	Server Server `config:"server"`
 }
 

--- a/internal/pkg/config/logging.go
+++ b/internal/pkg/config/logging.go
@@ -42,8 +42,6 @@ func (c *LoggingFiles) InitDefaults() {
 // Logging configuration.
 type Logging struct {
 	Level    string        `config:"level"`
-	JSON     bool          `config:"json"`
-	ECS      bool          `config:"ecs"`
 	ToStderr bool          `config:"to_stderr"`
 	ToFiles  bool          `config:"to_files"`
 	Files    *LoggingFiles `config:"files"`

--- a/internal/pkg/config/logging.go
+++ b/internal/pkg/config/logging.go
@@ -1,0 +1,70 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package config
+
+import (
+	"github.com/rs/zerolog"
+	"os"
+	"time"
+)
+
+// LoggingFiles configuration for the logging file output.
+type LoggingFiles struct {
+	Path            string        `config:"path"`
+	Name            string        `config:"name"`
+	MaxSize         uint          `config:"rotateeverybytes" validate:"min=1"`
+	MaxBackups      uint          `config:"keepfiles" validate:"max=1024"`
+	Permissions     uint32        `config:"permissions"`
+	Interval        time.Duration `config:"interval"`
+	RotateOnStartup bool          `config:"rotateonstartup"`
+	RedirectStderr  bool          `config:"redirect_stderr"`
+}
+
+// InitDefaults initializes the defaults for the configuration.
+func (c *LoggingFiles) InitDefaults() {
+	cwd, err := os.Getwd()
+	if err != nil {
+		// something really wrong here
+		panic(err)
+	}
+
+	c.Path = cwd
+	c.Name = "fleet-server.log"
+	c.MaxSize = 10 * 1024 * 1024
+	c.MaxBackups = 7
+	c.Permissions = 0600
+	c.Interval = 0
+	c.RotateOnStartup = true
+}
+
+// Logging configuration.
+type Logging struct {
+	Level    string        `config:"level"`
+	JSON     bool          `config:"json"`
+	ECS      bool          `config:"ecs"`
+	ToStderr bool          `config:"to_stderr"`
+	ToFiles  bool          `config:"to_files"`
+	Files    *LoggingFiles `config:"files"`
+}
+
+// InitDefaults initializes the defaults for the configuration.
+func (c *Logging) InitDefaults() {
+	c.Level = "info"
+	c.ToFiles = true
+}
+
+// Validate ensures that the configuration is valid.
+func (c *Logging) Validate() error {
+	if _, err := strToLevel(c.Level); err != nil {
+		return err
+	}
+	return nil
+}
+
+// LogLevel returns configured zerolog.Level
+func (c *Logging) LogLevel() zerolog.Level {
+	l, _ := strToLevel(c.Level)
+	return l
+}

--- a/internal/pkg/config/output.go
+++ b/internal/pkg/config/output.go
@@ -55,9 +55,6 @@ func (c *Elasticsearch) Validate() error {
 	if c.APIKey != "" {
 		return fmt.Errorf("cannot connect to elasticsearch with api_key; must use username/password")
 	}
-	if c.Username == "" || c.Password == "" {
-		return fmt.Errorf("cannot connect to elasticsearch without username/password")
-	}
 	if c.ProxyURL != "" && !c.ProxyDisable {
 		if _, err := common.ParseURL(c.ProxyURL); err != nil {
 			return err

--- a/internal/pkg/coordinator/monitor.go
+++ b/internal/pkg/coordinator/monitor.go
@@ -90,13 +90,17 @@ func NewMonitor(fleet config.Fleet, version string, bulker bulk.Bulk, monitor mo
 
 // Run runs the monitor.
 func (m *monitorT) Run(ctx context.Context) (err error) {
-	m.log.Info().Msg("start")
-	defer func() {
-		m.log.Info().Err(err).Msg("exited")
-	}()
+	// When ID of the Agent is not provided to Fleet Server then the Agent
+	// has not enrolled. The Fleet Server cannot become a leader until the
+	// Agent it is running under has been enrolled.
+	m.calcMetadata()
+	if m.agentMetadata.Id == "" {
+		m.log.Warn().Msg("missing config fleet.agent.id; acceptable until Elastic Agent has enrolled")
+		<-ctx.Done()
+		return ctx.Err()
+	}
 
 	// Ensure leadership on startup
-	m.calcMetadata()
 	err = m.ensureLeadership(ctx)
 	if err != nil {
 		return err

--- a/internal/pkg/logger/logger.go
+++ b/internal/pkg/logger/logger.go
@@ -78,6 +78,7 @@ func (l *Logger) Reload(_ context.Context, cfg *config.Config) error {
 	return nil
 }
 
+// Sync syncs the logger to its output.
 func (l *Logger) Sync() {
 	if l.sync != nil {
 		l.sync.Sync()

--- a/internal/pkg/logger/logger.go
+++ b/internal/pkg/logger/logger.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -20,36 +19,8 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
 )
 
-const (
-	kPrettyTimeFormat = "15:04:05.000000"
-)
-
 var once sync.Once
 var gLogger *Logger
-
-func strToLevel(s string) zerolog.Level {
-	l := zerolog.DebugLevel
-
-	s = strings.ToLower(s)
-	switch strings.TrimSpace(s) {
-	case "trace":
-		l = zerolog.TraceLevel
-	case "debug":
-		l = zerolog.DebugLevel
-	case "info":
-		l = zerolog.InfoLevel
-	case "warn":
-		l = zerolog.WarnLevel
-	case "error":
-		l = zerolog.ErrorLevel
-	case "fatal":
-		l = zerolog.FatalLevel
-	case "panic":
-		l = zerolog.PanicLevel
-	}
-
-	return l
-}
 
 // WriterSync implements a Sync function.
 type WriterSync interface {

--- a/internal/pkg/policy/monitor.go
+++ b/internal/pkg/policy/monitor.go
@@ -81,7 +81,7 @@ func (s *subT) Output() <-chan model.Policy {
 // NewMonitor creates the policy monitor for subscribing agents.
 func NewMonitor(bulker bulk.Bulk, monitor monitor.Monitor, throttle time.Duration) Monitor {
 	return &monitorT{
-		log:           log.With().Str("ctx", "policy agent manager").Logger(),
+		log:           log.With().Str("ctx", "policy agent monitor").Logger(),
 		bulker:        bulker,
 		monitor:       monitor,
 		kickCh:        make(chan struct{}, 1),

--- a/internal/pkg/policy/self.go
+++ b/internal/pkg/policy/self.go
@@ -1,0 +1,184 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
+	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
+	"github.com/elastic/fleet-server/v7/internal/pkg/model"
+	"github.com/elastic/fleet-server/v7/internal/pkg/monitor"
+	"github.com/elastic/fleet-server/v7/internal/pkg/status"
+)
+
+type SelfMonitor interface {
+	// Run runs the monitor.
+	Run(ctx context.Context) error
+}
+
+type selfMonitorT struct {
+	log zerolog.Logger
+
+	mut     sync.Mutex
+	bulker  bulk.Bulk
+	monitor monitor.Monitor
+
+	policyId string
+	reporter status.Reporter
+
+	policy *model.Policy
+
+	policyF       policyFetcher
+	policiesIndex string
+}
+
+// NewSelfMonitor creates the self policy monitor.
+//
+// Ensures that the policy that this Fleet Server attached to exists and that it
+// has a Fleet Server input defined.
+func NewSelfMonitor(bulker bulk.Bulk, monitor monitor.Monitor, policyId string, reporter status.Reporter) SelfMonitor {
+	return &selfMonitorT{
+		log:           log.With().Str("ctx", "policy self monitor").Logger(),
+		bulker:        bulker,
+		monitor:       monitor,
+		policyId:      policyId,
+		reporter:      reporter,
+		policyF:       dl.QueryLatestPolicies,
+		policiesIndex: dl.FleetPolicies,
+	}
+}
+
+// Run runs the monitor.
+func (m *selfMonitorT) Run(ctx context.Context) error {
+	s := m.monitor.Subscribe()
+	defer m.monitor.Unsubscribe(s)
+
+	err := m.process(ctx)
+	if err != nil {
+		return err
+	}
+
+LOOP:
+	for {
+		select {
+		case <-ctx.Done():
+			break LOOP
+		case hits := <-s.Output():
+			policies := make([]model.Policy, len(hits))
+			for i, hit := range hits {
+				err := hit.Unmarshal(&policies[i])
+				if err != nil {
+					return err
+				}
+			}
+			if err := m.processPolicies(ctx, policies); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (m *selfMonitorT) process(ctx context.Context) error {
+	policies, err := m.policyF(ctx, m.bulker, dl.WithIndexName(m.policiesIndex))
+	if err != nil {
+		return err
+	}
+	if len(policies) == 0 {
+		m.updateStatus()
+		return nil
+	}
+	return m.processPolicies(ctx, policies)
+}
+
+func (m *selfMonitorT) processPolicies(ctx context.Context, policies []model.Policy) error {
+	if len(policies) == 0 {
+		// nothing to do
+		return nil
+	}
+	latest := m.groupByLatest(policies)
+	for _, policy := range latest {
+		if m.policyId != "" && policy.PolicyId == m.policyId {
+			m.policy = &policy
+			break
+		} else if m.policyId == "" && policy.DefaultFleetServer {
+			m.policy = &policy
+			break
+		}
+	}
+	return m.updateStatus()
+}
+
+func (m *selfMonitorT) groupByLatest(policies []model.Policy) map[string]model.Policy {
+	latest := make(map[string]model.Policy)
+	for _, policy := range policies {
+		curr, ok := latest[policy.PolicyId]
+		if !ok {
+			latest[policy.PolicyId] = policy
+			continue
+		}
+		if policy.RevisionIdx > curr.RevisionIdx {
+			latest[policy.PolicyId] = policy
+			continue
+		} else if policy.RevisionIdx == curr.RevisionIdx && policy.CoordinatorIdx > curr.CoordinatorIdx {
+			latest[policy.PolicyId] = policy
+		}
+	}
+	return latest
+}
+
+func (m *selfMonitorT) updateStatus() error {
+	if m.policy == nil {
+		// no policy found
+		if m.policyId == "" {
+			m.reporter.Status(proto.StateObserved_STARTING, "Waiting on default policy with Fleet Server integration", nil)
+		} else {
+			m.reporter.Status(proto.StateObserved_STARTING, fmt.Sprintf("Waiting on policy with Fleet Server integration: %s", m.policyId), nil)
+		}
+		return nil
+	}
+
+	var data policyData
+	err := json.Unmarshal(m.policy.Data, &data)
+	if err != nil {
+		return err
+	}
+	if !data.HasType("fleet-server") {
+		return fmt.Errorf("assigned policy does not have fleet-server input")
+	}
+
+	if m.policyId == "" {
+		m.reporter.Status(proto.StateObserved_HEALTHY, "Running on default policy with Fleet Server integration", nil)
+	} else {
+		m.reporter.Status(proto.StateObserved_HEALTHY, fmt.Sprintf("Running on policy with Fleet Server integration: %s", m.policyId), nil)
+	}
+	return nil
+}
+
+type policyData struct {
+	Inputs []policyInput `json:"inputs"`
+}
+
+type policyInput struct {
+	Type string `json:"type"`
+}
+
+func (d *policyData) HasType(val string) bool {
+	for _, input := range d.Inputs {
+		if input.Type == val {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pkg/policy/self.go
+++ b/internal/pkg/policy/self.go
@@ -7,6 +7,7 @@ package policy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
 	"net/http"
@@ -105,9 +106,6 @@ func (m *selfMonitorT) process(ctx context.Context) error {
 		if elasticErr.Status != http.StatusNotFound {
 			return err
 		}
-		// index does not exist; yet!
-		m.updateStatus()
-		return nil
 	}
 	if len(policies) == 0 {
 		m.updateStatus()
@@ -169,7 +167,7 @@ func (m *selfMonitorT) updateStatus() error {
 		return err
 	}
 	if !data.HasType("fleet-server") {
-		return fmt.Errorf("assigned policy does not have fleet-server input")
+		return errors.New("assigned policy does not have fleet-server input")
 	}
 
 	status := proto.StateObserved_HEALTHY

--- a/internal/pkg/policy/self_test.go
+++ b/internal/pkg/policy/self_test.go
@@ -1,0 +1,227 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build !integration
+
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
+	"github.com/gofrs/uuid"
+	"github.com/rs/xid"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
+	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
+	"github.com/elastic/fleet-server/v7/internal/pkg/es"
+	"github.com/elastic/fleet-server/v7/internal/pkg/model"
+	"github.com/elastic/fleet-server/v7/internal/pkg/monitor/mock"
+	ftesting "github.com/elastic/fleet-server/v7/internal/pkg/testing"
+)
+
+func TestSelfMonitor_DefaultPolicy(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	reporter := &FakeReporter{}
+	bulker := ftesting.MockBulk{}
+	mm := mock.NewMockIndexMonitor()
+	monitor := NewSelfMonitor(bulker, mm, "", reporter)
+	sm := monitor.(*selfMonitorT)
+	sm.policyF = func(ctx context.Context, bulker bulk.Bulk, opt ...dl.Option) ([]model.Policy, error) {
+		return []model.Policy{}, nil
+	}
+
+	var merr error
+	var mwg sync.WaitGroup
+	mwg.Add(1)
+	go func() {
+		defer mwg.Done()
+		merr = monitor.Run(ctx)
+	}()
+
+	// should be set to starting
+	ftesting.Retry(t, ctx, func(ctx context.Context) error {
+		status, msg, _ := reporter.Current()
+		if status != proto.StateObserved_STARTING {
+			return fmt.Errorf("should be reported as starting")
+		}
+		if msg != "Waiting on default policy with Fleet Server integration" {
+			return fmt.Errorf("should be matching with default policy")
+		}
+		return nil
+	}, ftesting.RetrySleep(1*time.Second))
+
+	policyId := uuid.Must(uuid.NewV4()).String()
+	rId := xid.New().String()
+	policyContents, err := json.Marshal(&policyData{Inputs: []policyInput{
+		{
+			Type: "fleet-server",
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy := model.Policy{
+		ESDocument: model.ESDocument{
+			Id:      rId,
+			Version: 1,
+			SeqNo:   1,
+		},
+		PolicyId:           policyId,
+		CoordinatorIdx:     1,
+		Data:               policyContents,
+		RevisionIdx:        1,
+		DefaultFleetServer: true,
+	}
+	policyData, err := json.Marshal(&policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		mm.Notify(ctx, []es.HitT{
+			{
+				Id:      rId,
+				SeqNo:   1,
+				Version: 1,
+				Source:  policyData,
+			},
+		})
+	}()
+
+	// should now be set to healthy
+	ftesting.Retry(t, ctx, func(ctx context.Context) error {
+		status, msg, _ := reporter.Current()
+		if status != proto.StateObserved_HEALTHY {
+			return fmt.Errorf("should be reported as healthy")
+		}
+		if msg != "Running on default policy with Fleet Server integration" {
+			return fmt.Errorf("should be matching with default policy")
+		}
+		return nil
+	})
+
+	cancel()
+	mwg.Wait()
+	if merr != nil && merr != context.Canceled {
+		t.Fatal(merr)
+	}
+}
+
+func TestSelfMonitor_SpecificPolicy(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	policyId := uuid.Must(uuid.NewV4()).String()
+	reporter := &FakeReporter{}
+	bulker := ftesting.MockBulk{}
+	mm := mock.NewMockIndexMonitor()
+	monitor := NewSelfMonitor(bulker, mm, policyId, reporter)
+	sm := monitor.(*selfMonitorT)
+	sm.policyF = func(ctx context.Context, bulker bulk.Bulk, opt ...dl.Option) ([]model.Policy, error) {
+		return []model.Policy{}, nil
+	}
+
+	var merr error
+	var mwg sync.WaitGroup
+	mwg.Add(1)
+	go func() {
+		defer mwg.Done()
+		merr = monitor.Run(ctx)
+	}()
+
+	// should be set to starting
+	ftesting.Retry(t, ctx, func(ctx context.Context) error {
+		status, msg, _ := reporter.Current()
+		if status != proto.StateObserved_STARTING {
+			return fmt.Errorf("should be reported as starting")
+		}
+		if msg != fmt.Sprintf("Waiting on policy with Fleet Server integration: %s", policyId) {
+			return fmt.Errorf("should be matching with specific policy")
+		}
+		return nil
+	}, ftesting.RetrySleep(1*time.Second))
+
+	rId := xid.New().String()
+	policyContents, err := json.Marshal(&policyData{Inputs: []policyInput{
+		{
+			Type: "fleet-server",
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy := model.Policy{
+		ESDocument: model.ESDocument{
+			Id:      rId,
+			Version: 1,
+			SeqNo:   1,
+		},
+		PolicyId:           policyId,
+		CoordinatorIdx:     1,
+		Data:               policyContents,
+		RevisionIdx:        1,
+		DefaultFleetServer: true,
+	}
+	policyData, err := json.Marshal(&policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		mm.Notify(ctx, []es.HitT{
+			{
+				Id:      rId,
+				SeqNo:   1,
+				Version: 1,
+				Source:  policyData,
+			},
+		})
+	}()
+
+	// should now be set to healthy
+	ftesting.Retry(t, ctx, func(ctx context.Context) error {
+		status, msg, _ := reporter.Current()
+		if status != proto.StateObserved_HEALTHY {
+			return fmt.Errorf("should be reported as healthy")
+		}
+		if msg != fmt.Sprintf("Running on policy with Fleet Server integration: %s", policyId) {
+			return fmt.Errorf("should be matching with specific policy")
+		}
+		return nil
+	})
+
+	cancel()
+	mwg.Wait()
+	if merr != nil && merr != context.Canceled {
+		t.Fatal(merr)
+	}
+}
+
+type FakeReporter struct {
+	lock    sync.Mutex
+	status  proto.StateObserved_Status
+	msg     string
+	payload map[string]interface{}
+}
+
+func (r *FakeReporter) Status(status proto.StateObserved_Status, message string, payload map[string]interface{}) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.status = status
+	r.msg = message
+	r.payload = payload
+	return nil
+}
+
+func (r *FakeReporter) Current() (proto.StateObserved_Status, string, map[string]interface{}) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	return r.status, r.msg, r.payload
+}

--- a/internal/pkg/policy/self_test.go
+++ b/internal/pkg/policy/self_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/elastic/fleet-server/v7/internal/pkg/config"
 	"sync"
 	"testing"
 	"time"
@@ -30,10 +31,15 @@ func TestSelfMonitor_DefaultPolicy(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	cfg := config.Fleet{
+		Agent: config.Agent{
+			ID: "agent-id",
+		},
+	}
 	reporter := &FakeReporter{}
 	bulker := ftesting.MockBulk{}
 	mm := mock.NewMockIndexMonitor()
-	monitor := NewSelfMonitor(bulker, mm, "", reporter)
+	monitor := NewSelfMonitor(cfg, bulker, mm, "", reporter)
 	sm := monitor.(*selfMonitorT)
 	sm.policyF = func(ctx context.Context, bulker bulk.Bulk, opt ...dl.Option) ([]model.Policy, error) {
 		return []model.Policy{}, nil
@@ -115,15 +121,114 @@ func TestSelfMonitor_DefaultPolicy(t *testing.T) {
 	}
 }
 
+func TestSelfMonitor_DefaultPolicy_Degraded(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := config.Fleet{
+		Agent: config.Agent{
+			ID: "",
+		},
+	}
+	reporter := &FakeReporter{}
+	bulker := ftesting.MockBulk{}
+	mm := mock.NewMockIndexMonitor()
+	monitor := NewSelfMonitor(cfg, bulker, mm, "", reporter)
+	sm := monitor.(*selfMonitorT)
+	sm.policyF = func(ctx context.Context, bulker bulk.Bulk, opt ...dl.Option) ([]model.Policy, error) {
+		return []model.Policy{}, nil
+	}
+
+	var merr error
+	var mwg sync.WaitGroup
+	mwg.Add(1)
+	go func() {
+		defer mwg.Done()
+		merr = monitor.Run(ctx)
+	}()
+
+	// should be set to starting
+	ftesting.Retry(t, ctx, func(ctx context.Context) error {
+		status, msg, _ := reporter.Current()
+		if status != proto.StateObserved_STARTING {
+			return fmt.Errorf("should be reported as starting")
+		}
+		if msg != "Waiting on default policy with Fleet Server integration" {
+			return fmt.Errorf("should be matching with default policy")
+		}
+		return nil
+	}, ftesting.RetrySleep(1*time.Second))
+
+	policyId := uuid.Must(uuid.NewV4()).String()
+	rId := xid.New().String()
+	policyContents, err := json.Marshal(&policyData{Inputs: []policyInput{
+		{
+			Type: "fleet-server",
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy := model.Policy{
+		ESDocument: model.ESDocument{
+			Id:      rId,
+			Version: 1,
+			SeqNo:   1,
+		},
+		PolicyId:           policyId,
+		CoordinatorIdx:     1,
+		Data:               policyContents,
+		RevisionIdx:        1,
+		DefaultFleetServer: true,
+	}
+	policyData, err := json.Marshal(&policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		mm.Notify(ctx, []es.HitT{
+			{
+				Id:      rId,
+				SeqNo:   1,
+				Version: 1,
+				Source:  policyData,
+			},
+		})
+	}()
+
+	// should now be set to healthy
+	ftesting.Retry(t, ctx, func(ctx context.Context) error {
+		status, msg, _ := reporter.Current()
+		if status != proto.StateObserved_DEGRADED {
+			return fmt.Errorf("should be reported as healthy")
+		}
+		if msg != "Running on default policy with Fleet Server integration; missing config fleet.agent.id" {
+			return fmt.Errorf("should be matching with default policy")
+		}
+		return nil
+	})
+
+	cancel()
+	mwg.Wait()
+	if merr != nil && merr != context.Canceled {
+		t.Fatal(merr)
+	}
+}
+
 func TestSelfMonitor_SpecificPolicy(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	cfg := config.Fleet{
+		Agent: config.Agent{
+			ID: "agent-id",
+		},
+	}
 	policyId := uuid.Must(uuid.NewV4()).String()
 	reporter := &FakeReporter{}
 	bulker := ftesting.MockBulk{}
 	mm := mock.NewMockIndexMonitor()
-	monitor := NewSelfMonitor(bulker, mm, policyId, reporter)
+	monitor := NewSelfMonitor(cfg, bulker, mm, policyId, reporter)
 	sm := monitor.(*selfMonitorT)
 	sm.policyF = func(ctx context.Context, bulker bulk.Bulk, opt ...dl.Option) ([]model.Policy, error) {
 		return []model.Policy{}, nil
@@ -192,6 +297,100 @@ func TestSelfMonitor_SpecificPolicy(t *testing.T) {
 			return fmt.Errorf("should be reported as healthy")
 		}
 		if msg != fmt.Sprintf("Running on policy with Fleet Server integration: %s", policyId) {
+			return fmt.Errorf("should be matching with specific policy")
+		}
+		return nil
+	})
+
+	cancel()
+	mwg.Wait()
+	if merr != nil && merr != context.Canceled {
+		t.Fatal(merr)
+	}
+}
+
+func TestSelfMonitor_SpecificPolicy_Degraded(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := config.Fleet{
+		Agent: config.Agent{
+			ID: "",
+		},
+	}
+	policyId := uuid.Must(uuid.NewV4()).String()
+	reporter := &FakeReporter{}
+	bulker := ftesting.MockBulk{}
+	mm := mock.NewMockIndexMonitor()
+	monitor := NewSelfMonitor(cfg, bulker, mm, policyId, reporter)
+	sm := monitor.(*selfMonitorT)
+	sm.policyF = func(ctx context.Context, bulker bulk.Bulk, opt ...dl.Option) ([]model.Policy, error) {
+		return []model.Policy{}, nil
+	}
+
+	var merr error
+	var mwg sync.WaitGroup
+	mwg.Add(1)
+	go func() {
+		defer mwg.Done()
+		merr = monitor.Run(ctx)
+	}()
+
+	// should be set to starting
+	ftesting.Retry(t, ctx, func(ctx context.Context) error {
+		status, msg, _ := reporter.Current()
+		if status != proto.StateObserved_STARTING {
+			return fmt.Errorf("should be reported as starting")
+		}
+		if msg != fmt.Sprintf("Waiting on policy with Fleet Server integration: %s", policyId) {
+			return fmt.Errorf("should be matching with specific policy")
+		}
+		return nil
+	}, ftesting.RetrySleep(1*time.Second))
+
+	rId := xid.New().String()
+	policyContents, err := json.Marshal(&policyData{Inputs: []policyInput{
+		{
+			Type: "fleet-server",
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy := model.Policy{
+		ESDocument: model.ESDocument{
+			Id:      rId,
+			Version: 1,
+			SeqNo:   1,
+		},
+		PolicyId:           policyId,
+		CoordinatorIdx:     1,
+		Data:               policyContents,
+		RevisionIdx:        1,
+		DefaultFleetServer: true,
+	}
+	policyData, err := json.Marshal(&policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		mm.Notify(ctx, []es.HitT{
+			{
+				Id:      rId,
+				SeqNo:   1,
+				Version: 1,
+				Source:  policyData,
+			},
+		})
+	}()
+
+	// should now be set to healthy
+	ftesting.Retry(t, ctx, func(ctx context.Context) error {
+		status, msg, _ := reporter.Current()
+		if status != proto.StateObserved_DEGRADED {
+			return fmt.Errorf("should be reported as healthy")
+		}
+		if msg != fmt.Sprintf("Running on policy with Fleet Server integration: %s; missing config fleet.agent.id", policyId) {
 			return fmt.Errorf("should be matching with specific policy")
 		}
 		return nil

--- a/internal/pkg/status/reporter.go
+++ b/internal/pkg/status/reporter.go
@@ -1,0 +1,53 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package status
+
+import (
+	"github.com/rs/zerolog/log"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
+)
+
+// Reporter is interface that reports updated status on.
+type Reporter interface {
+	// Status triggers updating the status.
+	Status(status proto.StateObserved_Status, message string, payload map[string]interface{}) error
+}
+
+// Log logs the reported status.
+type Log struct{}
+
+// NewLog creates a LogStatus.
+func NewLog() *Log {
+	return &Log{}
+}
+
+// Status triggers updating the status.
+func (l *Log) Status(status proto.StateObserved_Status, message string, payload map[string]interface{}) error {
+	log.Info().Str("status", status.String()).Fields(map[string]interface{}{
+		"payload": payload,
+	}).Msg(message)
+	return nil
+}
+
+// Chained calls Status on all the provided reporters in the provided order.
+type Chained struct {
+	reporters []Reporter
+}
+
+// NewChained creates a Chained with provided reporters.
+func NewChained(reporters ...Reporter) *Chained {
+	return &Chained{reporters}
+}
+
+// Status triggers updating the status.
+func (l *Chained) Status(status proto.StateObserved_Status, message string, payload map[string]interface{}) error {
+	for _, reporter := range l.reporters {
+		if err := reporter.Status(status, message, payload); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/pkg/testing/retry.go
+++ b/internal/pkg/testing/retry.go
@@ -52,9 +52,7 @@ func Retry(t *testing.T, ctx context.Context, f RetryFunc, opts ...RetryOption) 
 		if err == nil {
 			return
 		}
-		if err = sleep.WithContext(ctx, o.sleep); err != nil {
-			break
-		}
+		sleep.WithContext(ctx, o.sleep)
 	}
 	t.Fatal(err)
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds communication back to the Elastic Agent when running in `--agent-mode`.

Waits to get the initial configuration from Elastic Agent before starting the actual `FleetServer`. On any updated configuration it reloads the `FleetServer`.

Reports the status of `Starting` until a policy for the Fleet Server is identified. Elastic Agent will use that status reporting to wait until it goes to `Healthy` to perform the enrollment of itself.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To coordinate the control of Fleet Server by Elastic Agent.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- [X] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
