### PR TITLE
Fix issue with rolling out policies from the coordinator.

### DIFF
--- a/internal/pkg/coordinator/v0.go
+++ b/internal/pkg/coordinator/v0.go
@@ -76,12 +76,7 @@ func (c *coordinatorZeroT) updatePolicy(p model.Policy) error {
 	if err != nil {
 		return err
 	}
-	if p.CoordinatorIdx == 0 {
-		p.CoordinatorIdx = 1
-		p.Data = newData
-		c.policy = p
-		c.out <- p
-	} else if string(newData) != string(p.Data) {
+	if p.CoordinatorIdx == 0 || string(newData) != string(p.Data) {
 		p.CoordinatorIdx += 1
 		p.Data = newData
 		c.policy = p

--- a/internal/pkg/coordinator/v0.go
+++ b/internal/pkg/coordinator/v0.go
@@ -28,7 +28,7 @@ func NewCoordinatorZero(policy model.Policy) (Coordinator, error) {
 	return &coordinatorZeroT{
 		log:    log.With().Str("ctx", "coordinator v0").Str("policyId", policy.PolicyId).Logger(),
 		policy: policy,
-		in:     make(chan model.Policy, 1),
+		in:     make(chan model.Policy),
 		out:    make(chan model.Policy),
 	}, nil
 }
@@ -40,25 +40,18 @@ func (c *coordinatorZeroT) Name() string {
 
 // Run runs the coordinator for the policy.
 func (c *coordinatorZeroT) Run(ctx context.Context) error {
-	c.in <- c.policy
+	err := c.updatePolicy(c.policy)
+	if err != nil {
+		c.log.Err(err).Msg("failed to handle policy")
+	}
+
 	for {
 		select {
 		case p := <-c.in:
-			newData, err := c.handlePolicy(p.Data)
+			err = c.updatePolicy(p)
 			if err != nil {
 				c.log.Err(err).Msg("failed to handle policy")
 				continue
-			}
-			if p.CoordinatorIdx == 0 {
-				p.CoordinatorIdx = 1
-				p.Data = newData
-				c.policy = p
-				c.out <- p
-			} else if string(newData) != string(p.Data) {
-				p.CoordinatorIdx += 1
-				p.Data = newData
-				c.policy = p
-				c.out <- p
 			}
 		case <-ctx.Done():
 			return ctx.Err()
@@ -77,7 +70,27 @@ func (c *coordinatorZeroT) Output() <-chan model.Policy {
 	return c.out
 }
 
-// handlePolicy handles the new policy.
+// updatePolicy performs the working of incrementing the coordinator idx.
+func (c *coordinatorZeroT) updatePolicy(p model.Policy) error {
+	newData, err := c.handlePolicy(p.Data)
+	if err != nil {
+		return err
+	}
+	if p.CoordinatorIdx == 0 {
+		p.CoordinatorIdx = 1
+		p.Data = newData
+		c.policy = p
+		c.out <- p
+	} else if string(newData) != string(p.Data) {
+		p.CoordinatorIdx += 1
+		p.Data = newData
+		c.policy = p
+		c.out <- p
+	}
+	return nil
+}
+
+// handlePolicy performs the actual work of coordination.
 //
 // Does nothing at the moment.
 func (c *coordinatorZeroT) handlePolicy(data json.RawMessage) (json.RawMessage, error) {

--- a/internal/pkg/dl/policies.go
+++ b/internal/pkg/dl/policies.go
@@ -27,7 +27,7 @@ func prepareQueryLatestPolicies() []byte {
 	root := dsl.NewRoot()
 	root.Size(0)
 	policyId := root.Aggs().Agg(FieldPolicyId)
-	policyId.Terms("field", FieldPolicyId, nil)
+	policyId.Terms("field", FieldPolicyId, nil).Size(10000)
 	revisionIdx := policyId.Aggs().Agg(FieldRevisionIdx).TopHits()
 	revisionIdx.Size(1)
 	rSort := revisionIdx.Sort()

--- a/internal/pkg/dsl/term.go
+++ b/internal/pkg/dsl/term.go
@@ -4,7 +4,7 @@
 
 package dsl
 
-func (n *Node) Term(field string, value interface{}, boost *float64) {
+func (n *Node) Term(field string, value interface{}, boost *float64) *Node {
 	childNode := n.appendOrSetChildNode(kKeywordTerm)
 
 	leaf := value
@@ -22,9 +22,10 @@ func (n *Node) Term(field string, value interface{}, boost *float64) {
 	childNode.nodeMap = nodeMapT{field: &Node{
 		leaf: leaf,
 	}}
+	return childNode
 }
 
-func (n *Node) Terms(field string, value interface{}, boost *float64) {
+func (n *Node) Terms(field string, value interface{}, boost *float64) *Node {
 	childNode := n.appendOrSetChildNode(kKeywordTerms)
 
 	childNode.nodeMap = nodeMapT{
@@ -34,4 +35,5 @@ func (n *Node) Terms(field string, value interface{}, boost *float64) {
 	if boost != nil {
 		childNode.nodeMap[kKeywordBoost] = &Node{leaf: *boost}
 	}
+	return childNode
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

There was an issue where it was possible for the policy coordinator to get stuck because the leader election happened at the same time the coordinator was starting. It was possible that pushing onto the coordinator channel in `Run` would block forever because `Update` was called before the `Run` could start the `for` loop. This removes that logic and removes the requirement of a buffered channel.

There was also an issue where the `QueryLatestPolicies` would only return the first 10 policies. If you had more than 10 policies the 10+ where never picked up by Fleet Server. This increases the size to the maximum amount of 10000.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So policies will pass through the coordinator and be rolled out to Elastic Agents.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #176
