### PR TITLE
Rename action input_id to input_type

### DIFF
--- a/cmd/fleet/handleCheckin.go
+++ b/cmd/fleet/handleCheckin.go
@@ -246,7 +246,7 @@ func convertActions(agentId string, actions []model.Action) ([]ActionResp, strin
 			Data:      []byte(action.Data),
 			Id:        action.ActionId,
 			Type:      action.Type,
-			InputId:   action.InputId,
+			InputType: action.InputType,
 		})
 	}
 

--- a/cmd/fleet/schema.go
+++ b/cmd/fleet/schema.go
@@ -123,7 +123,7 @@ type ActionResp struct {
 	Data      json.RawMessage `json:"data"`
 	Id        string          `json:"id"`
 	Type      string          `json:"type"`
-	InputId   string          `json:"input_id"`
+	InputType string          `json:"input_type"`
 }
 
 type Event struct {

--- a/internal/pkg/es/mapping.go
+++ b/internal/pkg/es/mapping.go
@@ -24,7 +24,7 @@ const (
 		"expiration": {
 			"type": "date"
 		},
-		"input_id": {
+		"input_type": {
 			"type": "keyword"
 		},
 		"@timestamp": {

--- a/internal/pkg/model/schema.go
+++ b/internal/pkg/model/schema.go
@@ -45,8 +45,8 @@ type Action struct {
 	// The action expiration date/time
 	Expiration string `json:"expiration,omitempty"`
 
-	// The input identifier the actions should be routed to.
-	InputId string `json:"input_id,omitempty"`
+	// The input type the actions should be routed to.
+	InputType string `json:"input_type,omitempty"`
 
 	// Date/time the action was created
 	Timestamp string `json:"@timestamp,omitempty"`

--- a/internal/pkg/testing/actions.go
+++ b/internal/pkg/testing/actions.go
@@ -9,12 +9,13 @@ package testing
 import (
 	"context"
 	"encoding/json"
+	"testing"
+	"time"
+
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/es"
 	"github.com/elastic/fleet-server/v7/internal/pkg/model"
 	"github.com/elastic/fleet-server/v7/internal/pkg/rnd"
-	"testing"
-	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/rs/xid"
@@ -60,7 +61,7 @@ func CreateRandomActions(min, max int) ([]model.Action, error) {
 			Timestamp:  r.Time(now, 2, 5, time.Second, rnd.TimeBefore).Format(time.RFC3339),
 			Expiration: r.Time(now, 12, 25, time.Minute, rnd.TimeAfter).Format(time.RFC3339),
 			Type:       "APP_ACTION",
-			InputId:    "osquery",
+			InputType:  "osquery",
 			Agents:     aid,
 			Data:       data,
 		}

--- a/model/schema.json
+++ b/model/schema.json
@@ -33,8 +33,8 @@
           "description": "The action type. APP_ACTION is the value for the actions that suppose to be routed to the endpoints/beats.",
           "type": "string"
         },
-        "input_id": {
-          "description": "The input identifier the actions should be routed to.",
+        "input_type": {
+          "description": "The input type the actions should be routed to.",
           "type": "string"
         },
         "agents": {


### PR DESCRIPTION
## What does this PR do?

Rename action input_id to input_type. Instead of integration input id that is generated every time by kibana, rely on more stable integration input type.

Related Fleet Server package change: https://github.com/elastic/integrations/pull/573

