### PR TITLE
Cherry-pick #118 to 7.x: Set agent active to false on unenroll

### DIFF
--- a/cmd/fleet/handleAck.go
+++ b/cmd/fleet/handleAck.go
@@ -194,6 +194,7 @@ func _handleUnenroll(ctx context.Context, bulker bulk.Bulk, agent *model.Agent) 
 	updates := make([]bulk.BulkOp, 0, 1)
 	now := time.Now().UTC().Format(time.RFC3339)
 	fields := map[string]interface{}{
+		dl.FieldActive:       false,
 		dl.FieldUnenrolledAt: now,
 		dl.FieldUpdatedAt:    now,
 	}

--- a/internal/pkg/dl/constants.go
+++ b/internal/pkg/dl/constants.go
@@ -31,6 +31,7 @@ const (
 	FieldPolicyRevisionIdx    = "policy_revision_idx"
 	FieldPolicyCoordinatorIdx = "policy_coordinator_idx"
 
+	FieldActive       = "active"
 	FieldUpdatedAt    = "updated_at"
 	FieldUnenrolledAt = "unenrolled_at"
 )


### PR DESCRIPTION
Cherry-pick of PR #118 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes issue where `.fleet-agents` `active` field is not set to `false` on un-enrollment. Without setting that field to `false` Kibana will still show the agent after successful un-enrollment.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So unenroll action works correctly.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
