### PR TITLE
Fix configuration for cache and server profiler off by default

### DIFF
--- a/fleet-server.yml
+++ b/fleet-server.yml
@@ -12,9 +12,13 @@ fleet:
 
 # Input config provided by the Elastic Agent for the server
 #inputs:
-#  - type:
-#    policy:
+#  - type: fleet-server
 #    server:
+#      host: localhost
+#      port: 8220
+#    cache:
+#      num_counters: 500000  # 10x times expected count
+#      max_cost: 50 * 1024 * 1024  # 50MiB cache size
 
 logging:
   to_stderr: true

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -27,7 +27,6 @@ type Config struct {
 	Inputs  []Input `config:"inputs"`
 	Logging Logging `config:"logging"`
 	HTTP    HTTP    `config:"http"`
-	Cache   Cache   `config:"cache"`
 }
 
 // InitDefaults initializes the defaults for the configuration.
@@ -35,7 +34,6 @@ func (c *Config) InitDefaults() {
 	c.Inputs = make([]Input, 1)
 	c.Inputs[0].InitDefaults()
 	c.HTTP.InitDefaults()
-	c.Cache.InitDefaults()
 }
 
 // Validate ensures that the configuration is valid.

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -56,7 +56,14 @@ func TestConfig(t *testing.T) {
 							MaxEnrollPending:  64,
 							RateLimitBurst:    1024,
 							RateLimitInterval: 5 * time.Millisecond,
-							Profile:           ServerProfile{Bind: "localhost:6060"},
+							Profile: ServerProfile{
+								Enabled: false,
+								Bind:    "localhost:6060",
+							},
+						},
+						Cache: Cache{
+							NumCounters: defaultCacheNumCounters,
+							MaxCost:     defaultCacheMaxCost,
 						},
 					},
 				},
@@ -69,10 +76,6 @@ func TestConfig(t *testing.T) {
 				HTTP: HTTP{
 					Host: kDefaultHTTPHost,
 					Port: kDefaultHTTPPort,
-				},
-				Cache: Cache{
-					NumCounters: defaultCacheNumCounters,
-					MaxCost:     defaultCacheMaxCost,
 				},
 			},
 		},
@@ -112,7 +115,14 @@ func TestConfig(t *testing.T) {
 							MaxEnrollPending:  64,
 							RateLimitBurst:    1024,
 							RateLimitInterval: 5 * time.Millisecond,
-							Profile:           ServerProfile{Bind: "localhost:6060"},
+							Profile: ServerProfile{
+								Enabled: false,
+								Bind:    "localhost:6060",
+							},
+						},
+						Cache: Cache{
+							NumCounters: defaultCacheNumCounters,
+							MaxCost:     defaultCacheMaxCost,
 						},
 					},
 				},
@@ -125,10 +135,6 @@ func TestConfig(t *testing.T) {
 				HTTP: HTTP{
 					Host: kDefaultHTTPHost,
 					Port: kDefaultHTTPPort,
-				},
-				Cache: Cache{
-					NumCounters: defaultCacheNumCounters,
-					MaxCost:     defaultCacheMaxCost,
 				},
 			},
 		},
@@ -166,7 +172,14 @@ func TestConfig(t *testing.T) {
 							MaxEnrollPending:  64,
 							RateLimitBurst:    1024,
 							RateLimitInterval: 5 * time.Millisecond,
-							Profile:           ServerProfile{Bind: "localhost:6060"},
+							Profile: ServerProfile{
+								Enabled: false,
+								Bind:    "localhost:6060",
+							},
+						},
+						Cache: Cache{
+							NumCounters: defaultCacheNumCounters,
+							MaxCost:     defaultCacheMaxCost,
 						},
 					},
 				},
@@ -179,10 +192,6 @@ func TestConfig(t *testing.T) {
 				HTTP: HTTP{
 					Host: kDefaultHTTPHost,
 					Port: kDefaultHTTPPort,
-				},
-				Cache: Cache{
-					NumCounters: defaultCacheNumCounters,
-					MaxCost:     defaultCacheMaxCost,
 				},
 			},
 		},
@@ -220,7 +229,14 @@ func TestConfig(t *testing.T) {
 							MaxEnrollPending:  64,
 							RateLimitBurst:    1024,
 							RateLimitInterval: 5 * time.Millisecond,
-							Profile:           ServerProfile{Bind: "localhost:6060"},
+							Profile: ServerProfile{
+								Enabled: false,
+								Bind:    "localhost:6060",
+							},
+						},
+						Cache: Cache{
+							NumCounters: defaultCacheNumCounters,
+							MaxCost:     defaultCacheMaxCost,
 						},
 					},
 				},
@@ -233,10 +249,6 @@ func TestConfig(t *testing.T) {
 				HTTP: HTTP{
 					Host: kDefaultHTTPHost,
 					Port: kDefaultHTTPPort,
-				},
-				Cache: Cache{
-					NumCounters: defaultCacheNumCounters,
-					MaxCost:     defaultCacheMaxCost,
 				},
 			},
 		},

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -34,8 +34,8 @@ func (c *ServerTimeouts) InitDefaults() {
 
 // ServerProfile is the configuration for profiling the server.
 type ServerProfile struct {
-	Enabled bool `config:"enabled"`
-	Bind string `config:"bind"`
+	Enabled bool   `config:"enabled"`
+	Bind    string `config:"bind"`
 }
 
 // InitDefaults initializes the defaults for the configuration.
@@ -62,7 +62,6 @@ type Server struct {
 	MaxConnections    int               `config:"max_connections"`
 	MaxEnrollPending  int64             `config:"max_enroll_pending"`
 	Profile           ServerProfile     `config:"profile"`
-
 }
 
 // InitDefaults initializes the defaults for the configuration.

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -34,11 +34,13 @@ func (c *ServerTimeouts) InitDefaults() {
 
 // ServerProfile is the configuration for profiling the server.
 type ServerProfile struct {
+	Enabled bool `config:"enabled"`
 	Bind string `config:"bind"`
 }
 
 // InitDefaults initializes the defaults for the configuration.
 func (c *ServerProfile) InitDefaults() {
+	c.Enabled = false
 	c.Bind = "localhost:6060"
 }
 
@@ -60,6 +62,7 @@ type Server struct {
 	MaxConnections    int               `config:"max_connections"`
 	MaxEnrollPending  int64             `config:"max_enroll_pending"`
 	Profile           ServerProfile     `config:"profile"`
+
 }
 
 // InitDefaults initializes the defaults for the configuration.
@@ -89,12 +92,14 @@ type Input struct {
 	Type   string `config:"type"`
 	Policy Policy `config:"policy"`
 	Server Server `config:"server"`
+	Cache  Cache  `config:"cache"`
 }
 
 // InitDefaults initializes the defaults for the configuration.
 func (c *Input) InitDefaults() {
 	c.Type = "fleet-server"
 	c.Server.InitDefaults()
+	c.Cache.InitDefaults()
 }
 
 // Validate ensures that the configuration is valid.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Moves `cache` keys under the input so they can be set by the Elastic Agent. Disables the server profile by default.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So `cache` can be adjusted from the Fleet Server integration.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #155
