### PR TITLE
Cherry-pick #171 to 7.x: Increase the monitor throughput: increase the default fetch size, make it configurable.

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -496,7 +496,7 @@ func (f *FleetServer) runServer(ctx context.Context, cfg *config.Config) (err er
 	g, ctx := errgroup.WithContext(ctx)
 
 	// Coordinator policy monitor
-	pim, err := monitor.New(dl.FleetPolicies, es)
+	pim, err := monitor.New(dl.FleetPolicies, es, monitor.WithFetchSize(cfg.Inputs[0].Monitor.FetchSize))
 	if err != nil {
 		return err
 	}
@@ -518,8 +518,7 @@ func (f *FleetServer) runServer(ctx context.Context, cfg *config.Config) (err er
 	var ad *action.Dispatcher
 	var tr *action.TokenResolver
 
-	// Behind the feature flag
-	am, err = monitor.NewSimple(dl.FleetActions, es, monitor.WithExpiration(true))
+	am, err = monitor.NewSimple(dl.FleetActions, es, monitor.WithExpiration(true), monitor.WithFetchSize(cfg.Inputs[0].Monitor.FetchSize))
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -65,6 +65,9 @@ func TestConfig(t *testing.T) {
 							NumCounters: defaultCacheNumCounters,
 							MaxCost:     defaultCacheMaxCost,
 						},
+						Monitor: Monitor{
+							FetchSize: defaultFetchSize,
+						},
 					},
 				},
 				Logging: Logging{
@@ -124,6 +127,9 @@ func TestConfig(t *testing.T) {
 							NumCounters: defaultCacheNumCounters,
 							MaxCost:     defaultCacheMaxCost,
 						},
+						Monitor: Monitor{
+							FetchSize: defaultFetchSize,
+						},
 					},
 				},
 				Logging: Logging{
@@ -181,6 +187,9 @@ func TestConfig(t *testing.T) {
 							NumCounters: defaultCacheNumCounters,
 							MaxCost:     defaultCacheMaxCost,
 						},
+						Monitor: Monitor{
+							FetchSize: defaultFetchSize,
+						},
 					},
 				},
 				Logging: Logging{
@@ -237,6 +246,9 @@ func TestConfig(t *testing.T) {
 						Cache: Cache{
 							NumCounters: defaultCacheNumCounters,
 							MaxCost:     defaultCacheMaxCost,
+						},
+						Monitor: Monitor{
+							FetchSize: defaultFetchSize,
 						},
 					},
 				},

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -88,10 +88,11 @@ func (c *Server) BindAddress() string {
 
 // Input is the input defined by Agent to run Fleet Server.
 type Input struct {
-	Type   string `config:"type"`
-	Policy Policy `config:"policy"`
-	Server Server `config:"server"`
-	Cache  Cache  `config:"cache"`
+	Type    string  `config:"type"`
+	Policy  Policy  `config:"policy"`
+	Server  Server  `config:"server"`
+	Cache   Cache   `config:"cache"`
+	Monitor Monitor `config:"monitor"`
 }
 
 // InitDefaults initializes the defaults for the configuration.
@@ -99,6 +100,7 @@ func (c *Input) InitDefaults() {
 	c.Type = "fleet-server"
 	c.Server.InitDefaults()
 	c.Cache.InitDefaults()
+	c.Monitor.InitDefaults()
 }
 
 // Validate ensures that the configuration is valid.

--- a/internal/pkg/config/monitor.go
+++ b/internal/pkg/config/monitor.go
@@ -1,0 +1,17 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package config
+
+const (
+	defaultFetchSize = 1000
+)
+
+type Monitor struct {
+	FetchSize int `config:"fetch_size"`
+}
+
+func (m *Monitor) InitDefaults() {
+	m.FetchSize = defaultFetchSize
+}


### PR DESCRIPTION
Cherry-pick of PR #171 to 7.x branch. Original message: 

## What does this PR do?

Increases the monitor throughput:

* Increase the monitor fetch size to 1000 by default, the max number of documents fetched at once.
* Makes the monitor fetch size configurable.
* Decreased the pause between fetches from 50ms to 10ms.

## Why is it important?

Tuning of the throughput.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

