### PR TITLE
mergify: priority is now a pro feature

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -38,7 +38,6 @@ pull_request_rules:
       merge:
         method: squash
         strict: smart+fasttrack
-        priority: low
   - name: automatic merge for 7.12 when CI passes
     conditions:
       - check-success=fleet-server/pr-merge
@@ -48,4 +47,3 @@ pull_request_rules:
       merge:
         method: squash
         strict: smart+fasttrack
-        priority: low


### PR DESCRIPTION
## What does this PR do?

Use the free options

## Why is it important?

We don't use the premium version

![image](https://user-images.githubusercontent.com/2871786/112859839-22a55500-90ab-11eb-88b4-0a142d6443e9.png)
