### PR TITLE
Add cache configuration option.

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -47,13 +47,23 @@ func installSignalHandler() context.Context {
 	return signal.HandleInterrupt(rootCtx)
 }
 
+func makeCache(cfg *config.Config) (cache.Cache, error) {
+
+	log.Info().
+		Int64("numCounters", cfg.Cache.NumCounters).
+		Int64("maxCost", cfg.Cache.MaxCost).
+		Msg("makeCache")
+
+	cacheCfg := cache.Config{
+		NumCounters: cfg.Cache.NumCounters,
+		MaxCost:     cfg.Cache.MaxCost,
+	}
+
+	return cache.New(cacheCfg)
+}
+
 func getRunCommand(version string) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		c, err := cache.New()
-		if err != nil {
-			return err
-		}
-
 		cfgObject := cmd.Flags().Lookup("E").Value.(*config.Flag)
 		cliCfg := cfgObject.Config()
 
@@ -70,6 +80,11 @@ func getRunCommand(version string) func(cmd *cobra.Command, args []string) error
 				return err
 			}
 			l, err = logger.Init(cfg)
+			if err != nil {
+				return err
+			}
+
+			c, err := makeCache(cfg)
 			if err != nil {
 				return err
 			}
@@ -99,6 +114,11 @@ func getRunCommand(version string) func(cmd *cobra.Command, args []string) error
 			}
 
 			l, err = logger.Init(cfg)
+			if err != nil {
+				return err
+			}
+
+			c, err := makeCache(cfg)
 			if err != nil {
 				return err
 			}

--- a/cmd/fleet/server_integration_test.go
+++ b/cmd/fleet/server_integration_test.go
@@ -63,7 +63,7 @@ func startTestServer(ctx context.Context) (*tserver, error) {
 		return nil, err
 	}
 
-	c, err := cache.New()
+	c, err := cache.New(cache.Config{NumCounters: 100, MaxCost: 100000})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/fleet/server_test.go
+++ b/cmd/fleet/server_test.go
@@ -33,7 +33,7 @@ func TestRunServer(t *testing.T) {
 	cfg.Host = "localhost"
 	cfg.Port = port
 
-	c, err := cache.New()
+	c, err := cache.New(cache.Config{NumCounters: 100, MaxCost: 100000})
 	require.NoError(t, err)
 	bulker := ftesting.MockBulk{}
 	pim := mock.NewMockIndexMonitor()

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -22,20 +22,25 @@ type Cache struct {
 	cache *ristretto.Cache
 }
 
+type Config struct {
+	NumCounters int64 // number of keys to track frequency of
+	MaxCost     int64 // maximum cost of cache in 'cost' units
+}
+
 type actionCache struct {
 	actionId   string
 	actionType string
 }
 
 // New creates a new cache.
-func New() (Cache, error) {
-	cfg := &ristretto.Config{
-		NumCounters: 1000000,           // number of keys to track frequency of
-		MaxCost:     100 * 1024 * 1024, // maximum cost of cache (100MB)
+func New(cfg Config) (Cache, error) {
+	rcfg := &ristretto.Config{
+		NumCounters: cfg.NumCounters,
+		MaxCost:     cfg.MaxCost,
 		BufferItems: 64,
 	}
 
-	cache, err := ristretto.NewCache(cfg)
+	cache, err := ristretto.NewCache(rcfg)
 	return Cache{cache}, err
 }
 

--- a/internal/pkg/config/cache.go
+++ b/internal/pkg/config/cache.go
@@ -1,0 +1,20 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package config
+
+const (
+	defaultCacheNumCounters = 500000           // 10x times expected count
+	defaultCacheMaxCost     = 50 * 1024 * 1024 // 50MiB cache size
+)
+
+type Cache struct {
+	NumCounters int64 `config:"num_counters"`
+	MaxCost     int64 `config:"max_cost"`
+}
+
+func (c *Cache) InitDefaults() {
+	c.NumCounters = defaultCacheNumCounters
+	c.MaxCost = defaultCacheMaxCost
+}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Inputs  []Input `config:"inputs"`
 	Logging Logging `config:"logging"`
 	HTTP    HTTP    `config:"http"`
+	Cache   Cache   `config:"cache"`
 }
 
 // InitDefaults initializes the defaults for the configuration.
@@ -34,6 +35,7 @@ func (c *Config) InitDefaults() {
 	c.Inputs = make([]Input, 1)
 	c.Inputs[0].InitDefaults()
 	c.HTTP.InitDefaults()
+	c.Cache.InitDefaults()
 }
 
 // Validate ensures that the configuration is valid.

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -70,6 +70,10 @@ func TestConfig(t *testing.T) {
 					Host: kDefaultHTTPHost,
 					Port: kDefaultHTTPPort,
 				},
+				Cache: Cache{
+					NumCounters: defaultCacheNumCounters,
+					MaxCost:     defaultCacheMaxCost,
+				},
 			},
 		},
 		"fleet-logging": {
@@ -122,6 +126,10 @@ func TestConfig(t *testing.T) {
 					Host: kDefaultHTTPHost,
 					Port: kDefaultHTTPPort,
 				},
+				Cache: Cache{
+					NumCounters: defaultCacheNumCounters,
+					MaxCost:     defaultCacheMaxCost,
+				},
 			},
 		},
 		"input": {
@@ -172,6 +180,10 @@ func TestConfig(t *testing.T) {
 					Host: kDefaultHTTPHost,
 					Port: kDefaultHTTPPort,
 				},
+				Cache: Cache{
+					NumCounters: defaultCacheNumCounters,
+					MaxCost:     defaultCacheMaxCost,
+				},
 			},
 		},
 		"input-config": {
@@ -221,6 +233,10 @@ func TestConfig(t *testing.T) {
 				HTTP: HTTP{
 					Host: kDefaultHTTPHost,
 					Port: kDefaultHTTPPort,
+				},
+				Cache: Cache{
+					NumCounters: defaultCacheNumCounters,
+					MaxCost:     defaultCacheMaxCost,
 				},
 			},
 		},

--- a/internal/pkg/throttle/throttle_test.go
+++ b/internal/pkg/throttle/throttle_test.go
@@ -17,7 +17,7 @@ func TestThrottleZero(t *testing.T) {
 	// but still cannot acquire existing that has not timed out
 	throttle := NewThrottle(0)
 
-	N := rand.Intn(2048) + 10
+	N := rand.Intn(64) + 10
 
 	var tokens []*Token
 	for i := 0; i < N; i++ {
@@ -106,7 +106,7 @@ func TestThrottleN(t *testing.T) {
 		}
 
 		// Any subsequent request should fail because at max
-		try := rand.Intn(1000) + 1
+		try := rand.Intn(64) + 1
 		for i := 0; i < try; i++ {
 
 			key := strconv.Itoa(N + i)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Adds optional configuration to tweak cache thresholds.  Tuned down the default configuration to minimize memory usage.

## Why is it important?

The server is expected to run in limited memory environments.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## How to test this PR locally

Modify the cache config section in the yaml, and restart server.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

- Closes https://github.com/elastic/fleet-server/issues/96

