### PR TITLE
Update fleet server monitor logging

### DIFF
--- a/internal/pkg/monitor/monitor.go
+++ b/internal/pkg/monitor/monitor.go
@@ -237,14 +237,14 @@ func (m *simpleMonitorT) Run(ctx context.Context) (err error) {
 		if err != nil {
 			if errors.Is(err, es.ErrIndexNotFound) {
 				// Wait until created
-				m.log.Info().Msgf("index not found, try again in %v", retryDelay)
+				m.log.Debug().Msgf("index not found, poll again in %v", retryDelay)
 			} else if errors.Is(err, es.ErrTimeout) {
 				// Timed out, wait again
-				m.log.Debug().Msg("wait global checkpoints advance, timeout, wait again")
+				m.log.Debug().Msg("timeout on global checkpoints advance, poll again")
 				continue
 			} else {
 				// Log the error and keep trying
-				m.log.Error().Err(err).Msg("failed waiting global checkpoints advance")
+				m.log.Error().Err(err).Msg("failed on waiting for global checkpoints advance")
 			}
 
 			// Delay next attempt


### PR DESCRIPTION
## What does this PR do?

Changed the fleet server monitor logging message level to debug for when the index is not found.

Improved a couple of more logging messages in the same scope.

## Why is it important?

Addresses https://github.com/elastic/fleet-server/issues/246

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas


## Related issues

- Closes https://github.com/elastic/fleet-server/issues/246

## Screenshots

proof that logging is at debug level:
<img width="1304" alt="Screen Shot 2021-04-19 at 7 55 37 AM" src="https://user-images.githubusercontent.com/872351/115233076-78d34a00-a0e5-11eb-944b-e8772c384728.png">

