### PR TITLE
Update Event payload type.

### DIFF
--- a/cmd/fleet/schema.go
+++ b/cmd/fleet/schema.go
@@ -132,7 +132,7 @@ type Event struct {
 	StreamId    string          `json:"stream_id"`
 	Timestamp   string          `json:"timestamp"`
 	Message     string          `json:"message"`
-	Payload     string          `json:"payload,omitempty"`
+	Payload     json.RawMessage `json:"payload,omitempty"`
 	StartedAt   string          `json:"started_at"`
 	CompletedAt string          `json:"completed_at"`
 	ActionData  json.RawMessage `json:"action_data,omitempty"`


### PR DESCRIPTION
## What does this PR do?

Fixed the type incompatibility if the agent sends the event payload. Event payload is expected to be a json fragment.
For Osquerybeat this payload would need to be searchable, since it will contain the version of osqueryd binary for example.

