### PR TITLE
Improve log message about degraded being okay during bootstrap.

### DIFF
--- a/internal/pkg/policy/self.go
+++ b/internal/pkg/policy/self.go
@@ -212,7 +212,7 @@ func (m *selfMonitorT) updateStatus(ctx context.Context) (proto.StateObserved_St
 	var payload map[string]interface{}
 	if m.fleet.Agent.ID == "" {
 		status = proto.StateObserved_DEGRADED
-		extendMsg = "; missing config fleet.agent.id"
+		extendMsg = "; missing config fleet.agent.id (expected during bootstrap process)"
 
 		// Elastic Agent has not been enrolled; Fleet Server passes back the enrollment token so the Elastic Agent
 		// can perform enrollment.

--- a/internal/pkg/policy/self_test.go
+++ b/internal/pkg/policy/self_test.go
@@ -262,7 +262,7 @@ func TestSelfMonitor_DefaultPolicy_Degraded(t *testing.T) {
 		if status != proto.StateObserved_DEGRADED {
 			return fmt.Errorf("should be reported as degraded; instead its %s", status)
 		}
-		if msg != "Running on default policy with Fleet Server integration; missing config fleet.agent.id" {
+		if msg != "Running on default policy with Fleet Server integration; missing config fleet.agent.id (expected during bootstrap process)" {
 			return fmt.Errorf("should be matching with default policy")
 		}
 		if payload == nil {
@@ -520,7 +520,7 @@ func TestSelfMonitor_SpecificPolicy_Degraded(t *testing.T) {
 		if status != proto.StateObserved_DEGRADED {
 			return fmt.Errorf("should be reported as degraded; instead its %s", status)
 		}
-		if msg != fmt.Sprintf("Running on policy with Fleet Server integration: %s; missing config fleet.agent.id", policyId) {
+		if msg != fmt.Sprintf("Running on policy with Fleet Server integration: %s; missing config fleet.agent.id (expected during bootstrap process)", policyId) {
 			return fmt.Errorf("should be matching with specific policy")
 		}
 		if payload == nil {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds context to the `missing config fleet.agent.id` so its clear that is okay during bootstrap.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So its not reported as an error by users.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
