### PR TITLE
Add user_id to .fleet-actions schema

### DIFF
--- a/internal/pkg/es/mapping.go
+++ b/internal/pkg/es/mapping.go
@@ -32,6 +32,9 @@ const (
 		},
 		"type": {
 			"type": "keyword"
+		},
+		"user_id": {
+			"type": "keyword"
 		}		
 	}
 }`

--- a/internal/pkg/model/schema.go
+++ b/internal/pkg/model/schema.go
@@ -53,6 +53,9 @@ type Action struct {
 
 	// The action type. INPUT_ACTION is the value for the actions that suppose to be routed to the endpoints/beats.
 	Type string `json:"type,omitempty"`
+
+	// The ID of the user who created the action.
+	UserId string `json:"user_id,omitempty"`
 }
 
 // ActionData The opaque payload.

--- a/model/schema.json
+++ b/model/schema.json
@@ -38,6 +38,10 @@
           "description": "The input type the actions should be routed to.",
           "type": "string"
         },
+        "user_id": {
+          "description": "The ID of the user who created the action.",
+          "type": "string"
+        },
         "agents": {
           "description": "The Agent IDs the action is intended for. No support for json.RawMessage with the current generator. Could be useful to lazy parse the agent ids",
           "type": "array",


### PR DESCRIPTION
## What does this PR do?

Add user_id to .fleet-actions schema, to reflect the addition of the field to the index in https://github.com/elastic/kibana/pull/95935

