### PR TITLE
Update graceful handling for missing indices to accommodate the new fleet system indices plugin

### DIFF
--- a/internal/pkg/dl/actions.go
+++ b/internal/pkg/dl/actions.go
@@ -6,9 +6,11 @@ package dl
 
 import (
 	"context"
+	"errors"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/dsl"
+	"github.com/elastic/fleet-server/v7/internal/pkg/es"
 	"github.com/elastic/fleet-server/v7/internal/pkg/model"
 )
 
@@ -83,6 +85,9 @@ func FindActions(ctx context.Context, bulker bulk.Bulk, tmpl *dsl.Tmpl, params m
 func findActions(ctx context.Context, bulker bulk.Bulk, tmpl *dsl.Tmpl, index string, params map[string]interface{}) ([]model.Action, error) {
 	res, err := Search(ctx, bulker, tmpl, index, params)
 	if err != nil {
+		if errors.Is(err, es.ErrIndexNotFound) {
+			err = nil
+		}
 		return nil, err
 	}
 

--- a/internal/pkg/dl/actions.go
+++ b/internal/pkg/dl/actions.go
@@ -12,6 +12,7 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/dsl"
 	"github.com/elastic/fleet-server/v7/internal/pkg/es"
 	"github.com/elastic/fleet-server/v7/internal/pkg/model"
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -86,6 +87,7 @@ func findActions(ctx context.Context, bulker bulk.Bulk, tmpl *dsl.Tmpl, index st
 	res, err := Search(ctx, bulker, tmpl, index, params)
 	if err != nil {
 		if errors.Is(err, es.ErrIndexNotFound) {
+			log.Debug().Str("index", index).Msg(es.ErrIndexNotFound.Error())
 			err = nil
 		}
 		return nil, err

--- a/internal/pkg/dl/policies_leader.go
+++ b/internal/pkg/dl/policies_leader.go
@@ -15,6 +15,7 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/dsl"
 	"github.com/elastic/fleet-server/v7/internal/pkg/es"
 	"github.com/elastic/fleet-server/v7/internal/pkg/model"
+	"github.com/rs/zerolog/log"
 )
 
 var (
@@ -51,6 +52,7 @@ func SearchPolicyLeaders(ctx context.Context, bulker bulk.Bulk, ids []string, op
 	res, err := bulker.Search(ctx, []string{o.indexName}, data)
 	if err != nil {
 		if errors.Is(err, es.ErrIndexNotFound) {
+			log.Debug().Str("index", o.indexName).Msg(es.ErrIndexNotFound.Error())
 			err = nil
 		}
 		return

--- a/internal/pkg/dl/policies_leader.go
+++ b/internal/pkg/dl/policies_leader.go
@@ -7,12 +7,14 @@ package dl
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"sync"
+	"time"
+
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/dsl"
 	"github.com/elastic/fleet-server/v7/internal/pkg/es"
 	"github.com/elastic/fleet-server/v7/internal/pkg/model"
-	"sync"
-	"time"
 )
 
 var (
@@ -48,6 +50,9 @@ func SearchPolicyLeaders(ctx context.Context, bulker bulk.Bulk, ids []string, op
 	}
 	res, err := bulker.Search(ctx, []string{o.indexName}, data)
 	if err != nil {
+		if errors.Is(err, es.ErrIndexNotFound) {
+			err = nil
+		}
 		return
 	}
 


### PR DESCRIPTION
## What does this PR do?

Graceful handling for the case where the indices are not found.

Tested full stack with ES system indices plugin PR https://github.com/elastic/elasticsearch/pull/70689
and kibana update for this https://github.com/elastic/kibana/pull/96338 working end to end with osquerybeat.
Found issues where fleet server doesn't handle the case where the index doesn't exists.

The ES system indices plugin no longer creates the indices. The indices are now created when the first document is pushed, and the fleet server doesn't handle the missing index case gracefully (as some point before it did).

This change can be merged before the related tickets.

## Why is it important?

This is important in order to adopt the fleet system indices plugin.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

