### PR TITLE
Add script to avoid race condition on updating policy metadata in age…

### DIFF
--- a/cmd/fleet/handleAck_test.go
+++ b/cmd/fleet/handleAck_test.go
@@ -1,0 +1,39 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package fleet
+
+import (
+	"testing"
+
+	"encoding/json"
+)
+
+func BenchmarkMakeUpdatePolicyBody(b *testing.B) {
+	b.ReportAllocs()
+
+	const policyId = "ed110be4-c2a0-42b8-adc0-94c2f0569207"
+	const newRev = 2
+	const coord = 1
+
+	for n := 0; n < b.N; n++ {
+		makeUpdatePolicyBody(policyId, newRev, coord)
+	}
+}
+
+func TestMakeUpdatePolicyBody(t *testing.T) {
+
+	const policyId = "ed110be4-c2a0-42b8-adc0-94c2f0569207"
+	const newRev = 2
+	const coord = 1
+
+	data := makeUpdatePolicyBody(policyId, newRev, coord)
+
+	var i interface{}
+	err := json.Unmarshal(data, &i)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/pkg/bulk/multi.go
+++ b/internal/pkg/bulk/multi.go
@@ -28,7 +28,7 @@ func (b *Bulker) multiWaitBulkAction(ctx context.Context, action Action, ops []B
 		var buf bytes.Buffer
 		buf.Grow(len(op.Body) + kSlop)
 
-		if err := b.writeBulkMeta(&buf, action, op.Index, op.Id); err != nil {
+		if err := b.writeBulkMeta(&buf, action, op.Index, op.Id, opt); err != nil {
 			return nil, err
 		}
 

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -12,7 +12,8 @@ import (
 // Transaction options
 
 type optionsT struct {
-	Refresh bool
+	Refresh         bool
+	RetryOnConflict int
 }
 
 type Opt func(*optionsT)
@@ -20,6 +21,12 @@ type Opt func(*optionsT)
 func WithRefresh() Opt {
 	return func(opt *optionsT) {
 		opt.Refresh = true
+	}
+}
+
+func WithRetryOnConflict(n int) Opt {
+	return func(opt *optionsT) {
+		opt.RetryOnConflict = n
 	}
 }
 


### PR DESCRIPTION
…nt record

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Works around a race condition where the policy that an agent is assigned to could change while updating the metadata related to the previous policy.

**NOTE** Not targeted for 7.13.

## Why is it important?

Without this change, an agent could end up with an inconsistent revision_id and/or coordinator_id on a newly assigned policy.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ x] My code follows the style guidelines of this project
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] I have made corresponding change to the default configuration files
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.



## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Assign a new policy to an agent.  Validate that the revision and the coordinator idx are set appropriately.
