### PR TITLE
Add optional gzip compression support on check-in response.

### DIFF
--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -60,6 +60,7 @@ func TestConfig(t *testing.T) {
 								Enabled: false,
 								Bind:    "localhost:6060",
 							},
+							CompressionLevel: 1,
 						},
 						Cache: Cache{
 							NumCounters: defaultCacheNumCounters,
@@ -122,6 +123,7 @@ func TestConfig(t *testing.T) {
 								Enabled: false,
 								Bind:    "localhost:6060",
 							},
+							CompressionLevel: 1,
 						},
 						Cache: Cache{
 							NumCounters: defaultCacheNumCounters,
@@ -182,6 +184,7 @@ func TestConfig(t *testing.T) {
 								Enabled: false,
 								Bind:    "localhost:6060",
 							},
+							CompressionLevel: 1,
 						},
 						Cache: Cache{
 							NumCounters: defaultCacheNumCounters,
@@ -242,6 +245,7 @@ func TestConfig(t *testing.T) {
 								Enabled: false,
 								Bind:    "localhost:6060",
 							},
+							CompressionLevel: 1,
 						},
 						Cache: Cache{
 							NumCounters: defaultCacheNumCounters,

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -5,6 +5,7 @@
 package config
 
 import (
+	"compress/flate"
 	"fmt"
 	"strings"
 	"time"
@@ -62,6 +63,7 @@ type Server struct {
 	MaxConnections    int               `config:"max_connections"`
 	MaxEnrollPending  int64             `config:"max_enroll_pending"`
 	Profile           ServerProfile     `config:"profile"`
+	CompressionLevel  int               `config:"compression_level"`
 }
 
 // InitDefaults initializes the defaults for the configuration.
@@ -74,6 +76,7 @@ func (c *Server) InitDefaults() {
 	c.RateLimitInterval = 5 * time.Millisecond
 	c.MaxConnections = 0 // no limit
 	c.MaxEnrollPending = 64
+	c.CompressionLevel = flate.BestSpeed
 	c.Profile.InitDefaults()
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
Adds optional gzip support if client asks for it.


## Why is it important?

Option to minimize response size.  Defaults to best speed.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ x] My code follows the style guidelines of this project
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] I have made corresponding change to the default configuration files
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally



## Related issues

- Closes https://github.com/elastic/fleet-server/issues/108



## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

[scunningham@sgc-docker ~]$ cat /tmp/fleet.log   | grep response
{"level":"trace","level":9,"time":"Apr  5 17:02:32.109433","message":"Compressing policy response"}