### PR TITLE
[mergify] assign the original author

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,17 +15,23 @@ pull_request_rules:
             ```
   - name: backport patches to 7.x branch
     conditions:
+      - merged
       - base=master
       - label=v7.13.0
     actions:
+      assignees:
+          - "{{ author }}"
       backport:
         branches:
           - "7.x"
   - name: backport patches to 7.12 branch
     conditions:
+      - merged
       - base=master
       - label=v7.12.0
     actions:
+      assignees:
+          - "{{ author }}"
       backport:
         branches:
           - "7.12"


### PR DESCRIPTION
## What does this PR do?

`Mergify` now supports the original author assignation. https://docs.mergify.io/actions/backport/#options

Besides, ensure the mergify backport GitHub commit status are not shown as waiting, for such, let's use the `merged` condition

## Why is it important?

To help with the tracking when mergify creates backports