### PR TITLE
Cherry-pick #131 to 7.x: Add API status endpoint

### DIFF
--- a/cmd/fleet/handleStatus.go
+++ b/cmd/fleet/handleStatus.go
@@ -1,0 +1,42 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package fleet
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
+	"github.com/julienschmidt/httprouter"
+	"github.com/rs/zerolog/log"
+)
+
+func (rt Router) handleStatus(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	status := rt.sm.Status()
+	resp := StatusResponse{
+		Name:   "fleet-server",
+		Status: status.String(),
+	}
+
+	data, err := json.Marshal(&resp)
+	if err != nil {
+		code := http.StatusInternalServerError
+		log.Error().Err(err).Int("code", code).Msg("fail status")
+		http.Error(w, err.Error(), code)
+		return
+	}
+
+	code := http.StatusServiceUnavailable
+	if status == proto.StateObserved_DEGRADED || status == proto.StateObserved_HEALTHY {
+		code = http.StatusOK
+	}
+	w.WriteHeader(code)
+	if _, err = w.Write(data); err != nil {
+		if err != context.Canceled {
+			log.Error().Err(err).Int("code", code).Msg("fail status")
+		}
+	}
+}

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -526,7 +526,7 @@ func (f *FleetServer) runServer(ctx context.Context, cfg *config.Config) (err er
 	if err != nil {
 		return err
 	}
-	router := NewRouter(bulker, ct, et)
+	router := NewRouter(bulker, ct, et, sm)
 
 	g.Go(loggedRunFunc(ctx, "Http server", func(ctx context.Context) error {
 		return runServer(ctx, router, &f.cfg.Inputs[0].Server)

--- a/cmd/fleet/router.go
+++ b/cmd/fleet/router.go
@@ -6,10 +6,12 @@ package fleet
 
 import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
+	"github.com/elastic/fleet-server/v7/internal/pkg/policy"
 	"github.com/julienschmidt/httprouter"
 )
 
 const (
+	ROUTE_STATUS  = "/api/status"
 	ROUTE_ENROLL  = "/api/fleet/agents/:id"
 	ROUTE_CHECKIN = "/api/fleet/agents/:id/checkin"
 	ROUTE_ACKS    = "/api/fleet/agents/:id/acks"
@@ -17,19 +19,23 @@ const (
 
 type Router struct {
 	bulker bulk.Bulk
+	ver    string
 	ct     *CheckinT
 	et     *EnrollerT
+	sm     policy.SelfMonitor
 }
 
-func NewRouter(bulker bulk.Bulk, ct *CheckinT, et *EnrollerT) *httprouter.Router {
+func NewRouter(bulker bulk.Bulk, ct *CheckinT, et *EnrollerT, sm policy.SelfMonitor) *httprouter.Router {
 
 	r := Router{
 		bulker: bulker,
 		ct:     ct,
 		et:     et,
+		sm:     sm,
 	}
 
 	router := httprouter.New()
+	router.GET(ROUTE_STATUS, r.handleStatus)
 	router.POST(ROUTE_ENROLL, r.handleEnroll)
 	router.POST(ROUTE_CHECKIN, r.handleCheckin)
 	router.POST(ROUTE_ACKS, r.handleAcks)

--- a/cmd/fleet/schema.go
+++ b/cmd/fleet/schema.go
@@ -139,3 +139,9 @@ type Event struct {
 	Data        json.RawMessage `json:"data,omitempty"`
 	Error       string          `json:"error,omitempty"`
 }
+
+type StatusResponse struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Status  string `json:"status"`
+}

--- a/cmd/fleet/server_integration_test.go
+++ b/cmd/fleet/server_integration_test.go
@@ -105,7 +105,7 @@ func (s *tserver) waitServerUp(ctx context.Context, dur time.Duration) error {
 	start := time.Now()
 	cli := cleanhttp.DefaultClient()
 	for {
-		res, err := cli.Get(s.baseUrl())
+		res, err := cli.Get(s.baseUrl() + "/api/status")
 		if err != nil {
 			if time.Since(start) > dur {
 				return err

--- a/cmd/fleet/server_test.go
+++ b/cmd/fleet/server_test.go
@@ -43,7 +43,7 @@ func TestRunServer(t *testing.T) {
 	et, err := NewEnrollerT(cfg, nil, c)
 	require.NoError(t, err)
 
-	router := NewRouter(bulker, ct, et)
+	router := NewRouter(bulker, ct, et, nil)
 	errCh := make(chan error)
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
Cherry-pick of PR #131 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds an `/api/status` endpoint to verify that Fleet Server is running properly. This is also used by the Elastic Agent that it can communicate with a Fleet Server.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Elastic Agent verifies that it can communicate with a Fleet Server when a policy included an updated connection URL to a Fleet Server. Without this endpoint present then Elastic Agent will not accept and apply the policy because it cannot verify that the Fleet Server it needs to communicate with is correct.

This mirrors the `/api/status` URL by Kibana, so nothing needs to change in Elastic Agent. Elastic Agent can switch from a Kibana to Fleet Server without any custom logic.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
