### PR TITLE
Cherry-pick #124 to 7.x: Add API key invalidation on unenroll ACK.

### DIFF
--- a/cmd/fleet/handleAck.go
+++ b/cmd/fleet/handleAck.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/cache"
 	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
@@ -191,6 +192,13 @@ func _handlePolicyChange(ctx context.Context, bulker bulk.Bulk, agent *model.Age
 }
 
 func _handleUnenroll(ctx context.Context, bulker bulk.Bulk, agent *model.Agent) error {
+	apiKeys := _getAPIKeyIDs(agent)
+	if len(apiKeys) > 0 {
+		if err := apikey.Invalidate(ctx, bulker.Client(), apiKeys...); err != nil {
+			return err
+		}
+	}
+
 	updates := make([]bulk.BulkOp, 0, 1)
 	now := time.Now().UTC().Format(time.RFC3339)
 	fields := map[string]interface{}{
@@ -213,4 +221,15 @@ func _handleUnenroll(ctx context.Context, bulker bulk.Bulk, agent *model.Agent) 
 	})
 
 	return bulker.MUpdate(ctx, updates, bulk.WithRefresh())
+}
+
+func _getAPIKeyIDs(agent *model.Agent) []string {
+	keys := make([]string, 0, 1)
+	if agent.AccessApiKeyId != "" {
+		keys = append(keys, agent.AccessApiKeyId)
+	}
+	if agent.DefaultApiKeyId != "" {
+		keys = append(keys, agent.DefaultApiKeyId)
+	}
+	return keys
 }

--- a/cmd/fleet/server_integration_test.go
+++ b/cmd/fleet/server_integration_test.go
@@ -181,7 +181,7 @@ func TestServerUnauthorized(t *testing.T) {
 
 	// Unauthorized, expecting error from /_security/_authenticate
 	t.Run("unauthorized", func(t *testing.T) {
-		const expectedErrResponsePrefix = `Fail Auth: [401 Unauthorized]`
+		const expectedErrResponsePrefix = `fail Auth: [401 Unauthorized]`
 		for _, u := range agenturls {
 			req, err := http.NewRequest("POST", u, bytes.NewBuffer([]byte("{}")))
 			require.NoError(t, err)

--- a/internal/pkg/apikey/auth.go
+++ b/internal/pkg/apikey/auth.go
@@ -48,7 +48,7 @@ func (k ApiKey) Authenticate(ctx context.Context, es *elasticsearch.Client) (*Se
 	}
 
 	if res.IsError() {
-		return nil, fmt.Errorf("Fail Auth: %s", res.String())
+		return nil, fmt.Errorf("fail Auth: %s", res.String())
 	}
 
 	var info SecurityInfo

--- a/internal/pkg/apikey/create.go
+++ b/internal/pkg/apikey/create.go
@@ -48,7 +48,7 @@ func Create(ctx context.Context, client *elasticsearch.Client, name, ttl string,
 	defer res.Body.Close()
 
 	if res.IsError() {
-		return nil, fmt.Errorf("Fail CreateAPIKey: %s", res.String())
+		return nil, fmt.Errorf("fail CreateAPIKey: %s", res.String())
 	}
 
 	type APIKeyResponse struct {

--- a/internal/pkg/apikey/invalidate.go
+++ b/internal/pkg/apikey/invalidate.go
@@ -1,0 +1,50 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package apikey
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/elastic/go-elasticsearch/v8/esapi"
+)
+
+// Invalidate invalidates the provides API keys by ID.
+func Invalidate(ctx context.Context, client *elasticsearch.Client, ids ...string) error {
+
+	payload := struct {
+		IDs []string `json:"ids,omitempty"`
+	}{
+		ids,
+	}
+
+	body, err := json.Marshal(&payload)
+	if err != nil {
+		return err
+	}
+
+	opts := []func(*esapi.SecurityInvalidateAPIKeyRequest){
+		client.Security.InvalidateAPIKey.WithContext(ctx),
+	}
+
+	res, err := client.Security.InvalidateAPIKey(
+		bytes.NewReader(body),
+		opts...,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	defer res.Body.Close()
+
+	if res.IsError() {
+		return fmt.Errorf("fail InvalidateAPIKey: %s", res.String())
+	}
+	return nil
+}


### PR DESCRIPTION
Cherry-pick of PR #124 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Invalidates both API keys used by the Agent after un-enrollment.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So those API keys cannot be used any more.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #123
