### PR TITLE
Move to less aggressive bulk queue preallocation size by default.

### DIFF
--- a/internal/pkg/bulk/bulk.go
+++ b/internal/pkg/bulk/bulk.go
@@ -82,6 +82,7 @@ const (
 	defaultFlushThresholdCnt = 32768
 	defaultFlushThresholdSz  = 1024 * 1024 * 10
 	defaultMaxPending        = 32
+	defaultQueuePrealloc     = 64
 )
 
 func InitES(ctx context.Context, cfg *config.Config, opts ...BulkOpt) (*elasticsearch.Client, Bulk, error) {
@@ -119,6 +120,7 @@ func (b *Bulker) parseBulkOpts(opts ...BulkOpt) bulkOptT {
 		flushThresholdCnt: defaultFlushThresholdCnt,
 		flushThresholdSz:  defaultFlushThresholdSz,
 		maxPending:        defaultMaxPending,
+		queuePrealloc:     defaultQueuePrealloc,
 	}
 
 	for _, f := range opts {
@@ -182,7 +184,7 @@ func (b *Bulker) Run(ctx context.Context, opts ...BulkOpt) error {
 
 		queues = append(queues, &queueT{
 			action: action,
-			queue:  make([]bulkT, 0, bopts.flushThresholdCnt),
+			queue:  make([]bulkT, 0, bopts.queuePrealloc),
 		})
 	}
 
@@ -198,7 +200,7 @@ func (b *Bulker) Run(ctx context.Context, opts ...BulkOpt) error {
 				}
 
 				q.pending = 0
-				q.queue = make([]bulkT, 0, bopts.flushThresholdCnt)
+				q.queue = make([]bulkT, 0, bopts.queuePrealloc)
 			}
 		}
 

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -31,6 +31,7 @@ type bulkOptT struct {
 	flushThresholdCnt int
 	flushThresholdSz  int
 	maxPending        int
+	queuePrealloc     int
 }
 
 type BulkOpt func(*bulkOptT)


### PR DESCRIPTION
The larger queues are more efficient at high scale, but are way overkill on small systems.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

The memory usage at bootstrap and at scale was large given the default settings.  Scale down the default and make configurable.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Provides smaller boot footprint for tiny containers.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x ] My code follows the style guidelines of this project
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] I have made corresponding change to the default configuration files
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

