### PR TITLE
Implement support for API Key metadata

### DIFF
--- a/cmd/fleet/handleEnroll.go
+++ b/cmd/fleet/handleEnroll.go
@@ -293,12 +293,12 @@ func createFleetAgent(ctx context.Context, bulker bulk.Bulk, id string, agent mo
 }
 
 func generateAccessApiKey(ctx context.Context, client *elasticsearch.Client, agentId string) (*apikey.ApiKey, error) {
-	return apikey.Create(ctx, client, agentId, "", []byte(kFleetAccessRolesJSON))
+	return apikey.Create(ctx, client, apikey.TypeAccess, agentId, agentId, "", []byte(kFleetAccessRolesJSON))
 }
 
 func generateOutputApiKey(ctx context.Context, client *elasticsearch.Client, agentId, outputName string, roles []byte) (*apikey.ApiKey, error) {
 	name := fmt.Sprintf("%s:%s", agentId, outputName)
-	return apikey.Create(ctx, client, name, "", roles)
+	return apikey.Create(ctx, client, apikey.TypeOutput, agentId, name, "", roles)
 }
 
 func (et *EnrollerT) fetchEnrollmentKeyRecord(ctx context.Context, id string) (*model.EnrollmentApiKey, error) {

--- a/cmd/fleet/handleEnroll.go
+++ b/cmd/fleet/handleEnroll.go
@@ -294,13 +294,21 @@ func createFleetAgent(ctx context.Context, bulker bulk.Bulk, id string, agent mo
 
 func generateAccessApiKey(ctx context.Context, client *elasticsearch.Client, agentId string) (*apikey.ApiKey, error) {
 	return apikey.Create(ctx, client, agentId, "", []byte(kFleetAccessRolesJSON),
-		apikey.WithAgentId(agentId), apikey.WithType(apikey.TypeAccess))
+		apikey.Metadata{
+			Application: apikey.FleetAgentApplication,
+			AgentId:     agentId,
+			Type:        apikey.TypeAccess.String(),
+		})
 }
 
 func generateOutputApiKey(ctx context.Context, client *elasticsearch.Client, agentId, outputName string, roles []byte) (*apikey.ApiKey, error) {
 	name := fmt.Sprintf("%s:%s", agentId, outputName)
 	return apikey.Create(ctx, client, name, "", roles,
-		apikey.WithAgentId(agentId), apikey.WithType(apikey.TypeOutput))
+		apikey.Metadata{
+			Application: apikey.FleetAgentApplication,
+			AgentId:     agentId,
+			Type:        apikey.TypeOutput.String(),
+		})
 }
 
 func (et *EnrollerT) fetchEnrollmentKeyRecord(ctx context.Context, id string) (*model.EnrollmentApiKey, error) {

--- a/cmd/fleet/handleEnroll.go
+++ b/cmd/fleet/handleEnroll.go
@@ -294,21 +294,13 @@ func createFleetAgent(ctx context.Context, bulker bulk.Bulk, id string, agent mo
 
 func generateAccessApiKey(ctx context.Context, client *elasticsearch.Client, agentId string) (*apikey.ApiKey, error) {
 	return apikey.Create(ctx, client, agentId, "", []byte(kFleetAccessRolesJSON),
-		apikey.Metadata{
-			Application: apikey.FleetAgentApplication,
-			AgentId:     agentId,
-			Type:        apikey.TypeAccess.String(),
-		})
+		apikey.NewMetadata(agentId, apikey.TypeAccess))
 }
 
 func generateOutputApiKey(ctx context.Context, client *elasticsearch.Client, agentId, outputName string, roles []byte) (*apikey.ApiKey, error) {
 	name := fmt.Sprintf("%s:%s", agentId, outputName)
 	return apikey.Create(ctx, client, name, "", roles,
-		apikey.Metadata{
-			Application: apikey.FleetAgentApplication,
-			AgentId:     agentId,
-			Type:        apikey.TypeOutput.String(),
-		})
+		apikey.NewMetadata(agentId, apikey.TypeOutput))
 }
 
 func (et *EnrollerT) fetchEnrollmentKeyRecord(ctx context.Context, id string) (*model.EnrollmentApiKey, error) {

--- a/cmd/fleet/handleEnroll.go
+++ b/cmd/fleet/handleEnroll.go
@@ -293,12 +293,14 @@ func createFleetAgent(ctx context.Context, bulker bulk.Bulk, id string, agent mo
 }
 
 func generateAccessApiKey(ctx context.Context, client *elasticsearch.Client, agentId string) (*apikey.ApiKey, error) {
-	return apikey.Create(ctx, client, apikey.TypeAccess, agentId, agentId, "", []byte(kFleetAccessRolesJSON))
+	return apikey.Create(ctx, client, agentId, "", []byte(kFleetAccessRolesJSON),
+		apikey.WithAgentId(agentId), apikey.WithType(apikey.TypeAccess))
 }
 
 func generateOutputApiKey(ctx context.Context, client *elasticsearch.Client, agentId, outputName string, roles []byte) (*apikey.ApiKey, error) {
 	name := fmt.Sprintf("%s:%s", agentId, outputName)
-	return apikey.Create(ctx, client, apikey.TypeOutput, agentId, name, "", roles)
+	return apikey.Create(ctx, client, name, "", roles,
+		apikey.WithAgentId(agentId), apikey.WithType(apikey.TypeOutput))
 }
 
 func (et *EnrollerT) fetchEnrollmentKeyRecord(ctx context.Context, id string) (*model.EnrollmentApiKey, error) {

--- a/internal/pkg/apikey/apikey.go
+++ b/internal/pkg/apikey/apikey.go
@@ -22,6 +22,7 @@ var (
 	ErrMalformedHeader = errors.New("malformed authorization header")
 	ErrMalformedToken  = errors.New("malformed token")
 	ErrInvalidToken    = errors.New("token not valid utf8")
+	ErrApiKeyNotFound  = errors.New("api key not found")
 )
 
 var AuthKey = http.CanonicalHeaderKey("Authorization")

--- a/internal/pkg/apikey/apikey_integration_test.go
+++ b/internal/pkg/apikey/apikey_integration_test.go
@@ -39,7 +39,8 @@ func TestCreateApiKeyWithMetadata(t *testing.T) {
 	// Create the key
 	agentId := uuid.Must(uuid.NewV4()).String()
 	name := uuid.Must(uuid.NewV4()).String()
-	akey, err := Create(ctx, bulker.Client(), TypeAccess, agentId, name, "", []byte(testFleetRoles))
+	akey, err := Create(ctx, bulker.Client(), name, "", []byte(testFleetRoles),
+		WithAgentId(agentId), WithType(TypeAccess))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pkg/apikey/apikey_integration_test.go
+++ b/internal/pkg/apikey/apikey_integration_test.go
@@ -1,0 +1,78 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build integration
+
+package apikey
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	ftesting "github.com/elastic/fleet-server/v7/internal/pkg/testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/google/go-cmp/cmp"
+)
+
+const testFleetRoles = `
+{
+	"fleet-apikey-access": {
+		"cluster": [],
+		"applications": [{
+			"application": ".fleet",
+			"privileges": ["no-privileges"],
+			"resources": ["*"]
+		}]
+	}
+}
+`
+
+func TestCreateApiKeyWithMetadata(t *testing.T) {
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+
+	bulker := ftesting.SetupBulk(ctx, t)
+
+	// Create the key
+	agentId := uuid.Must(uuid.NewV4()).String()
+	name := uuid.Must(uuid.NewV4()).String()
+	akey, err := Create(ctx, bulker.Client(), TypeAccess, agentId, name, "", []byte(testFleetRoles))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get the key and verify that metadata was saved correctly
+	aKeyMeta, err := Get(ctx, bulker.Client(), akey.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	diff := cmp.Diff(fleetAgent, aKeyMeta.Metadata.Application)
+	if diff != "" {
+		t.Error(diff)
+	}
+
+	diff = cmp.Diff(fleetAgent, aKeyMeta.Metadata.Application)
+	if diff != "" {
+		t.Error(diff)
+	}
+
+	diff = cmp.Diff(agentId, aKeyMeta.Metadata.AgentId)
+	if diff != "" {
+		t.Error(diff)
+	}
+
+	diff = cmp.Diff(TypeAccess.String(), aKeyMeta.Metadata.Type)
+	if diff != "" {
+		t.Error(diff)
+	}
+
+	// Try to get the key that doesn't exists, expect ErrApiKeyNotFound
+	aKeyMeta, err = Get(ctx, bulker.Client(), "0000000000000")
+	if !errors.Is(err, ErrApiKeyNotFound) {
+		t.Errorf("Unexpected error type: %v", err)
+	}
+}

--- a/internal/pkg/apikey/apikey_integration_test.go
+++ b/internal/pkg/apikey/apikey_integration_test.go
@@ -40,11 +40,7 @@ func TestCreateApiKeyWithMetadata(t *testing.T) {
 	agentId := uuid.Must(uuid.NewV4()).String()
 	name := uuid.Must(uuid.NewV4()).String()
 	akey, err := Create(ctx, bulker.Client(), name, "", []byte(testFleetRoles),
-		Metadata{
-			Application: FleetAgentApplication,
-			AgentId:     agentId,
-			Type:        TypeAccess.String(),
-		})
+		NewMetadata(agentId, TypeAccess))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +51,12 @@ func TestCreateApiKeyWithMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	diff := cmp.Diff(FleetAgentApplication, aKeyMeta.Metadata.Application)
+	diff := cmp.Diff(ManagedByFleetServer, aKeyMeta.Metadata.ManagedBy)
+	if diff != "" {
+		t.Error(diff)
+	}
+
+	diff = cmp.Diff(true, aKeyMeta.Metadata.Managed)
 	if diff != "" {
 		t.Error(diff)
 	}

--- a/internal/pkg/apikey/apikey_integration_test.go
+++ b/internal/pkg/apikey/apikey_integration_test.go
@@ -40,7 +40,11 @@ func TestCreateApiKeyWithMetadata(t *testing.T) {
 	agentId := uuid.Must(uuid.NewV4()).String()
 	name := uuid.Must(uuid.NewV4()).String()
 	akey, err := Create(ctx, bulker.Client(), name, "", []byte(testFleetRoles),
-		WithAgentId(agentId), WithType(TypeAccess))
+		Metadata{
+			Application: FleetAgentApplication,
+			AgentId:     agentId,
+			Type:        TypeAccess.String(),
+		})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,12 +55,7 @@ func TestCreateApiKeyWithMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	diff := cmp.Diff(fleetAgent, aKeyMeta.Metadata.Application)
-	if diff != "" {
-		t.Error(diff)
-	}
-
-	diff = cmp.Diff(fleetAgent, aKeyMeta.Metadata.Application)
+	diff := cmp.Diff(FleetAgentApplication, aKeyMeta.Metadata.Application)
 	if diff != "" {
 		t.Error(diff)
 	}

--- a/internal/pkg/apikey/apikey_test.go
+++ b/internal/pkg/apikey/apikey_test.go
@@ -2,12 +2,15 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+// +build !integration
+
 package apikey
 
 import (
 	"encoding/base64"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMonitorLeadership(t *testing.T) {

--- a/internal/pkg/apikey/create.go
+++ b/internal/pkg/apikey/create.go
@@ -14,24 +14,17 @@ import (
 	"github.com/elastic/go-elasticsearch/v8/esapi"
 )
 
-func Create(ctx context.Context, client *elasticsearch.Client, name, ttl string, roles []byte, metaopts ...MetadataFunc) (*ApiKey, error) {
-
-	metadata := NewMetadata()
-
-	for _, opt := range metaopts {
-		opt(&metadata)
-	}
-
+func Create(ctx context.Context, client *elasticsearch.Client, name, ttl string, roles []byte, meta interface{}) (*ApiKey, error) {
 	payload := struct {
 		Name       string          `json:"name,omitempty"`
 		Expiration string          `json:"expiration,omitempty"`
 		Roles      json.RawMessage `json:"role_descriptors,omitempty"`
-		Metadata   Metadata        `json:"metadata"`
+		Metadata   interface{}     `json:"metadata"`
 	}{
 		Name:       name,
 		Expiration: ttl,
 		Roles:      roles,
-		Metadata:   metadata,
+		Metadata:   meta,
 	}
 
 	body, err := json.Marshal(&payload)

--- a/internal/pkg/apikey/get.go
+++ b/internal/pkg/apikey/get.go
@@ -1,0 +1,66 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package apikey
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/elastic/go-elasticsearch/v8/esapi"
+)
+
+type ApiKeyMetadata struct {
+	Id       string
+	Metadata Metadata
+}
+
+func Get(ctx context.Context, client *elasticsearch.Client, id string) (apiKey ApiKeyMetadata, err error) {
+
+	opts := []func(*esapi.SecurityGetAPIKeyRequest){
+		client.Security.GetAPIKey.WithContext(ctx),
+		client.Security.GetAPIKey.WithID(id),
+	}
+
+	res, err := client.Security.GetAPIKey(
+		opts...,
+	)
+
+	if err != nil {
+		return
+	}
+
+	defer res.Body.Close()
+
+	if res.IsError() {
+		return apiKey, fmt.Errorf("fail GetAPIKey: %s, %w", res.String(), ErrApiKeyNotFound)
+	}
+
+	type APIKeyResponse struct {
+		Id       string   `json:"id"`
+		Metadata Metadata `json:"metadata"`
+	}
+	type GetAPIKeyResponse struct {
+		ApiKeys []APIKeyResponse `json:"api_keys"`
+	}
+
+	var resp GetAPIKeyResponse
+	d := json.NewDecoder(res.Body)
+	if err = d.Decode(&resp); err != nil {
+		return
+	}
+
+	if len(resp.ApiKeys) == 0 {
+		return apiKey, ErrApiKeyNotFound
+	}
+
+	first := resp.ApiKeys[0]
+
+	return ApiKeyMetadata{
+		Id:       first.Id,
+		Metadata: first.Metadata,
+	}, nil
+}

--- a/internal/pkg/apikey/metadata.go
+++ b/internal/pkg/apikey/metadata.go
@@ -1,0 +1,44 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package apikey
+
+const fleetAgent = "fleet-agent"
+
+type Type int
+
+const (
+	TypeAccess Type = iota
+	TypeOutput
+)
+
+func (t Type) String() string {
+	return []string{"access", "output"}[t]
+}
+
+type Metadata struct {
+	Application string `json:"application"`
+	AgentId     string `json:"agent_id"`
+	Type        string `json:"type"`
+}
+
+func NewMetadata() Metadata {
+	return Metadata{
+		Application: fleetAgent,
+	}
+}
+
+type MetadataFunc func(m *Metadata)
+
+func WithAgentId(agentId string) MetadataFunc {
+	return func(m *Metadata) {
+		m.AgentId = agentId
+	}
+}
+
+func WithType(t Type) MetadataFunc {
+	return func(m *Metadata) {
+		m.Type = t.String()
+	}
+}

--- a/internal/pkg/apikey/metadata.go
+++ b/internal/pkg/apikey/metadata.go
@@ -18,7 +18,7 @@ func (t Type) String() string {
 }
 
 type Metadata struct {
-	Application string `json:"application"`
-	AgentId     string `json:"agent_id"`
-	Type        string `json:"type"`
+	Application string `json:"application,omitempty"`
+	AgentId     string `json:"agent_id,omitempty"`
+	Type        string `json:"type,omitempty"`
 }

--- a/internal/pkg/apikey/metadata.go
+++ b/internal/pkg/apikey/metadata.go
@@ -4,7 +4,7 @@
 
 package apikey
 
-const fleetAgent = "fleet-agent"
+const FleetAgentApplication = "fleet-agent"
 
 type Type int
 
@@ -21,24 +21,4 @@ type Metadata struct {
 	Application string `json:"application"`
 	AgentId     string `json:"agent_id"`
 	Type        string `json:"type"`
-}
-
-func NewMetadata() Metadata {
-	return Metadata{
-		Application: fleetAgent,
-	}
-}
-
-type MetadataFunc func(m *Metadata)
-
-func WithAgentId(agentId string) MetadataFunc {
-	return func(m *Metadata) {
-		m.AgentId = agentId
-	}
-}
-
-func WithType(t Type) MetadataFunc {
-	return func(m *Metadata) {
-		m.Type = t.String()
-	}
 }

--- a/internal/pkg/apikey/metadata.go
+++ b/internal/pkg/apikey/metadata.go
@@ -4,7 +4,7 @@
 
 package apikey
 
-const FleetAgentApplication = "fleet-agent"
+const ManagedByFleetServer = "fleet-server"
 
 type Type int
 
@@ -18,7 +18,17 @@ func (t Type) String() string {
 }
 
 type Metadata struct {
-	Application string `json:"application,omitempty"`
-	AgentId     string `json:"agent_id,omitempty"`
-	Type        string `json:"type,omitempty"`
+	AgentId   string `json:"agent_id,omitempty"`
+	Managed   bool   `json:"managed,omitempty"`
+	ManagedBy string `json:"managed_by,omitempty"`
+	Type      string `json:"type,omitempty"`
+}
+
+func NewMetadata(agentId string, typ Type) Metadata {
+	return Metadata{
+		AgentId:   agentId,
+		Managed:   true,
+		ManagedBy: ManagedByFleetServer,
+		Type:      typ.String(),
+	}
 }


### PR DESCRIPTION
## What does this PR do?

Adds metadata to they api keys.
```
      "metadata" : {
        "application" : "fleet-agent",
        "agent_id" : "887f1001-5dc8-45e2-aa61-413123c8013b",
        "type" : "access"
      }
```

Not sure about the ```type``` field,  wanted to capture the possible values ```output``` and ```access```.
Maybe a better name? or can remove if not needed. @scunningham @ruflin 

P.S. If you are having issues running integration tests locally,  try delete the elasticsearch docker image and pull the latest one that implements the new api.

## Why is it important?

Adopting new ES Api https://github.com/elastic/elasticsearch/issues/48182 for 7.13.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues

- Closes https://github.com/elastic/fleet-server/issues/193

## Screenshots

<img width="611" alt="Screen Shot 2021-03-31 at 12 55 03 PM" src="https://user-images.githubusercontent.com/872351/113190522-61154e00-922a-11eb-9bce-47c541d73516.png">
