### PR TITLE
Add ssl configuration to fleet server http.

### DIFF
--- a/cmd/fleet/server.go
+++ b/cmd/fleet/server.go
@@ -6,13 +6,15 @@ package fleet
 
 import (
 	"context"
-	"github.com/elastic/fleet-server/v7/internal/pkg/config"
+	"crypto/tls"
 	slog "log"
 	"net"
 	"net/http"
 
+	"github.com/elastic/fleet-server/v7/internal/pkg/config"
 	"github.com/elastic/fleet-server/v7/internal/pkg/rate"
 
+	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 	"github.com/julienschmidt/httprouter"
 	"github.com/rs/zerolog/log"
 )
@@ -64,21 +66,23 @@ func runServer(ctx context.Context, router *httprouter.Router, cfg *config.Serve
 		}
 	}()
 
-	ln, err := makeListener(ctx, addr, cfg)
+	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return err
 	}
 
 	defer ln.Close()
 
-	// TODO: Use tls.Config to properly mux down tls connection
-	keyFile := cfg.TLS.Key
-	certFile := cfg.TLS.Cert
-
-	if keyFile != "" || certFile != "" {
-		return server.ServeTLS(ln, certFile, keyFile)
+	if cfg.TLS != nil && cfg.TLS.IsEnabled() {
+		tlsCfg, err := tlscommon.LoadTLSConfig(cfg.TLS)
+		if err != nil {
+			return err
+		}
+		server.TLSConfig = tlsCfg.ToConfig()
+		ln = tls.NewListener(ln, server.TLSConfig)
 	}
 
+	ln = wrapRateLimitter(ctx, ln, cfg)
 	if err := server.Serve(ln); err != nil && err != context.Canceled {
 		return err
 	}
@@ -86,13 +90,7 @@ func runServer(ctx context.Context, router *httprouter.Router, cfg *config.Serve
 	return nil
 }
 
-func makeListener(ctx context.Context, addr string, cfg *config.Server) (net.Listener, error) {
-	// Create listener
-	ln, err := net.Listen("tcp", addr)
-	if err != nil {
-		return nil, err
-	}
-
+func wrapRateLimitter(ctx context.Context, ln net.Listener, cfg *config.Server) net.Listener {
 	rateLimitBurst := cfg.RateLimitBurst
 	rateLimitInterval := cfg.RateLimitInterval
 
@@ -103,7 +101,7 @@ func makeListener(ctx context.Context, addr string, cfg *config.Server) (net.Lis
 		log.Info().Msg("Server connection rate limiter disabled")
 	}
 
-	return ln, err
+	return ln
 }
 
 type stubLogger struct {

--- a/cmd/fleet/server.go
+++ b/cmd/fleet/server.go
@@ -39,7 +39,7 @@ func runServer(ctx context.Context, router *httprouter.Router, cfg *config.Serve
 		Str("bind", addr).
 		Dur("rdTimeout", rdto).
 		Dur("wrTimeout", wrto).
-		Msg("Server listening")
+		Msg("server listening")
 
 	server := http.Server{
 		Addr:           addr,
@@ -59,10 +59,10 @@ func runServer(ctx context.Context, router *httprouter.Router, cfg *config.Serve
 	go func() {
 		select {
 		case <-ctx.Done():
-			log.Debug().Msg("Force server close on ctx.Done()")
+			log.Debug().Msg("force server close on ctx.Done()")
 			server.Close()
 		case <-forceCh:
-			log.Debug().Msg("Go routine forced closed on exit")
+			log.Debug().Msg("go routine forced closed on exit")
 		}
 	}()
 
@@ -80,6 +80,8 @@ func runServer(ctx context.Context, router *httprouter.Router, cfg *config.Serve
 		}
 		server.TLSConfig = tlsCfg.ToConfig()
 		ln = tls.NewListener(ln, server.TLSConfig)
+	} else {
+		log.Warn().Msg("exposed over insecure HTTP; enablement of TLS is strongly recommended")
 	}
 
 	ln = wrapRateLimitter(ctx, ln, cfg)
@@ -98,7 +100,7 @@ func wrapRateLimitter(ctx context.Context, ln net.Listener, cfg *config.Server) 
 		log.Info().Dur("interval", rateLimitInterval).Int("burst", rateLimitBurst).Msg("Server rate limiter installed")
 		ln = rate.NewRateListener(ctx, ln, rateLimitBurst, rateLimitInterval)
 	} else {
-		log.Info().Msg("Server connection rate limiter disabled")
+		log.Info().Msg("server connection rate limiter disabled")
 	}
 
 	return ln

--- a/cmd/fleet/server_integration_test.go
+++ b/cmd/fleet/server_integration_test.go
@@ -47,7 +47,7 @@ func (s *tserver) baseUrl() string {
 	input := s.cfg.Inputs[0]
 	tls := input.Server.TLS
 	schema := "http"
-	if tls.Key != "" || tls.Cert != "" {
+	if tls != nil && tls.IsEnabled() {
 		schema = "https"
 	}
 	return fmt.Sprintf("%s://%s:%d", schema, input.Server.Host, input.Server.Port)

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"fmt"
+	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 	"strings"
 	"time"
 )
@@ -48,15 +49,15 @@ type ServerTLS struct {
 
 // Server is the configuration for the server
 type Server struct {
-	Host              string         `config:"host"`
-	Port              uint16         `config:"port"`
-	TLS               ServerTLS      `config:"tls"`
-	Timeouts          ServerTimeouts `config:"timeouts"`
-	MaxHeaderByteSize int            `config:"max_header_byte_size"`
-	RateLimitBurst    int            `config:"rate_limit_burst"`
-	RateLimitInterval time.Duration  `config:"rate_limit_interval"`
-	MaxEnrollPending  int64          `config:"max_enroll_pending"`
-	Profile           ServerProfile  `config:"profile"`
+	Host              string            `config:"host"`
+	Port              uint16            `config:"port"`
+	TLS               *tlscommon.Config `config:"ssl"`
+	Timeouts          ServerTimeouts    `config:"timeouts"`
+	MaxHeaderByteSize int               `config:"max_header_byte_size"`
+	RateLimitBurst    int               `config:"rate_limit_burst"`
+	RateLimitInterval time.Duration     `config:"rate_limit_interval"`
+	MaxEnrollPending  int64             `config:"max_enroll_pending"`
+	Profile           ServerProfile     `config:"profile"`
 }
 
 // InitDefaults initializes the defaults for the configuration.

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -6,9 +6,10 @@ package config
 
 import (
 	"fmt"
-	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 	"strings"
 	"time"
+
+	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 )
 
 const kDefaultHost = "localhost"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds the ability to configure the TLS of the HTTP endpoint exposed by Fleet Server.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So Elastic Agent can configure and expose the Fleet Server over HTTPS.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #90 
