### PR TITLE
Change default bind port from 8000 to 8220

### DIFF
--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -46,8 +46,8 @@ func TestConfig(t *testing.T) {
 					{
 						Type: "fleet-server",
 						Server: Server{
-							Host: "localhost",
-							Port: 8000,
+							Host: kDefaultHost,
+							Port: kDefaultPort,
 							Timeouts: ServerTimeouts{
 								Read:  5 * time.Second,
 								Write: 60 * 10 * time.Second,
@@ -94,8 +94,8 @@ func TestConfig(t *testing.T) {
 					{
 						Type: "fleet-server",
 						Server: Server{
-							Host: "localhost",
-							Port: 8000,
+							Host: kDefaultHost,
+							Port: kDefaultPort,
 							Timeouts: ServerTimeouts{
 								Read:  5 * time.Second,
 								Write: 60 * 10 * time.Second,
@@ -140,8 +140,8 @@ func TestConfig(t *testing.T) {
 					{
 						Type: "fleet-server",
 						Server: Server{
-							Host: "localhost",
-							Port: 8000,
+							Host: kDefaultHost,
+							Port: kDefaultPort,
 							Timeouts: ServerTimeouts{
 								Read:  5 * time.Second,
 								Write: 60 * 10 * time.Second,
@@ -186,7 +186,7 @@ func TestConfig(t *testing.T) {
 					{
 						Type: "fleet-server",
 						Server: Server{
-							Host: "localhost",
+							Host: kDefaultHost,
 							Port: 8888,
 							Timeouts: ServerTimeouts{
 								Read:  20 * time.Second,

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -10,6 +10,9 @@ import (
 	"time"
 )
 
+const kDefaultHost = "localhost"
+const kDefaultPort = 8220
+
 // Policy is the configuration policy to use.
 type Policy struct {
 	ID string `config:"id"`
@@ -58,8 +61,8 @@ type Server struct {
 
 // InitDefaults initializes the defaults for the configuration.
 func (c *Server) InitDefaults() {
-	c.Host = "localhost"
-	c.Port = 8000
+	c.Host = kDefaultHost
+	c.Port = kDefaultPort
 	c.Timeouts.InitDefaults()
 	c.MaxHeaderByteSize = 8192 // 8k
 	c.RateLimitBurst = 1024


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Changes the default TCP/IP port that the fleet server binds to from 8000 to 8220.

## Why is it important?

8000 is commonly used.  8220 is not.

## Checklist

- [ x] My code follows the style guidelines of this project
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] I have made corresponding change to the default configuration files
- [x ] I have added tests that prove my fix is effective or that my feature works

