### PR TITLE
Wait on index when polling global checkpoints

### DIFF
--- a/internal/pkg/es/fleet_global_checkpoints.go
+++ b/internal/pkg/es/fleet_global_checkpoints.go
@@ -47,6 +47,7 @@ type GlobalCheckpointsRequest struct {
 
 	Index          string
 	WaitForAdvance *bool
+	WaitForIndex   *bool
 	Checkpoints    []int64
 	Timeout        time.Duration
 
@@ -75,6 +76,10 @@ func (r GlobalCheckpointsRequest) Do(ctx context.Context, transport esapi.Transp
 
 	if r.WaitForAdvance != nil {
 		params["wait_for_advance"] = strconv.FormatBool(*r.WaitForAdvance)
+	}
+
+	if r.WaitForIndex != nil {
+		params["wait_for_index"] = strconv.FormatBool(*r.WaitForIndex)
 	}
 
 	if len(r.Checkpoints) > 0 {
@@ -148,6 +153,12 @@ func (f GlobalCheckpoints) WithIndex(index string) func(*GlobalCheckpointsReques
 func (f GlobalCheckpoints) WithWaitForAdvance(v bool) func(*GlobalCheckpointsRequest) {
 	return func(r *GlobalCheckpointsRequest) {
 		r.WaitForAdvance = &v
+	}
+}
+
+func (f GlobalCheckpoints) WithWaitForIndex(v bool) func(*GlobalCheckpointsRequest) {
+	return func(r *GlobalCheckpointsRequest) {
+		r.WaitForIndex = &v
 	}
 }
 

--- a/internal/pkg/monitor/global_checkpoint.go
+++ b/internal/pkg/monitor/global_checkpoint.go
@@ -53,6 +53,7 @@ func waitCheckpointAdvance(ctx context.Context, es *elasticsearch.Client, index 
 		req.WithIndex(index),
 		req.WithCheckpoints(checkpoint),
 		req.WithWaitForAdvance(true),
+		req.WithWaitForIndex(true),
 		req.WithTimeout(to),
 	)
 


### PR DESCRIPTION
## What does this PR do?

Adopts the Elasticsearch polling API change that now handles the waiting on index if it doesn't exists.
https://github.com/elastic/elasticsearch/pull/71890

ATTN!!! This PR integration tests will fail until the Elasticsearch docker images are updated with the corresponding ES change. Merging it before the change will break fleet server for a lot of good people out there.

## Why is it important?

The Fleet Server would poll every 3 secs for each monitored index until it is created otherwise.
This change reduces the number of http requests the Fleet Server would have to do to detect the very document in the index and let Eleasticsearch handle the wait.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

