### PR TITLE
Validate Elasticsearch version for compatibility

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/reload"
 	"github.com/elastic/fleet-server/v7/internal/pkg/signal"
 	"github.com/elastic/fleet-server/v7/internal/pkg/status"
+	"github.com/elastic/fleet-server/v7/internal/pkg/ver"
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
@@ -509,6 +510,12 @@ func (f *FleetServer) runServer(ctx context.Context, cfg *config.Config) (err er
 	esCli, bulker, err := bulk.InitES(bulkCtx, cfg)
 	if err != nil {
 		return err
+	}
+
+	// Check version compatibility with Elasticsearch
+	err = ver.CheckCompatibility(ctx, esCli, f.ver)
+	if err != nil {
+		return fmt.Errorf("failed version compatibility check with elasticsearch: %w", err)
 	}
 
 	// Monitoring es client, longer timeout, no retries

--- a/internal/pkg/es/info.go
+++ b/internal/pkg/es/info.go
@@ -1,0 +1,50 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package es
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/elastic/go-elasticsearch/v8"
+)
+
+type versionInfo struct {
+	Number string `json:"number"`
+}
+
+type infoResponse struct {
+	Version versionInfo `json:"version"`
+	Error   ErrorT      `json:"error,omitempty"`
+}
+
+func FetchESVersion(ctx context.Context, esCli *elasticsearch.Client) (version string, err error) {
+	res, err := esCli.Info(
+		esCli.Info.WithContext(ctx),
+	)
+
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+
+	var sres infoResponse
+
+	err = json.NewDecoder(res.Body).Decode(&sres)
+	if err != nil {
+		return
+	}
+
+	// Check error
+	err = TranslateError(res.StatusCode, sres.Error)
+	if err != nil {
+		return
+	}
+
+	verStr := strings.TrimSpace(strings.TrimSuffix(strings.ToLower(sres.Version.Number), "-snapshot"))
+
+	return verStr, nil
+}

--- a/internal/pkg/ver/check.go
+++ b/internal/pkg/ver/check.go
@@ -1,0 +1,87 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package ver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	esh "github.com/elastic/fleet-server/v7/internal/pkg/es"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/hashicorp/go-version"
+	"github.com/rs/zerolog/log"
+)
+
+var (
+	ErrUnsupportedVersion = errors.New("unsupported version")
+	ErrMalformedVersion   = errors.New("malformed version")
+)
+
+func CheckCompatibility(ctx context.Context, esCli *elasticsearch.Client, fleetVersion string) error {
+	log.Debug().Str("fleet_version", fleetVersion).Msg("check version compatibility with elasticsearch")
+
+	esVersion, err := esh.FetchESVersion(ctx, esCli)
+
+	if err != nil {
+		log.Error().Err(err).Msg("failed to fetch elasticsearch version")
+		return err
+	}
+	log.Debug().Str("elasticsearch_version", esVersion).Msg("fetched elasticsearch version")
+
+	return checkCompatibility(fleetVersion, esVersion)
+}
+
+func checkCompatibility(fleetVersion, esVersion string) error {
+	verConst, err := buildVersionConstraint(fleetVersion)
+	if err != nil {
+		log.Error().Err(err).Str("fleet_version", fleetVersion).Msg("failed to build constraint")
+		return err
+	}
+
+	ver, err := parseVersion(esVersion)
+	if err != nil {
+		return err
+	}
+
+	if !verConst.Check(ver) {
+		log.Error().Err(ErrUnsupportedVersion).Msg("failed elasticsearch version check")
+		return ErrUnsupportedVersion
+	}
+	log.Info().Str("fleet_version", fleetVersion).Str("elasticsearch_version", esVersion).Msg("versions are compatible")
+	return nil
+}
+
+func buildVersionConstraint(fleetVersion string) (version.Constraints, error) {
+	ver, err := parseVersion(fleetVersion)
+	if err != nil {
+		return nil, err
+	}
+	return version.NewConstraint(fmt.Sprintf(">= %s", minimizePatch(ver)))
+}
+
+func minimizePatch(ver *version.Version) string {
+	segments := ver.Segments()
+	if len(segments) > 2 {
+		segments = segments[:2]
+	}
+	segments = append(segments, 0)
+	segStrs := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		segStrs = append(segStrs, strconv.Itoa(segment))
+	}
+	return strings.Join(segStrs, ".")
+}
+
+func parseVersion(sver string) (*version.Version, error) {
+	ver, err := version.NewVersion(sver)
+	if err != nil {
+		return nil, fmt.Errorf("%v: %w", err, ErrMalformedVersion)
+	}
+	return ver, nil
+}

--- a/internal/pkg/ver/check_test.go
+++ b/internal/pkg/ver/check_test.go
@@ -1,0 +1,92 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package ver
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCheckCompatibilityInternal(t *testing.T) {
+	tests := []struct {
+		name         string
+		fleetVersion string
+		esVersion    string
+		err          error
+	}{
+		{
+			name:         "empty fleet and elasticsearch version",
+			fleetVersion: "",
+			esVersion:    "",
+			err:          ErrMalformedVersion,
+		},
+		{
+			name:         "empty fleet version",
+			fleetVersion: "",
+			esVersion:    "8.0.0",
+			err:          ErrMalformedVersion,
+		},
+		{
+			name:         "empty elasticsearch version",
+			fleetVersion: "7.13",
+			esVersion:    "",
+			err:          ErrMalformedVersion,
+		},
+		{
+			name:         "supported elasticsearch 713-713",
+			fleetVersion: "7.13.0",
+			esVersion:    "7.13.0",
+			err:          nil,
+		},
+		{
+			name:         "supported elasticsearch 7131-7132",
+			fleetVersion: "7.13.2",
+			esVersion:    "7.13.1",
+			err:          nil,
+		},
+		{
+			name:         "supported elasticsearch 713-714",
+			fleetVersion: "7.13.2",
+			esVersion:    "7.14.2",
+			err:          nil,
+		},
+		{
+			name:         "supported elasticsearch 715-800",
+			fleetVersion: "7.15.2",
+			esVersion:    "8.0.0",
+			err:          nil,
+		},
+		{
+			name:         "unsupported elasticsearch 714-713",
+			fleetVersion: "7.14.0",
+			esVersion:    "7.13.1",
+			err:          ErrUnsupportedVersion,
+		},
+		{
+			name:         "unsupported elasticsearch 800-718",
+			fleetVersion: "8.0.0",
+			esVersion:    "7.18.0",
+			err:          ErrUnsupportedVersion,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkCompatibility(tc.fleetVersion, tc.esVersion)
+			if tc.err != nil {
+				if err == nil {
+					t.Error("expected error")
+				} else {
+					if !errors.Is(err, tc.err) {
+						t.Errorf("unexpected error kind: %v", err)
+					}
+				}
+			} else {
+				if err != nil {
+					t.Error("unexpected error")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Adds validation for elasticsearch version, according to the spec https://github.com/elastic/fleet-server/issues/167#event-4612390369

## Why is it important?

This needs to be in 7.13 release.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues
- Closes https://github.com/elastic/fleet-server/issues/167

## Logs

```
{"log.level":"debug","fleet_version":"8.0.0","@timestamp":"2021-04-19T16:46:33.903Z","message":"check version compatibility with elasticsearch"}
{"log.level":"debug","elasticsearch_version":"8.0.0","@timestamp":"2021-04-19T16:46:33.903Z","message":"fetched elasticsearch version"}
{"log.level":"info","fleet_version":"8.0.0","elasticsearch_version":"8.0.0","@timestamp":"2021-04-19T16:46:33.903Z","message":"versions are compatible"}
```
