### PR TITLE
Enable trace level logging

### DIFF
--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -215,7 +215,7 @@ func TestConfig(t *testing.T) {
 			err: "only 1 fleet-server input can be defined",
 		},
 		"bad-logging": {
-			err: "invalid log level; must be one of: debug, info, warning, error",
+			err: "invalid log level; must be one of: trace, debug, info, warning, error",
 		},
 		"bad-output": {
 			err: "can only contain elasticsearch key",

--- a/internal/pkg/config/fleet.go
+++ b/internal/pkg/config/fleet.go
@@ -6,8 +6,9 @@ package config
 
 import (
 	"fmt"
-	"github.com/rs/zerolog"
 	"strings"
+
+	"github.com/rs/zerolog"
 )
 
 // AgentLogging is the log level set on the Agent.
@@ -58,6 +59,8 @@ func strToLevel(s string) (zerolog.Level, error) {
 
 	s = strings.ToLower(s)
 	switch strings.TrimSpace(s) {
+	case "trace":
+		l = zerolog.TraceLevel
 	case "debug":
 		l = zerolog.DebugLevel
 	case "info":
@@ -67,7 +70,7 @@ func strToLevel(s string) (zerolog.Level, error) {
 	case "error":
 		l = zerolog.ErrorLevel
 	default:
-		return l, fmt.Errorf("invalid log level; must be one of: debug, info, warning, error")
+		return l, fmt.Errorf("invalid log level; must be one of: trace, debug, info, warning, error")
 	}
 
 	return l, nil

--- a/internal/pkg/config/testdata/bad-logging.yml
+++ b/internal/pkg/config/testdata/bad-logging.yml
@@ -7,4 +7,4 @@ fleet:
   agent:
     id: 1e4954ce-af37-4731-9f4a-407b08e69e42
     logging:
-      level: trace
+      level: grace


### PR DESCRIPTION
## What does this PR do?
Enable trace level logging.

Fleet Server has some useful trace level logs that are too noisy to surface to debug level.
The Elastic Agent would not be able to set the config lower than debug level, but this is still useful for development&diags when running Fleet Server standalone.


