### PR TITLE
[mergify] auto-merge backports

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -29,9 +29,8 @@ pull_request_rules:
       backport:
         branches:
           - "7.12"
-  - name: automatic merge for 7.x when CI passes and 1 review
+  - name: automatic merge for 7.x when CI passes
     conditions:
-      - "#approved-reviews-by>=1"
       - check-success=fleet-server/pr-merge
       - check-success=CLA
       - base=7.x
@@ -40,9 +39,8 @@ pull_request_rules:
         method: squash
         strict: smart+fasttrack
         priority: low
-  - name: automatic merge for 7.12 when CI passes and 1 review
+  - name: automatic merge for 7.12 when CI passes
     conditions:
-      - "#approved-reviews-by>=1"
       - check-success=fleet-server/pr-merge
       - check-success=CLA
       - base=7.12

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -29,3 +29,25 @@ pull_request_rules:
       backport:
         branches:
           - "7.12"
+  - name: automatic merge for 7.x when CI passes and 1 review
+    conditions:
+      - "#approved-reviews-by>=1"
+      - check-success=fleet-server/pr-merge
+      - check-success=CLA
+      - base=7.x
+    actions:
+      merge:
+        method: squash
+        strict: smart+fasttrack
+        priority: low
+  - name: automatic merge for 7.12 when CI passes and 1 review
+    conditions:
+      - "#approved-reviews-by>=1"
+      - check-success=fleet-server/pr-merge
+      - check-success=CLA
+      - base=7.12
+    actions:
+      merge:
+        method: squash
+        strict: smart+fasttrack
+        priority: low


### PR DESCRIPTION
## What does this PR do?

Auto-merge backports for 7.x and 7.12 branches only if:

- CLA success
- CI success

Auto-merge based on `squash-merge`

## Why is it important?

No more manual actions for backports

@blakerouse asked about the auto-merge so this is the proposal