### PR TITLE
Remove darwin/arm64 support.  Remove ASLR support for darwin.  

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,11 @@ DEFAULT_VERSION=$(shell awk '/const defaultVersion/{print $$NF}' main.go | tr -d
 TARGET_ARCH_386=x86
 TARGET_ARCH_amd64=x86_64
 TARGET_ARCH_arm64=arm64
-BUILDMODE_ARCH_386= ## ASLR either not supported or weak on 32bit machines
-BUILDMODE_ARCH_amd64=-buildmode=pie
-BUILDMODE_ARCH_arm64=-buildmode=pie
-PLATFORMS ?= darwin/amd64 darwin/arm64 linux/386 linux/amd64 linux/arm64 windows/386 windows/amd64
+PLATFORMS ?= darwin/amd64 linux/386 linux/amd64 linux/arm64 windows/386 windows/amd64
+BUILDMODE_linux_amd64=-buildmode=pie
+BUILDMODE_linux_arm64=-buildmode=pie
+BUILDMODE_windows_386=-buildmode=pie
+BUILDMODE_windows_amd64=-buildmode=pie
 
 ifeq ($(SNAPSHOT),true)
 VERSION=${DEFAULT_VERSION}-SNAPSHOT
@@ -111,7 +112,7 @@ $(PLATFORM_TARGETS): release-%:
 	$(eval $@_OS := $(firstword $(subst /, ,$(lastword $(subst release-, ,$@)))))
 	$(eval $@_GO_ARCH := $(lastword $(subst /, ,$(lastword $(subst release-, ,$@)))))
 	$(eval $@_ARCH := $(TARGET_ARCH_$($@_GO_ARCH)))
-	$(eval $@_BUILDMODE:= $(BUILDMODE_ARCH_$($@_GO_ARCH)))
+	$(eval $@_BUILDMODE:= $(BUILDMODE_$($@_OS)_$($@_GO_ARCH)))
 	GOOS=$($@_OS) GOARCH=$($@_GO_ARCH) go build -ldflags="${LDFLAGS}" $($@_BUILDMODE) -o build/binaries/fleet-server-$(VERSION)-$($@_OS)-$($@_ARCH)/fleet-server .
 	@$(MAKE) OS=$($@_OS) ARCH=$($@_ARCH) package-target
 


### PR DESCRIPTION
Both darwin build modes fail on the linux build machines.  This is a temporary change until we can get the cross compile resolved.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Builds are currently broken due cross compile requirements for darwin.  This is a temporary work around.

