### PR TITLE
Fix coordinator goroutine tight loop on cancelled context

### DIFF
--- a/internal/pkg/coordinator/monitor.go
+++ b/internal/pkg/coordinator/monitor.go
@@ -372,6 +372,8 @@ func runCoordinator(ctx context.Context, cord Coordinator, l zerolog.Logger, d t
 			if sleep.WithContext(ctx, d) == context.Canceled {
 				break
 			}
+		} else {
+			break
 		}
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Fixes coordinator goroutine tight loop on cancelled context.

## Why is it important?

Addresses https://github.com/elastic/fleet-server/issues/220

## Checklist

- [x] My code follows the style guidelines of this project

## Related issues

- Closes https://github.com/elastic/fleet-server/issues/220

