### PR TITLE
[Backport 7.x] Flatten .fleet-actions-results schema

### DIFF
--- a/cmd/fleet/handleAck.go
+++ b/cmd/fleet/handleAck.go
@@ -108,10 +108,13 @@ func _handleAckEvents(ctx context.Context, agent *model.Agent, events []Event, b
 		}
 
 		acr := model.ActionResult{
-			ActionId: ev.ActionId,
-			AgentId:  agent.Id,
-			Data:     ev.Data,
-			Error:    ev.Error,
+			ActionId:    ev.ActionId,
+			AgentId:     agent.Id,
+			StartedAt:   ev.StartedAt,
+			CompletedAt: ev.CompletedAt,
+			ActionData:  ev.ActionData,
+			Data:        ev.Data,
+			Error:       ev.Error,
 		}
 		if _, err := dl.CreateActionResult(ctx, bulker, acr); err != nil {
 			return err

--- a/cmd/fleet/schema.go
+++ b/cmd/fleet/schema.go
@@ -127,15 +127,18 @@ type ActionResp struct {
 }
 
 type Event struct {
-	Type      string          `json:"type"`
-	SubType   string          `json:"subtype"`
-	AgentId   string          `json:"agent_id"`
-	ActionId  string          `json:"action_id"`
-	PolicyId  string          `json:"policy_id"`
-	StreamId  string          `json:"stream_id"`
-	Timestamp string          `json:"timestamp"`
-	Message   string          `json:"message"`
-	Payload   string          `json:"payload,omitempty"`
-	Data      json.RawMessage `json:"data,omitempty"`
-	Error     string          `json:"error,omitempty"`
+	Type        string          `json:"type"`
+	SubType     string          `json:"subtype"`
+	AgentId     string          `json:"agent_id"`
+	ActionId    string          `json:"action_id"`
+	PolicyId    string          `json:"policy_id"`
+	StreamId    string          `json:"stream_id"`
+	Timestamp   string          `json:"timestamp"`
+	Message     string          `json:"message"`
+	Payload     string          `json:"payload,omitempty"`
+	StartedAt   string          `json:"started_at"`
+	CompletedAt string          `json:"completed_at"`
+	ActionData  json.RawMessage `json:"action_data,omitempty"`
+	Data        json.RawMessage `json:"data,omitempty"`
+	Error       string          `json:"error,omitempty"`
 }

--- a/internal/pkg/es/mapping.go
+++ b/internal/pkg/es/mapping.go
@@ -36,14 +36,28 @@ const (
 	}
 }`
 
+	// ActionData The opaque payload.
+	MappingActionData = `{
+	"properties": {
+		
+	}
+}`
+
 	// ActionResult An Elastic Agent action results
 	MappingActionResult = `{
 	"properties": {
+		"action_data": {
+			"enabled" : false,
+			"type": "object"
+		},
 		"action_id": {
 			"type": "keyword"
 		},
 		"agent_id": {
 			"type": "keyword"
+		},
+		"completed_at": {
+			"type": "date"
 		},
 		"data": {
 			"enabled" : false,
@@ -51,6 +65,9 @@ const (
 		},
 		"error": {
 			"type": "keyword"
+		},
+		"started_at": {
+			"type": "date"
 		},
 		"@timestamp": {
 			"type": "date"

--- a/internal/pkg/model/schema.go
+++ b/internal/pkg/model/schema.go
@@ -55,9 +55,16 @@ type Action struct {
 	Type string `json:"type,omitempty"`
 }
 
+// ActionData The opaque payload.
+type ActionData struct {
+}
+
 // ActionResult An Elastic Agent action results
 type ActionResult struct {
 	ESDocument
+
+	// The opaque payload.
+	ActionData json.RawMessage `json:"action_data,omitempty"`
 
 	// The action id.
 	ActionId string `json:"action_id,omitempty"`
@@ -65,11 +72,17 @@ type ActionResult struct {
 	// The agent id.
 	AgentId string `json:"agent_id,omitempty"`
 
+	// Date/time the action was completed
+	CompletedAt string `json:"completed_at,omitempty"`
+
 	// The opaque payload.
 	Data json.RawMessage `json:"data,omitempty"`
 
 	// The action error message.
 	Error string `json:"error,omitempty"`
+
+	// Date/time the action was started
+	StartedAt string `json:"started_at,omitempty"`
 
 	// Date/time the action was created
 	Timestamp string `json:"@timestamp,omitempty"`

--- a/model/schema.json
+++ b/model/schema.json
@@ -73,6 +73,21 @@
           "description": "The action id.",
           "type": "string"
         },
+        "started_at": {
+          "description": "Date/time the action was started",
+          "type": "string",
+          "format": "date-time"
+        },
+        "completed_at": {
+          "description": "Date/time the action was completed",
+          "type": "string",
+          "format": "date-time"
+        },
+        "action_data": {
+          "description": "The opaque payload.",
+          "type": "object",
+          "format": "raw"
+        },
         "error": {
           "description": "The action error message.",
           "type": "string"


### PR DESCRIPTION
## What does this PR do?

Backport to 7.x of https://github.com/elastic/fleet-server/pull/87

