### PR TITLE
mergify: Automerge only the backport

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -52,31 +52,11 @@ pull_request_rules:
           - "7.12"
         labels:
           - "backport"
-  - name: automatic merge for 7.x when CI passes
+  - name: automatic merge for 7\. branches when CI passes
     conditions:
       - check-success=fleet-server/pr-merge
       - check-success=CLA
-      - base=7.x
-      - label=backport
-    actions:
-      merge:
-        method: squash
-        strict: smart+fasttrack
-  - name: automatic merge for 7.13 when CI passes
-    conditions:
-      - check-success=fleet-server/pr-merge
-      - check-success=CLA
-      - base=7.13
-      - label=backport
-    actions:
-      merge:
-        method: squash
-        strict: smart+fasttrack
-  - name: automatic merge for 7.12 when CI passes
-    conditions:
-      - check-success=fleet-server/pr-merge
-      - check-success=CLA
-      - base=7.12
+      - base~=^7\.
       - label=backport
     actions:
       merge:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,6 +24,8 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "7.x"
+        labels:
+          - "backport"
   - name: backport patches to 7.13 branch
     conditions:
       - merged
@@ -35,6 +37,8 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "7.13"
+        labels:
+          - "backport"
   - name: backport patches to 7.12 branch
     conditions:
       - merged
@@ -46,11 +50,24 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "7.12"
+        labels:
+          - "backport"
   - name: automatic merge for 7.x when CI passes
     conditions:
       - check-success=fleet-server/pr-merge
       - check-success=CLA
       - base=7.x
+      - label=backport
+    actions:
+      merge:
+        method: squash
+        strict: smart+fasttrack
+  - name: automatic merge for 7.13 when CI passes
+    conditions:
+      - check-success=fleet-server/pr-merge
+      - check-success=CLA
+      - base=7.13
+      - label=backport
     actions:
       merge:
         method: squash
@@ -60,6 +77,7 @@ pull_request_rules:
       - check-success=fleet-server/pr-merge
       - check-success=CLA
       - base=7.12
+      - label=backport
     actions:
       merge:
         method: squash

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -58,6 +58,7 @@ pull_request_rules:
       - check-success=CLA
       - base~=^7\.
       - label=backport
+      - author=mergify[bot]
     actions:
       merge:
         method: squash


### PR DESCRIPTION
## What does this PR do?

1) Only automerge for those backports with the `backport` label and PR's author `mergify[bot]`
2) Backports will add the `backport` label to help with the auto-merge.

Simplify the rules with the `~=` regex pattern -> https://docs.mergify.io/conditions/#grammar

## Why is it important?

Automerge only the backport