### PR TITLE
[Backport 7.x]: Reduce actions fetching interval if the full page of action documents was fetched

### DIFF
--- a/internal/pkg/dl/actions.go
+++ b/internal/pkg/dl/actions.go
@@ -15,6 +15,8 @@ import (
 const (
 	FieldAgents     = "agents"
 	FieldExpiration = "expiration"
+
+	maxAgentActionsFetchSize = 100
 )
 
 var (
@@ -44,6 +46,8 @@ func prepareFindAgentActions() *dsl.Tmpl {
 
 	filter.Terms(FieldAgents, tmpl.Bind(FieldAgents), nil)
 
+	// Select more actions per agent since the agents array is not loaded
+	root.Size(maxAgentActionsFetchSize)
 	root.Source().Excludes(FieldAgents)
 
 	tmpl.MustResolve(root)

--- a/internal/pkg/model/schema.go
+++ b/internal/pkg/model/schema.go
@@ -51,7 +51,7 @@ type Action struct {
 	// Date/time the action was created
 	Timestamp string `json:"@timestamp,omitempty"`
 
-	// The action type. APP_ACTION is the value for the actions that suppose to be routed to the endpoints/beats.
+	// The action type. INPUT_ACTION is the value for the actions that suppose to be routed to the endpoints/beats.
 	Type string `json:"type,omitempty"`
 }
 

--- a/model/schema.json
+++ b/model/schema.json
@@ -30,7 +30,7 @@
           "format": "date-time"
         },
         "type": {
-          "description": "The action type. APP_ACTION is the value for the actions that suppose to be routed to the endpoints/beats.",
+          "description": "The action type. INPUT_ACTION is the value for the actions that suppose to be routed to the endpoints/beats.",
           "type": "string"
         },
         "input_type": {


### PR DESCRIPTION
Backport to 7.x: 
https://github.com/elastic/fleet-server/pull/82