### PR TITLE
Handle artifact request from endpoint  

### DIFF
--- a/cmd/fleet/auth.go
+++ b/cmd/fleet/auth.go
@@ -23,6 +23,7 @@ const (
 )
 
 var ErrApiKeyNotEnabled = errors.New("APIKey not enabled")
+var ErrAgentCorrupted = errors.New("agent record corrupted")
 
 func authApiKey(r *http.Request, client *elasticsearch.Client, c cache.Cache) (*apikey.ApiKey, error) {
 
@@ -79,11 +80,11 @@ func authAgent(r *http.Request, id string, bulker bulk.Bulk, c cache.Cache) (*mo
 
 	// validate key alignment
 	if agent.AccessApiKeyId != key.Id {
-		log.Debug().
+		log.Info().
 			Err(ErrAgentCorrupted).
 			Interface("agent", &agent).
 			Str("key.Id", key.Id).
-			Msg("agent id mismatch")
+			Msg("agent API key id mismatch agent record")
 		return nil, ErrAgentCorrupted
 	}
 

--- a/cmd/fleet/auth.go
+++ b/cmd/fleet/auth.go
@@ -25,6 +25,9 @@ const (
 var ErrApiKeyNotEnabled = errors.New("APIKey not enabled")
 var ErrAgentCorrupted = errors.New("agent record corrupted")
 
+// This authenticates that the provided API key exists and is enabled.
+// WARNING: This does not validate that the api key is valid for the Fleet Domain.
+// An additional check must be executed to validate it is not a random api key.
 func authApiKey(r *http.Request, client *elasticsearch.Client, c cache.Cache) (*apikey.ApiKey, error) {
 
 	key, err := apikey.ExtractAPIKey(r)
@@ -41,16 +44,17 @@ func authApiKey(r *http.Request, client *elasticsearch.Client, c cache.Cache) (*
 	info, err := key.Authenticate(r.Context(), client)
 
 	if err != nil {
-		log.Error().
+		log.Info().
 			Err(err).
-			Dur("tdiff", time.Since(start)).
+			Str("id", key.Id).
+			Dur("rtt", time.Since(start)).
 			Msg("ApiKey fail authentication")
 		return nil, err
 	}
 
 	log.Trace().
 		Str("id", key.Id).
-		Dur("tdiff", time.Since(start)).
+		Dur("rtt", time.Since(start)).
 		Str("UserName", info.UserName).
 		Strs("Roles", info.Roles).
 		Bool("enabled", info.Enabled).
@@ -61,6 +65,11 @@ func authApiKey(r *http.Request, client *elasticsearch.Client, c cache.Cache) (*
 		c.SetApiKey(*key, kAPIKeyTTL)
 	} else {
 		err = ErrApiKeyNotEnabled
+		log.Info().
+			Err(err).
+			Str("id", key.Id).
+			Dur("rtt", time.Since(start)).
+			Msg("ApiKey not enabled")
 	}
 
 	return key, err

--- a/cmd/fleet/handleArtifacts.go
+++ b/cmd/fleet/handleArtifacts.go
@@ -5,11 +5,14 @@
 package fleet
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"time"
 
@@ -20,98 +23,151 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/throttle"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
 const (
-	defaultCacheTTL    = time.Hour * 24 // TODO: configurable
 	defaultMaxParallel = 8              // TODO: configurable
+	defaultCacheTTL    = time.Hour * 24 // TODO: configurable
 	defaultThrottleTTL = time.Minute    // TODO: configurable
 )
 
 var (
-	artThrottle     = throttle.NewThrottle(defaultMaxParallel)
-	ErrorThrottle   = errors.New("Cannot acquire throttle token")
-	ErrorIdentifier = errors.New("Identifier mismatch")
-	ErrorBadSha2    = errors.New("Malformed sha256")
+	artThrottle       = throttle.NewThrottle(defaultMaxParallel)
+	ErrorThrottle     = errors.New("cannot acquire throttle token")
+	ErrorBadSha2      = errors.New("malformed sha256")
+	ErrorRecord       = errors.New("artifact record mismatch")
+	ErrorMismatchSha2 = errors.New("mismatched sha256")
 )
 
 func (rt Router) handleArtifacts(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	start := time.Now()
+
 	var (
-		id   = ps.ByName("id")
-		sha2 = ps.ByName("sha2")
+		id   = ps.ByName("id")   // Identifier in the artifact record
+		sha2 = ps.ByName("sha2") // DecodedSha256 in the artifact record
 	)
 
-	err := _handleArtifacts(w, r, id, sha2, rt.ct.bulker, rt.ct.cache)
+	zlog := log.With().
+		Str("id", id).
+		Str("sha2", sha2).
+		Str("remoteAddr", r.RemoteAddr).
+		Logger()
+
+	// Authenticate the APIKey; retrieve agent record.
+	// Note: This is going to be a bit slow even if we hit the cache on the api key.
+	// In order to validate that the agent still has that api key, we fetch the agent record from elastic.
+	agent, err := authAgent(r, "", rt.ct.bulker, rt.ct.cache)
+	if err != nil {
+		code := http.StatusUnauthorized
+		zlog.Info().
+			Err(err).
+			Int("code", code).
+			Msg("Fail auth")
+
+		http.Error(w, "", code)
+		return
+	}
+
+	zlog = zlog.With().
+		Str("APIKeyId", agent.AccessApiKeyId).
+		Str("agentId", agent.Id).
+		Logger()
+
+	ah := artHandler{
+		zlog:   zlog,
+		bulker: rt.ct.bulker,
+		c:      rt.ct.cache,
+	}
+
+	rdr, err := ah.handle(r.Context(), agent, id, sha2)
+
+	var nWritten int64
+	if err == nil {
+		nWritten, err = io.Copy(w, rdr)
+		zlog.Trace().
+			Err(err).
+			Int64("nWritten", nWritten).
+			Dur("rtt", time.Since(start)).
+			Msg("Response sent")
+	}
 
 	if err != nil {
+		code, lvl := assessError(err)
 
-		var code int
-		switch err {
-		case dl.ErrNotFound:
-			code = http.StatusNotFound
-		case ErrorThrottle:
-			code = http.StatusTooManyRequests
-		case context.Canceled:
-			code = http.StatusServiceUnavailable
-		default:
-			code = http.StatusBadRequest
-		}
-
-		// TODO: return a 503 on elastic timeout, connection drop
-
-		log.Debug().
+		zlog.WithLevel(lvl).
 			Err(err).
-			Str("sha2", sha2).
-			Str("id", id).
 			Int("code", code).
-			Msg("Fail artifact")
+			Int64("nWritten", nWritten).
+			Dur("rtt", time.Since(start)).
+			Msg("Fail handle artifact")
 
 		http.Error(w, "", code)
 	}
 }
 
-func _handleArtifacts(w http.ResponseWriter, r *http.Request, id, sha2 string, bulker bulk.Bulk, c cache.Cache) error {
+func assessError(err error) (int, zerolog.Level) {
+	lvl := zerolog.DebugLevel
 
-	// Authenticate the APIKey; retrieve agent record.
-	// NOTE: We are currently not using the agent record aside from logging.
-	// Eventually we will use the policy id in the record to authorize access to the artifact.
-	agent, err := authAgent(r, "", bulker, c)
-	if err != nil {
-		return err
+	// TODO: return a 503 on elastic timeout, connection drop
+
+	var code int
+	switch err {
+	case dl.ErrNotFound:
+		// Artifact not found indicates a race condition upstream
+		// or an attack on the fleet server.  Either way it should
+		// show up in the logs at a higher level than debug
+		lvl = zerolog.WarnLevel
+		code = http.StatusNotFound
+	case ErrorThrottle:
+		code = http.StatusTooManyRequests
+	case context.Canceled:
+		code = http.StatusServiceUnavailable
+	default:
+		code = http.StatusBadRequest
 	}
 
-	zlog := log.With().
-		Str("id", id).
-		Str("sha2", sha2).
-		Str("agent", agent.Id).
-		Logger()
+	return code, lvl
+}
+
+type artHandler struct {
+	zlog   zerolog.Logger
+	bulker bulk.Bulk
+	c      cache.Cache
+}
+
+func (ah artHandler) handle(ctx context.Context, agent *model.Agent, id, sha2 string) (io.Reader, error) {
 
 	// Input validation
-	if err := validateSha2(sha2); err != nil {
-		return err
+	if err := validateSha2String(sha2); err != nil {
+		return nil, err
+	}
+
+	// Determine whether the agent should have access to this artifact
+	if err := ah.authorizeArtifact(ctx, agent, id, sha2); err != nil {
+		ah.zlog.Warn().Err(err).Msg("Unauthorized GET on artifact")
+		return nil, err
 	}
 
 	// Grab artifact, whether from cache or elastic.
-	artifact, err := getArtifact(r.Context(), bulker, c, sha2)
+	artifact, err := ah.getArtifact(ctx, id, sha2)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// TODO: Add per policy authorization on artifacts;
-	// ie. limit the set of allowed artifacts by policy
-
-	// Validate idenitifer in artifact record is same as url
-	if artifact.Identifier != id {
-		err = ErrorIdentifier
-		zlog.Info().
+	// Sanity check; just in case something underneath is misbehaving
+	if artifact.Identifier != id || artifact.DecodedSha256 != sha2 {
+		err = ErrorRecord
+		ah.zlog.Info().
 			Err(err).
 			Str("artifact_id", artifact.Identifier).
+			Str("artifact_sha2", artifact.DecodedSha256).
 			Msg("Identifier mismatch on url")
-		return err
+		return nil, err
 	}
 
-	zlog.Debug().
+	ah.zlog.Debug().
 		Int("sz", len(artifact.Body)).
 		Int64("decodedSz", artifact.DecodedSize).
 		Str("compression", artifact.CompressionAlgorithm).
@@ -120,61 +176,76 @@ func _handleArtifacts(w http.ResponseWriter, r *http.Request, id, sha2 string, b
 		Msg("Artifact GET")
 
 	// Write the payload
-	if _, err = w.Write(artifact.Body); err != nil {
-		zlog.Debug().Err(err).Msg("Fail HTTP write")
-		return err
-	}
-
-	return nil
+	rdr := bytes.NewReader(artifact.Body)
+	return rdr, nil
 }
 
-// Return artifact from cache by sha2 or fetch directly from Elastic, updating cache.
-func getArtifact(ctx context.Context, bulker bulk.Bulk, c cache.Cache, sha2 string) (*model.Artifact, error) {
+// TODO: Pull the policy record for this agent and validate that the
+// requested artifact is assigned to this policy.  This will prevent
+// agents from retrieving artifacts that they do not have access to.
+// Note that this is racy, the policy could have changed to allow an
+// artifact before this instantiation of FleetServer has its local
+// copy updated.  Take the race conditions into consideration.
+//
+// Initial implementation is dependent on security by obscurity; ie.
+// it should be difficult for an attacker to guess a guid.
+func (ah artHandler) authorizeArtifact(ctx context.Context, agent *model.Agent, ident, sha2 string) error {
+	return nil // TODO
+}
+
+// Return artifact from cache by sha2 or fetch directly from Elastic.
+// Update cache on successful retrieval from Elastic.
+func (ah artHandler) getArtifact(ctx context.Context, ident, sha2 string) (*model.Artifact, error) {
 
 	// Check the cache; return immediately if found.
-	if artifact, ok := c.GetArtifact(sha2); ok {
+	if artifact, ok := ah.c.GetArtifact(ident, sha2); ok {
 		return &artifact, nil
 	}
 
-	zlog := log.With().Str("sha2", sha2).Logger()
-
 	// Fetch the artifact from elastic
-	art, err := fetchArtifact(ctx, bulker, sha2)
+	art, err := ah.fetchArtifact(ctx, ident, sha2)
 
 	if err != nil {
-		zlog.Info().Err(err).Msg("Fail retrieve artifact")
+		ah.zlog.Info().Err(err).Msg("Fail retrieve artifact")
 		return nil, err
 	}
 
 	// The 'Body' field type is Raw; extract to string.
 	var srcPayload string
 	if err = json.Unmarshal(art.Body, &srcPayload); err != nil {
-		zlog.Error().Err(err).Msg("Cannot unmarshal artifact payload")
+		ah.zlog.Error().Err(err).Msg("Cannot unmarshal artifact payload")
 		return nil, err
 	}
 
 	// Artifact is stored base64 encoded in ElasticSearch.
-	// Base64 decode the payload before putting in cache to avoid having to decode on each cache hit.
+	// Base64 decode the payload before putting in cache
+	// to avoid having to decode on each cache hit.
 	dstPayload, err := base64.StdEncoding.DecodeString(srcPayload)
 	if err != nil {
-		zlog.Error().Err(err).Msg("Fail base64 decode artifact")
+		ah.zlog.Error().Err(err).Msg("Fail base64 decode artifact")
 		return nil, err
 	}
 
-	// Reassign decoded payload before adding to cache
+	// Validate the sha256 hash; this is just good hygiene.
+	if err = validateSha2Data(dstPayload, art.EncodedSha256); err != nil {
+		ah.zlog.Error().Err(err).Msg("Fail sha2 hash validation")
+		return nil, err
+	}
+
+	// Reassign decoded payload before adding to cache, avoid base64 decode on cache hit.
 	art.Body = dstPayload
 
-	// And cache it
-	c.SetArtifact(sha2, *art, defaultCacheTTL)
+	// Update the cache.
+	ah.c.SetArtifact(*art, defaultCacheTTL)
 
 	return art, nil
 }
 
-// Attempt to fetch the artifact down from elastic
+// Attempt to fetch the artifact from Elastic
 // TODO: Design a mechanism to mitigate a DDOS attack on bogus hashes.
 // Perhaps have a cache of the most recently used hashes available, and items that aren't
 // in the cache can do a lookup but throttle as below.  We could update the cache every 10m or so.
-func fetchArtifact(ctx context.Context, bulker bulk.Bulk, sha2 string) (*model.Artifact, error) {
+func (ah artHandler) fetchArtifact(ctx context.Context, ident, sha2 string) (*model.Artifact, error) {
 	// Throttle prevents more than N outstanding requests to elastic globally and per sha2.
 	if token := artThrottle.Acquire(sha2, defaultThrottleTTL); token == nil {
 		return nil, ErrorThrottle
@@ -183,27 +254,38 @@ func fetchArtifact(ctx context.Context, bulker bulk.Bulk, sha2 string) (*model.A
 	}
 
 	start := time.Now()
-	artifact, err := dl.FindArtifactBySha256(ctx, bulker, sha2)
+	artifact, err := dl.FindArtifact(ctx, ah.bulker, ident, sha2)
 
-	log.Debug().
+	ah.zlog.Info().
 		Err(err).
-		Str("sha2", sha2).
 		Dur("rtt", time.Since(start)).
 		Msg("fetch artifact")
 
 	return artifact, err
 }
 
-func validateSha2(sha2 string) error {
+func validateSha2String(sha2 string) error {
 
 	if len(sha2) != 64 {
-		log.Info().Str("sha2", sha2).Msg("sha2 bad length")
 		return ErrorBadSha2
 	}
 
 	if _, err := hex.DecodeString(sha2); err != nil {
-		log.Info().Err(err).Str("sha2", sha2).Msg("sha2 is not hex")
 		return ErrorBadSha2
+	}
+
+	return nil
+}
+
+func validateSha2Data(data []byte, sha2 string) error {
+	src, err := hex.DecodeString(sha2)
+	if err != nil {
+		return err
+	}
+
+	sum := sha256.Sum256(data)
+	if !bytes.Equal(sum[:], src) {
+		return ErrorMismatchSha2
 	}
 
 	return nil

--- a/cmd/fleet/handleArtifacts.go
+++ b/cmd/fleet/handleArtifacts.go
@@ -1,0 +1,210 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package fleet
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
+	"github.com/elastic/fleet-server/v7/internal/pkg/cache"
+	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
+	"github.com/elastic/fleet-server/v7/internal/pkg/model"
+	"github.com/elastic/fleet-server/v7/internal/pkg/throttle"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	defaultCacheTTL    = time.Hour * 24 // TODO: configurable
+	defaultMaxParallel = 8              // TODO: configurable
+	defaultThrottleTTL = time.Minute    // TODO: configurable
+)
+
+var (
+	artThrottle     = throttle.NewThrottle(defaultMaxParallel)
+	ErrorThrottle   = errors.New("Cannot acquire throttle token")
+	ErrorIdentifier = errors.New("Identifier mismatch")
+	ErrorBadSha2    = errors.New("Malformed sha256")
+)
+
+func (rt Router) handleArtifacts(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	var (
+		id   = ps.ByName("id")
+		sha2 = ps.ByName("sha2")
+	)
+
+	err := _handleArtifacts(w, r, id, sha2, rt.ct.bulker, rt.ct.cache)
+
+	if err != nil {
+
+		var code int
+		switch err {
+		case dl.ErrNotFound:
+			code = http.StatusNotFound
+		case ErrorThrottle:
+			code = http.StatusTooManyRequests
+		case context.Canceled:
+			code = http.StatusServiceUnavailable
+		default:
+			code = http.StatusBadRequest
+		}
+
+		// TODO: return a 503 on elastic timeout, connection drop
+
+		log.Debug().
+			Err(err).
+			Str("sha2", sha2).
+			Str("id", id).
+			Int("code", code).
+			Msg("Fail artifact")
+
+		http.Error(w, "", code)
+	}
+}
+
+func _handleArtifacts(w http.ResponseWriter, r *http.Request, id, sha2 string, bulker bulk.Bulk, c cache.Cache) error {
+
+	// Authenticate the APIKey; retrieve agent record.
+	// NOTE: We are currently not using the agent record aside from logging.
+	// Eventually we will use the policy id in the record to authorize access to the artifact.
+	agent, err := authAgent(r, "", bulker, c)
+	if err != nil {
+		return err
+	}
+
+	zlog := log.With().
+		Str("id", id).
+		Str("sha2", sha2).
+		Str("agent", agent.Id).
+		Logger()
+
+	// Input validation
+	if err := validateSha2(sha2); err != nil {
+		return err
+	}
+
+	// Grab artifact, whether from cache or elastic.
+	artifact, err := getArtifact(r.Context(), bulker, c, sha2)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Add per policy authorization on artifacts;
+	// ie. limit the set of allowed artifacts by policy
+
+	// Validate idenitifer in artifact record is same as url
+	if artifact.Identifier != id {
+		err = ErrorIdentifier
+		zlog.Info().
+			Err(err).
+			Str("artifact_id", artifact.Identifier).
+			Msg("Identifier mismatch on url")
+		return err
+	}
+
+	zlog.Debug().
+		Int("sz", len(artifact.Body)).
+		Int64("decodedSz", artifact.DecodedSize).
+		Str("compression", artifact.CompressionAlgorithm).
+		Str("encryption", artifact.EncryptionAlgorithm).
+		Str("created", artifact.Created).
+		Msg("Artifact GET")
+
+	// Write the payload
+	if _, err = w.Write(artifact.Body); err != nil {
+		zlog.Debug().Err(err).Msg("Fail HTTP write")
+		return err
+	}
+
+	return nil
+}
+
+// Return artifact from cache by sha2 or fetch directly from Elastic, updating cache.
+func getArtifact(ctx context.Context, bulker bulk.Bulk, c cache.Cache, sha2 string) (*model.Artifact, error) {
+
+	// Check the cache; return immediately if found.
+	if artifact, ok := c.GetArtifact(sha2); ok {
+		return &artifact, nil
+	}
+
+	zlog := log.With().Str("sha2", sha2).Logger()
+
+	// Fetch the artifact from elastic
+	art, err := fetchArtifact(ctx, bulker, sha2)
+
+	if err != nil {
+		zlog.Info().Err(err).Msg("Fail retrieve artifact")
+		return nil, err
+	}
+
+	// The 'Body' field type is Raw; extract to string.
+	var srcPayload string
+	if err = json.Unmarshal(art.Body, &srcPayload); err != nil {
+		zlog.Error().Err(err).Msg("Cannot unmarshal artifact payload")
+		return nil, err
+	}
+
+	// Artifact is stored base64 encoded in ElasticSearch.
+	// Base64 decode the payload before putting in cache to avoid having to decode on each cache hit.
+	dstPayload, err := base64.StdEncoding.DecodeString(srcPayload)
+	if err != nil {
+		zlog.Error().Err(err).Msg("Fail base64 decode artifact")
+		return nil, err
+	}
+
+	// Reassign decoded payload before adding to cache
+	art.Body = dstPayload
+
+	// And cache it
+	c.SetArtifact(sha2, *art, defaultCacheTTL)
+
+	return art, nil
+}
+
+// Attempt to fetch the artifact down from elastic
+// TODO: Design a mechanism to mitigate a DDOS attack on bogus hashes.
+// Perhaps have a cache of the most recently used hashes available, and items that aren't
+// in the cache can do a lookup but throttle as below.  We could update the cache every 10m or so.
+func fetchArtifact(ctx context.Context, bulker bulk.Bulk, sha2 string) (*model.Artifact, error) {
+	// Throttle prevents more than N outstanding requests to elastic globally and per sha2.
+	if token := artThrottle.Acquire(sha2, defaultThrottleTTL); token == nil {
+		return nil, ErrorThrottle
+	} else {
+		defer token.Release()
+	}
+
+	start := time.Now()
+	artifact, err := dl.FindArtifactBySha256(ctx, bulker, sha2)
+
+	log.Debug().
+		Err(err).
+		Str("sha2", sha2).
+		Dur("rtt", time.Since(start)).
+		Msg("fetch artifact")
+
+	return artifact, err
+}
+
+func validateSha2(sha2 string) error {
+
+	if len(sha2) != 64 {
+		log.Info().Str("sha2", sha2).Msg("sha2 bad length")
+		return ErrorBadSha2
+	}
+
+	if _, err := hex.DecodeString(sha2); err != nil {
+		log.Info().Err(err).Str("sha2", sha2).Msg("sha2 is not hex")
+		return ErrorBadSha2
+	}
+
+	return nil
+}

--- a/cmd/fleet/handleCheckin.go
+++ b/cmd/fleet/handleCheckin.go
@@ -27,8 +27,7 @@ import (
 )
 
 var (
-	ErrAgentNotFound  = errors.New("agent not found")
-	ErrAgentCorrupted = errors.New("agent record corrupted")
+	ErrAgentNotFound = errors.New("agent not found")
 
 	kCheckinTimeout  = 30 * time.Second
 	kLongPollTimeout = 300 * time.Second // 5m

--- a/cmd/fleet/handleEnroll.go
+++ b/cmd/fleet/handleEnroll.go
@@ -133,6 +133,7 @@ func (et *EnrollerT) handleEnroll(r *http.Request) ([]byte, error) {
 		return nil, err
 	}
 
+	// Validate that an enrollment record exists for a key with this id.
 	erec, err := et.fetchEnrollmentKeyRecord(r.Context(), key.Id)
 	if err != nil {
 		return nil, err

--- a/cmd/fleet/router.go
+++ b/cmd/fleet/router.go
@@ -16,6 +16,9 @@ const (
 	ROUTE_CHECKIN   = "/api/fleet/agents/:id/checkin"
 	ROUTE_ACKS      = "/api/fleet/agents/:id/acks"
 	ROUTE_ARTIFACTS = "/api/fleet/artifacts/:id/:sha2"
+
+	// Support previous relative path exposed in Kibana until all feature flags are flipped
+	ROUTE_ARTIFACTS_DEPRECATED = "/api/endpoint/artifacts/download/:id/:sha2"
 )
 
 type Router struct {
@@ -41,5 +44,9 @@ func NewRouter(bulker bulk.Bulk, ct *CheckinT, et *EnrollerT, sm policy.SelfMoni
 	router.POST(ROUTE_CHECKIN, r.handleCheckin)
 	router.POST(ROUTE_ACKS, r.handleAcks)
 	router.GET(ROUTE_ARTIFACTS, r.handleArtifacts)
+
+	// deprecated: TODO: remove
+	router.GET(ROUTE_ARTIFACTS_DEPRECATED, r.handleArtifacts)
+
 	return router
 }

--- a/cmd/fleet/router.go
+++ b/cmd/fleet/router.go
@@ -11,10 +11,11 @@ import (
 )
 
 const (
-	ROUTE_STATUS  = "/api/status"
-	ROUTE_ENROLL  = "/api/fleet/agents/:id"
-	ROUTE_CHECKIN = "/api/fleet/agents/:id/checkin"
-	ROUTE_ACKS    = "/api/fleet/agents/:id/acks"
+	ROUTE_STATUS    = "/api/status"
+	ROUTE_ENROLL    = "/api/fleet/agents/:id"
+	ROUTE_CHECKIN   = "/api/fleet/agents/:id/checkin"
+	ROUTE_ACKS      = "/api/fleet/agents/:id/acks"
+	ROUTE_ARTIFACTS = "/api/fleet/artifacts/:id/:sha2"
 )
 
 type Router struct {
@@ -39,5 +40,6 @@ func NewRouter(bulker bulk.Bulk, ct *CheckinT, et *EnrollerT, sm policy.SelfMoni
 	router.POST(ROUTE_ENROLL, r.handleEnroll)
 	router.POST(ROUTE_CHECKIN, r.handleCheckin)
 	router.POST(ROUTE_ACKS, r.handleAcks)
+	router.GET(ROUTE_ARTIFACTS, r.handleArtifacts)
 	return router
 }

--- a/internal/pkg/dl/artifact.go
+++ b/internal/pkg/dl/artifact.go
@@ -1,0 +1,65 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package dl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
+	"github.com/elastic/fleet-server/v7/internal/pkg/dsl"
+	"github.com/elastic/fleet-server/v7/internal/pkg/model"
+)
+
+const (
+	artifactsIndexName = ".fleet-artifacts"
+)
+
+var (
+	QueryArtifactBySha2 = prepareQueryArtifactBySha2()
+	ErrConflict         = errors.New("Fail multiple artifacts for the same sha256")
+)
+
+func prepareQueryArtifactBySha2() *dsl.Tmpl {
+	root := dsl.NewRoot()
+	tmpl := dsl.NewTmpl()
+
+	root.Query().Bool().Filter().Term(FieldEncodedSha256, tmpl.Bind(FieldEncodedSha256), nil)
+	tmpl.MustResolve(root)
+	return tmpl
+}
+
+func FindArtifactBySha256(ctx context.Context, bulker bulk.Bulk, sha2 string) (*model.Artifact, error) {
+
+	res, err := SearchWithOneParam(
+		ctx,
+		bulker,
+		QueryArtifactBySha2,
+		artifactsIndexName,
+		FieldEncodedSha256,
+		sha2,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(res.Hits) == 0 {
+		return nil, ErrNotFound
+	}
+
+	if len(res.Hits) > 1 {
+		return nil, ErrConflict
+	}
+
+	// deserialize
+	var artifact model.Artifact
+	if err = json.Unmarshal(res.Hits[0].Source, &artifact); err != nil {
+		return nil, err
+	}
+
+	return &artifact, nil
+}

--- a/internal/pkg/dl/constants.go
+++ b/internal/pkg/dl/constants.go
@@ -34,6 +34,8 @@ const (
 	FieldActive       = "active"
 	FieldUpdatedAt    = "updated_at"
 	FieldUnenrolledAt = "unenrolled_at"
+
+	FieldEncodedSha256 = "encodedSha256"
 )
 
 // Public constants

--- a/internal/pkg/dl/constants.go
+++ b/internal/pkg/dl/constants.go
@@ -9,6 +9,7 @@ const (
 	FleetActions           = ".fleet-actions"
 	FleetActionsResults    = ".fleet-actions-results"
 	FleetAgents            = ".fleet-agents"
+	FleetArtifacts         = ".fleet-artifacts"
 	FleetEnrollmentAPIKeys = ".fleet-enrollment-api-keys"
 	FleetPolicies          = ".fleet-policies"
 	FleetPoliciesLeader    = ".fleet-policies-leader"
@@ -35,7 +36,8 @@ const (
 	FieldUpdatedAt    = "updated_at"
 	FieldUnenrolledAt = "unenrolled_at"
 
-	FieldEncodedSha256 = "encodedSha256"
+	FieldDecodedSha256 = "decodedSha256"
+	FieldIdentifier    = "identifier"
 )
 
 // Public constants

--- a/internal/pkg/es/mapping.go
+++ b/internal/pkg/es/mapping.go
@@ -171,6 +171,47 @@ const (
 	}
 }`
 
+	// Artifact An artifact served by Fleet
+	MappingArtifact = `{
+	"properties": {
+		"body": {
+			"enabled" : false,
+			"type": "object"
+		},
+		"compressionAlgorithm": {
+			"type": "keyword"
+		},
+		"created": {
+			"type": "date"
+		},
+		"decodedSha256": {
+			"type": "keyword"
+		},
+		"decodedSize": {
+			"type": "integer"
+		},
+		"encodedSha256": {
+			"type": "keyword"
+		},
+		"encodedSize": {
+			"type": "integer"
+		},
+		"encryptionAlgorithm": {
+			"type": "keyword"
+		},
+		"identifier": {
+			"type": "keyword"
+		}		
+	}
+}`
+
+	// Body Encoded artifact data
+	MappingBody = `{
+	"properties": {
+		
+	}
+}`
+
 	// Data The opaque payload.
 	MappingData = `{
 	"properties": {

--- a/internal/pkg/model/schema.go
+++ b/internal/pkg/model/schema.go
@@ -170,6 +170,42 @@ type AgentMetadata struct {
 	Version string `json:"version"`
 }
 
+// Artifact An artifact served by Fleet
+type Artifact struct {
+	ESDocument
+
+	// Encoded artifact data
+	Body json.RawMessage `json:"body"`
+
+	// Name of compression algorithm applied to artifact
+	CompressionAlgorithm string `json:"compressionAlgorithm"`
+
+	// Timestamp artifact was created
+	Created string `json:"created"`
+
+	// SHA256 of artifact before encoding has been applied
+	DecodedSha256 string `json:"decodedSha256"`
+
+	// Size of artifact before encoding has been applied
+	DecodedSize int64 `json:"decodedSize"`
+
+	// SHA256 of artifact after encoding has been applied
+	EncodedSha256 string `json:"encodedSha256"`
+
+	// Size of artifact after encoding has been applied
+	EncodedSize int64 `json:"encodedSize"`
+
+	// Name of encryption algorithm applied to artifact
+	EncryptionAlgorithm string `json:"encryptionAlgorithm,omitempty"`
+
+	// Human readable artifact identifier
+	Identifier string `json:"identifier"`
+}
+
+// Body Encoded artifact data
+type Body struct {
+}
+
 // Data The opaque payload.
 type Data struct {
 }

--- a/internal/pkg/throttle/throttle.go
+++ b/internal/pkg/throttle/throttle.go
@@ -1,0 +1,154 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package throttle
+
+import (
+	"github.com/rs/zerolog/log"
+	"sync"
+	"time"
+)
+
+type Token struct {
+	id       uint64
+	key      string
+	throttle *Throttle
+}
+
+type tstate struct {
+	id     uint64
+	expire time.Time
+}
+
+type Throttle struct {
+	mut         sync.Mutex
+	maxParallel int
+	tokenCnt    uint64
+	tokenMap    map[string]tstate
+}
+
+// Throttle provides two controls:
+// 1) Only one Token per key at a time can be acquired.  Token expires if not released by ttl.
+// 2) Only max unexpired tokens acquired at any one time.
+
+func NewThrottle(max int) *Throttle {
+	return &Throttle{
+		maxParallel: max,
+		tokenMap:    make(map[string]tstate),
+	}
+}
+
+func (tt *Throttle) Acquire(key string, ttl time.Duration) *Token {
+	var token *Token
+
+	tt.mut.Lock()
+	defer tt.mut.Unlock()
+
+	if tt.checkAtMaxPending(key) {
+		log.Trace().
+			Str("key", key).
+			Int("max", tt.maxParallel).
+			Int("szMap", len(tt.tokenMap)).
+			Msg("Throttle fail acquire on max pending")
+		return nil
+	}
+
+	// Is there already a pending request on this key?
+	state, ok := tt.tokenMap[key]
+
+	// If there's nohting pending on 'key' or previous timed out create token
+
+	now := time.Now()
+	if !ok || state.expire.Before(now) {
+		tt.tokenCnt += 1
+
+		token = &Token{
+			id:       tt.tokenCnt,
+			key:      key,
+			throttle: tt,
+		}
+
+		state := tstate{
+			id:     token.id,
+			expire: now.Add(ttl),
+		}
+
+		tt.tokenMap[key] = state
+
+		log.Trace().
+			Str("key", key).
+			Uint64("token", token.id).
+			Time("expire", state.expire).
+			Msg("Throttle acquired")
+
+		return token
+	}
+
+	log.Trace().
+		Str("key", key).
+		Msg("Throttle fail acquire on existing token")
+
+	return token
+}
+
+// WARNING:  Assumes mutex already held
+func (tt *Throttle) checkAtMaxPending(key string) bool {
+
+	// Are we already at max parallel?
+	if tt.maxParallel == 0 || len(tt.tokenMap) < tt.maxParallel {
+		return false
+	}
+
+	now := time.Now()
+
+	// Try to eject the target key first
+	if state, ok := tt.tokenMap[key]; ok && state.expire.Before(now) {
+		delete(tt.tokenMap, key)
+		log.Trace().
+			Str("key", key).
+			Msg("Ejected target token on expiration")
+
+		return false
+	}
+
+	// Scan through map looking for something to expire.
+	// Not very efficient, O(N), but perhaps not worth optimizing
+	var found bool
+	for skey, state := range tt.tokenMap {
+		if state.expire.Before(now) {
+			found = true
+			delete(tt.tokenMap, skey)
+			log.Trace().
+				Str("key", key).
+				Msg("Ejected token on expiration")
+			break
+		}
+	}
+
+	return !found
+}
+
+func (tt *Throttle) release(id uint64, key string) bool {
+
+	tt.mut.Lock()
+	defer tt.mut.Unlock()
+
+	state, ok := tt.tokenMap[key]
+	if !ok {
+		log.Trace().Uint64("id", id).Str("key", key).Msg("Token not found to release")
+		return false
+	}
+
+	if state.id == id {
+		log.Trace().Uint64("id", id).Str("key", key).Msg("Token released")
+		delete(tt.tokenMap, key)
+		return true
+	}
+
+	return false
+}
+
+func (t Token) Release() bool {
+	return t.throttle.release(t.id, t.key)
+}

--- a/internal/pkg/throttle/throttle_test.go
+++ b/internal/pkg/throttle/throttle_test.go
@@ -1,0 +1,216 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package throttle
+
+import (
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestThrottleZero(t *testing.T) {
+
+	// Zero max parallel means we can acquire as many as we want,
+	// but still cannot acquire existing that has not timed out
+	throttle := NewThrottle(0)
+
+	N := rand.Intn(2048) + 10
+
+	var tokens []*Token
+	for i := 0; i < N; i++ {
+
+		key := strconv.Itoa(i)
+
+		// Acquire token for key with long timeout so doesn't trip unit test
+		token1 := throttle.Acquire(key, time.Hour)
+		if token1 == nil {
+			t.Fatal("Acquire failed")
+		}
+		tokens = append(tokens, token1)
+
+		// Second acquire should fail because we have not released the orginal token,
+		// or possibly if i == N-1 we could max parallel
+		token2 := throttle.Acquire(key, time.Hour)
+		if token2 != nil {
+			t.Error("Expected second acquire to fail on conflict")
+		}
+	}
+
+	// Validate again that all tokens are blocked after allocating N
+	for i := 0; i < N; i++ {
+
+		key := strconv.Itoa(i)
+
+		// Acquire should fail because we have not released the orginal token,
+		token := throttle.Acquire(key, time.Hour)
+		if token != nil {
+			t.Error("Expected acquire to fail on conflict")
+		}
+	}
+
+	for i, token := range tokens {
+
+		found := token.Release()
+		if !found {
+			t.Error("Expect token to be found")
+		}
+
+		// Second release should return false
+		found = token.Release()
+		if found {
+			t.Error("Expect token to not found on second release")
+		}
+
+		// We should now be able to to acquire
+		key := strconv.Itoa(i)
+
+		token = throttle.Acquire(key, time.Hour)
+		if token == nil {
+			t.Fatal("Acquire failed")
+		}
+
+		found = token.Release()
+		if !found {
+			t.Error("Expect token to be found")
+		}
+	}
+}
+
+func TestThrottleN(t *testing.T) {
+
+	for N := 1; N < 11; N++ {
+
+		throttle := NewThrottle(N)
+
+		var tokens []*Token
+		for i := 0; i < N; i++ {
+
+			key := strconv.Itoa(i)
+
+			// Acquire token for key with long timeout so doesn't trip unit test
+			token1 := throttle.Acquire(key, time.Hour)
+			if token1 == nil {
+				t.Fatal("Acquire failed")
+			}
+			tokens = append(tokens, token1)
+
+			// Second acquire should fail because we have not released the orginal token,
+			// or possibly if i == N-1 we could max parallel
+			token2 := throttle.Acquire(key, time.Hour)
+			if token2 != nil {
+				t.Error("Expected second acquire to fail on conflict")
+			}
+		}
+
+		// Any subsequent request should fail because at max
+		try := rand.Intn(1000) + 1
+		for i := 0; i < try; i++ {
+
+			key := strconv.Itoa(N + i)
+
+			token1 := throttle.Acquire(key, time.Hour)
+			if token1 != nil {
+				t.Fatal("Expect acquire to fail on max tokens")
+			}
+		}
+
+		// Release one at a time, validate that we can reacquire
+		for i, token := range tokens {
+
+			found := token.Release()
+			if !found {
+				t.Error("Expect token to be found")
+			}
+
+			// Second release should return false
+			found = token.Release()
+			if found {
+				t.Error("Expect token to not found on second release")
+			}
+
+			// We should now be able to to acquire
+			key := strconv.Itoa(i)
+
+			token = throttle.Acquire(key, time.Hour)
+			if token == nil {
+				t.Fatal("Acquire failed")
+			}
+
+			found = token.Release()
+			if !found {
+				t.Error("Expect token to be found")
+			}
+		}
+	}
+}
+
+func TestThrottleExpireIdentity(t *testing.T) {
+	throttle := NewThrottle(1)
+
+	key := "xxx"
+	token := throttle.Acquire(key, time.Second)
+
+	// Should *NOT* be able to re-acquire until TTL
+	token2 := throttle.Acquire(key, time.Hour)
+	if token2 != nil {
+		t.Error("Expected second acquire to fail on conflict")
+	}
+
+	time.Sleep(time.Second)
+
+	// Should be able to re-acquire on expiration
+	token3 := throttle.Acquire(key, time.Hour)
+	if token3 == nil {
+		t.Error("Expected third aquire to succeed")
+	}
+
+	// Original token should fail release
+	found := token.Release()
+	if found {
+		t.Error("Expected token to have expired")
+	}
+
+	// However, third token should release fine
+	found = token3.Release()
+	if !found {
+		t.Error("Expect recently acquired token to release cleanly")
+	}
+}
+
+// Test that a token from a different key is expired when at max
+func TestThrottleExpireAtMax(t *testing.T) {
+	throttle := NewThrottle(1)
+
+	key1 := "xxx"
+	token1 := throttle.Acquire(key1, time.Second)
+
+	// Should be at max, cannot acquire different key
+	key2 := "yyy"
+	token2 := throttle.Acquire(key2, time.Hour)
+	if token2 != nil {
+		t.Error("Expected second acquire to fail on max")
+	}
+
+	time.Sleep(time.Second)
+
+	// Should be able acquire second after timeout
+	token2 = throttle.Acquire(key2, time.Hour)
+	if token2 == nil {
+		t.Error("Expected third aquire to succeed")
+	}
+
+	// Original token should fail release
+	found := token1.Release()
+	if found {
+		t.Error("Expected token to have expired")
+	}
+
+	// However, third token should release fine
+	found = token2.Release()
+	if !found {
+		t.Error("Expect recently acquired token2 to release cleanly")
+	}
+}

--- a/model/schema.json
+++ b/model/schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+
     "action": {
       "title": "Agent action",
       "description": "An Elastic Agent action",
@@ -125,6 +126,63 @@
         "version"
       ]
     },
+
+    "artifact": {
+      "title": "Artifact",
+      "description": "An artifact served by Fleet",
+      "type": "object",
+      "properties": {
+        "identifier": {
+          "description": "Human readable artifact identifier",
+          "type": "string"
+        },
+        "compressionAlgorithm": {
+          "description": "Name of compression algorithm applied to artifact",
+          "type": "string"
+        },
+        "encryptionAlgorithm": {
+          "description": "Name of encryption algorithm applied to artifact",
+          "type": "string"
+        },
+        "encodedSha256": {
+          "description": "SHA256 of artifact after encoding has been applied",
+          "type": "string"
+        },
+        "encodedSize": {
+          "description": "Size of artifact after encoding has been applied",
+          "type": "integer"
+        },
+        "decodedSha256": {
+          "description": "SHA256 of artifact before encoding has been applied",
+          "type": "string"
+        },
+        "decodedSize": {
+          "description": "Size of artifact before encoding has been applied",
+          "type": "integer"
+        },
+        "created": {
+          "description": "Timestamp artifact was created",
+          "type": "string",
+          "format": "date-time"
+        },
+        "body": {
+          "description": "Encoded artifact data",
+          "type": "object",
+          "format": "raw"
+        }
+      },
+      "required": [
+        "identifier",
+        "compressionAlgorithm",
+        "encodedSha256",
+        "encodedSize",
+        "decodedSha256",
+        "decodedSize",
+        "created",
+        "body"
+      ]
+    },
+  
     "host-metadata": {
       "title": "Host Metadata",
       "description": "The host metadata for the Elastic Agent",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

The security app generates multiple user defined artifacts for delivery to the endpoint.  There is an existing implementation in Kibana to server up these artifacts via HTTPS.  With the introduction of Fleet Server, endpoints will no longer have credentials nor necessarily a route to Kibana.  As such, these artifacts must be served from Fleet Server instead.

Artifacts were previously stored in saved objects.  There is ongoing work in Kibana to move the records from saved objects into a dedicated .fleet-artifacts indice.  Fleet-Server and Kibana have agreed on a [schema](https://github.com/elastic/kibana/issues/90513#issuecomment-783684463).  In addition, there is an agreed upon URL format that Kibana will employ when generating a schema:

```
api/fleet/artifacts/:id/:sha2
```

This structure is consistent with the already existing fleet [api](https://github.com/elastic/fleet-server/blob/master/cmd/fleet/router.go#L12)  structure.

Artifact records will be immutable.  This will allow forward caching in a Fleet Server without concern for stale records.

Implementation is straight forward.  A new policy will roll out to the agents, which in turn will trickle down to endpoint.  Endpoint will interpret the policy and detect that there are new artifacts available.  Relative URL's of the above form will be included in the schema.  Endpoint will open HTTPS connection to the Fleet Server and do a GET on the relative URL.  The Fleet Server will authenticate the API Key presented by the agent, do a lookup on the sha2 in its local cache, and return if has payload.   If there is a local cache miss, the Fleet Server will do a search in .fleet-artifacts indice and retrieve the artifact record if available.  Record will be cached on hit and returned to requestor.  Artifact records will expire out of the cache in 24 hours.

Note there is currently no additional authorization on the artifact.  This means that any endpoint with a valid API Key will be able to pull any artifact from the system, assuming the sha2 is known.  This may be addressed at later point; and is commented in the code.

To prevent unnecessary round trips to Elastic Search for a specific sha2, a throttle has been implemented that limits the number of requests for a specific sha2.  In addition, there is a limit to the overall number of parallel requests to Elastic Search.  This will not defeat a DDOS attack on random sha2, but will limit the damage to the Fleet Server and Elastic Search.

The initial implementation uses the in memory cache for all artifacts.  As the artifacts grow in size, this may become an issue, causing thrashing on the cache.  There is a TODO to spill large artifacts to disk storage in the cache code to limit the memory overhead.

## Why is it important?

Endpoint requires this functionality for GA.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ x] My code follows the style guidelines of this project
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [ x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- https://github.com/elastic/kibana/issues/90513

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
