### PR TITLE
Reduce actions fetching interval if the full page of action documents was fetched

### DIFF
--- a/internal/pkg/model/schema.go
+++ b/internal/pkg/model/schema.go
@@ -51,7 +51,7 @@ type Action struct {
 	// Date/time the action was created
 	Timestamp string `json:"@timestamp,omitempty"`
 
-	// The action type. APP_ACTION is the value for the actions that suppose to be routed to the endpoints/beats.
+	// The action type. INPUT_ACTION is the value for the actions that suppose to be routed to the endpoints/beats.
 	Type string `json:"type,omitempty"`
 }
 

--- a/model/schema.json
+++ b/model/schema.json
@@ -30,7 +30,7 @@
           "format": "date-time"
         },
         "type": {
-          "description": "The action type. APP_ACTION is the value for the actions that suppose to be routed to the endpoints/beats.",
+          "description": "The action type. INPUT_ACTION is the value for the actions that suppose to be routed to the endpoints/beats.",
           "type": "string"
         },
         "input_type": {


### PR DESCRIPTION
## What does this PR do?

Reduce actions fetching interval if the full page of action documents was fetched. Otherwise the monitor waits for 1 secs (by default) until the next poll.

Presently the UPGRADE action is creating individual action documents for each agent, which will be slow to roll out if we delay for 1 sec between each 10 actions. Ideally we would group as many agents under one document as possible.
Talked to @nchaulet and this is on his to do list for kibana.

