### PR TITLE
[mergify] change title for the backports

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -26,6 +26,7 @@ pull_request_rules:
           - "7.x"
         labels:
           - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 7.13 branch
     conditions:
       - merged
@@ -39,6 +40,7 @@ pull_request_rules:
           - "7.13"
         labels:
           - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 7.12 branch
     conditions:
       - merged
@@ -52,6 +54,7 @@ pull_request_rules:
           - "7.12"
         labels:
           - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: automatic merge for 7\. branches when CI passes
     conditions:
       - check-success=fleet-server/pr-merge


### PR DESCRIPTION
## What does this PR do?

Since https://github.com/Mergifyio/mergify-engine/issues/2419 has been solved we can now change the title.

This is a proposal to change the title in the PRs that are backported with `mergify`.

`[target-branch](backport #1234) title`

## Why is it important?

Highlight what's important in the title to easily filter target branches


## Issues

Similar to https://github.com/elastic/beats/pull/25396