### PR TITLE
Increase the monitor throughput: increase the default fetch size, make it configurable.

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -496,7 +496,7 @@ func (f *FleetServer) runServer(ctx context.Context, cfg *config.Config) (err er
 	g, ctx := errgroup.WithContext(ctx)
 
 	// Coordinator policy monitor
-	pim, err := monitor.New(dl.FleetPolicies, es, monitor.WithFetchSize(cfg.Monitor.FetchSize))
+	pim, err := monitor.New(dl.FleetPolicies, es, monitor.WithFetchSize(cfg.Inputs[0].Monitor.FetchSize))
 	if err != nil {
 		return err
 	}
@@ -518,7 +518,7 @@ func (f *FleetServer) runServer(ctx context.Context, cfg *config.Config) (err er
 	var ad *action.Dispatcher
 	var tr *action.TokenResolver
 
-	am, err = monitor.NewSimple(dl.FleetActions, es, monitor.WithExpiration(true), monitor.WithFetchSize(cfg.Monitor.FetchSize))
+	am, err = monitor.NewSimple(dl.FleetActions, es, monitor.WithExpiration(true), monitor.WithFetchSize(cfg.Inputs[0].Monitor.FetchSize))
 	if err != nil {
 		return err
 	}

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -496,7 +496,7 @@ func (f *FleetServer) runServer(ctx context.Context, cfg *config.Config) (err er
 	g, ctx := errgroup.WithContext(ctx)
 
 	// Coordinator policy monitor
-	pim, err := monitor.New(dl.FleetPolicies, es)
+	pim, err := monitor.New(dl.FleetPolicies, es, monitor.WithFetchSize(cfg.Monitor.FetchSize))
 	if err != nil {
 		return err
 	}
@@ -518,8 +518,7 @@ func (f *FleetServer) runServer(ctx context.Context, cfg *config.Config) (err er
 	var ad *action.Dispatcher
 	var tr *action.TokenResolver
 
-	// Behind the feature flag
-	am, err = monitor.NewSimple(dl.FleetActions, es, monitor.WithExpiration(true))
+	am, err = monitor.NewSimple(dl.FleetActions, es, monitor.WithExpiration(true), monitor.WithFetchSize(cfg.Monitor.FetchSize))
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -27,8 +27,6 @@ type Config struct {
 	Inputs  []Input `config:"inputs"`
 	Logging Logging `config:"logging"`
 	HTTP    HTTP    `config:"http"`
-	Cache   Cache   `config:"cache"`
-	Monitor Monitor `config:"monitor"`
 }
 
 // InitDefaults initializes the defaults for the configuration.
@@ -36,8 +34,6 @@ func (c *Config) InitDefaults() {
 	c.Inputs = make([]Input, 1)
 	c.Inputs[0].InitDefaults()
 	c.HTTP.InitDefaults()
-	c.Cache.InitDefaults()
-	c.Monitor.InitDefaults()
 }
 
 // Validate ensures that the configuration is valid.

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -27,6 +27,8 @@ type Config struct {
 	Inputs  []Input `config:"inputs"`
 	Logging Logging `config:"logging"`
 	HTTP    HTTP    `config:"http"`
+	Cache   Cache   `config:"cache"`
+	Monitor Monitor `config:"monitor"`
 }
 
 // InitDefaults initializes the defaults for the configuration.
@@ -34,6 +36,8 @@ func (c *Config) InitDefaults() {
 	c.Inputs = make([]Input, 1)
 	c.Inputs[0].InitDefaults()
 	c.HTTP.InitDefaults()
+	c.Cache.InitDefaults()
+	c.Monitor.InitDefaults()
 }
 
 // Validate ensures that the configuration is valid.

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -77,6 +77,13 @@ func TestConfig(t *testing.T) {
 					Host: kDefaultHTTPHost,
 					Port: kDefaultHTTPPort,
 				},
+				Cache: Cache{
+					NumCounters: defaultCacheNumCounters,
+					MaxCost:     defaultCacheMaxCost,
+				},
+				Monitor: Monitor{
+					FetchSize: defaultFetchSize,
+				},
 			},
 		},
 		"fleet-logging": {
@@ -136,6 +143,13 @@ func TestConfig(t *testing.T) {
 					Host: kDefaultHTTPHost,
 					Port: kDefaultHTTPPort,
 				},
+				Cache: Cache{
+					NumCounters: defaultCacheNumCounters,
+					MaxCost:     defaultCacheMaxCost,
+				},
+				Monitor: Monitor{
+					FetchSize: defaultFetchSize,
+				},
 			},
 		},
 		"input": {
@@ -193,6 +207,13 @@ func TestConfig(t *testing.T) {
 					Host: kDefaultHTTPHost,
 					Port: kDefaultHTTPPort,
 				},
+				Cache: Cache{
+					NumCounters: defaultCacheNumCounters,
+					MaxCost:     defaultCacheMaxCost,
+				},
+				Monitor: Monitor{
+					FetchSize: defaultFetchSize,
+				},
 			},
 		},
 		"input-config": {
@@ -249,6 +270,13 @@ func TestConfig(t *testing.T) {
 				HTTP: HTTP{
 					Host: kDefaultHTTPHost,
 					Port: kDefaultHTTPPort,
+				},
+				Cache: Cache{
+					NumCounters: defaultCacheNumCounters,
+					MaxCost:     defaultCacheMaxCost,
+				},
+				Monitor: Monitor{
+					FetchSize: defaultFetchSize,
 				},
 			},
 		},

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -65,6 +65,9 @@ func TestConfig(t *testing.T) {
 							NumCounters: defaultCacheNumCounters,
 							MaxCost:     defaultCacheMaxCost,
 						},
+						Monitor: Monitor{
+							FetchSize: defaultFetchSize,
+						},
 					},
 				},
 				Logging: Logging{
@@ -76,13 +79,6 @@ func TestConfig(t *testing.T) {
 				HTTP: HTTP{
 					Host: kDefaultHTTPHost,
 					Port: kDefaultHTTPPort,
-				},
-				Cache: Cache{
-					NumCounters: defaultCacheNumCounters,
-					MaxCost:     defaultCacheMaxCost,
-				},
-				Monitor: Monitor{
-					FetchSize: defaultFetchSize,
 				},
 			},
 		},
@@ -131,6 +127,9 @@ func TestConfig(t *testing.T) {
 							NumCounters: defaultCacheNumCounters,
 							MaxCost:     defaultCacheMaxCost,
 						},
+						Monitor: Monitor{
+							FetchSize: defaultFetchSize,
+						},
 					},
 				},
 				Logging: Logging{
@@ -142,13 +141,6 @@ func TestConfig(t *testing.T) {
 				HTTP: HTTP{
 					Host: kDefaultHTTPHost,
 					Port: kDefaultHTTPPort,
-				},
-				Cache: Cache{
-					NumCounters: defaultCacheNumCounters,
-					MaxCost:     defaultCacheMaxCost,
-				},
-				Monitor: Monitor{
-					FetchSize: defaultFetchSize,
 				},
 			},
 		},
@@ -195,6 +187,9 @@ func TestConfig(t *testing.T) {
 							NumCounters: defaultCacheNumCounters,
 							MaxCost:     defaultCacheMaxCost,
 						},
+						Monitor: Monitor{
+							FetchSize: defaultFetchSize,
+						},
 					},
 				},
 				Logging: Logging{
@@ -206,13 +201,6 @@ func TestConfig(t *testing.T) {
 				HTTP: HTTP{
 					Host: kDefaultHTTPHost,
 					Port: kDefaultHTTPPort,
-				},
-				Cache: Cache{
-					NumCounters: defaultCacheNumCounters,
-					MaxCost:     defaultCacheMaxCost,
-				},
-				Monitor: Monitor{
-					FetchSize: defaultFetchSize,
 				},
 			},
 		},
@@ -259,6 +247,9 @@ func TestConfig(t *testing.T) {
 							NumCounters: defaultCacheNumCounters,
 							MaxCost:     defaultCacheMaxCost,
 						},
+						Monitor: Monitor{
+							FetchSize: defaultFetchSize,
+						},
 					},
 				},
 				Logging: Logging{
@@ -270,13 +261,6 @@ func TestConfig(t *testing.T) {
 				HTTP: HTTP{
 					Host: kDefaultHTTPHost,
 					Port: kDefaultHTTPPort,
-				},
-				Cache: Cache{
-					NumCounters: defaultCacheNumCounters,
-					MaxCost:     defaultCacheMaxCost,
-				},
-				Monitor: Monitor{
-					FetchSize: defaultFetchSize,
 				},
 			},
 		},

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -88,10 +88,11 @@ func (c *Server) BindAddress() string {
 
 // Input is the input defined by Agent to run Fleet Server.
 type Input struct {
-	Type   string `config:"type"`
-	Policy Policy `config:"policy"`
-	Server Server `config:"server"`
-	Cache  Cache  `config:"cache"`
+	Type    string  `config:"type"`
+	Policy  Policy  `config:"policy"`
+	Server  Server  `config:"server"`
+	Cache   Cache   `config:"cache"`
+	Monitor Monitor `config:"monitor"`
 }
 
 // InitDefaults initializes the defaults for the configuration.
@@ -99,6 +100,7 @@ func (c *Input) InitDefaults() {
 	c.Type = "fleet-server"
 	c.Server.InitDefaults()
 	c.Cache.InitDefaults()
+	c.Monitor.InitDefaults()
 }
 
 // Validate ensures that the configuration is valid.

--- a/internal/pkg/config/monitor.go
+++ b/internal/pkg/config/monitor.go
@@ -1,0 +1,17 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package config
+
+const (
+	defaultFetchSize = 1000
+)
+
+type Monitor struct {
+	FetchSize int `config:"fetch_size"`
+}
+
+func (m *Monitor) InitDefaults() {
+	m.FetchSize = defaultFetchSize
+}


### PR DESCRIPTION
## What does this PR do?

Increases the monitor throughput:

* Increase the monitor fetch size to 1000 by default, the max number of documents fetched at once.
* Makes the monitor fetch size configurable.
* Decreased the pause between fetches from 50ms to 10ms.

## Why is it important?

Tuning of the throughput.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

