### PR TITLE
Cherry-pick #98 to 7.x: Add ssl configuration to fleet server http.

### DIFF
--- a/cmd/fleet/server_integration_test.go
+++ b/cmd/fleet/server_integration_test.go
@@ -47,7 +47,7 @@ func (s *tserver) baseUrl() string {
 	input := s.cfg.Inputs[0]
 	tls := input.Server.TLS
 	schema := "http"
-	if tls.Key != "" || tls.Cert != "" {
+	if tls != nil && tls.IsEnabled() {
 		schema = "https"
 	}
 	return fmt.Sprintf("%s://%s:%d", schema, input.Server.Host, input.Server.Port)

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 )
 
 const kDefaultHost = "localhost"
@@ -48,15 +50,15 @@ type ServerTLS struct {
 
 // Server is the configuration for the server
 type Server struct {
-	Host              string         `config:"host"`
-	Port              uint16         `config:"port"`
-	TLS               ServerTLS      `config:"tls"`
-	Timeouts          ServerTimeouts `config:"timeouts"`
-	MaxHeaderByteSize int            `config:"max_header_byte_size"`
-	RateLimitBurst    int            `config:"rate_limit_burst"`
-	RateLimitInterval time.Duration  `config:"rate_limit_interval"`
-	MaxEnrollPending  int64          `config:"max_enroll_pending"`
-	Profile           ServerProfile  `config:"profile"`
+	Host              string            `config:"host"`
+	Port              uint16            `config:"port"`
+	TLS               *tlscommon.Config `config:"ssl"`
+	Timeouts          ServerTimeouts    `config:"timeouts"`
+	MaxHeaderByteSize int               `config:"max_header_byte_size"`
+	RateLimitBurst    int               `config:"rate_limit_burst"`
+	RateLimitInterval time.Duration     `config:"rate_limit_interval"`
+	MaxEnrollPending  int64             `config:"max_enroll_pending"`
+	Profile           ServerProfile     `config:"profile"`
 }
 
 // InitDefaults initializes the defaults for the configuration.


### PR DESCRIPTION
Cherry-pick of PR #98 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds the ability to configure the TLS of the HTTP endpoint exposed by Fleet Server.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So Elastic Agent can configure and expose the Fleet Server over HTTPS.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #90 
