### PR TITLE
Reduce the monitor long poll timeout to 4 minutes by default

### DIFF
--- a/internal/pkg/config/monitor.go
+++ b/internal/pkg/config/monitor.go
@@ -8,7 +8,7 @@ import "time"
 
 const (
 	defaultFetchSize   = 1000
-	defaultPollTimeout = 5 * time.Minute
+	defaultPollTimeout = 4 * time.Minute
 )
 
 type Monitor struct {

--- a/internal/pkg/monitor/monitor.go
+++ b/internal/pkg/monitor/monitor.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	defaultPollTimeout    = 5 * time.Minute // default long poll timeout
+	defaultPollTimeout    = 4 * time.Minute // default long poll timeout
 	defaultSeqNo          = int64(-1)       // the _seq_no in elasticsearch start with 0
 	defaultWithExpiration = false
 
@@ -244,7 +244,7 @@ func (m *simpleMonitorT) Run(ctx context.Context) (err error) {
 				continue
 			} else {
 				// Log the error and keep trying
-				m.log.Error().Err(err).Msg("failed on waiting for global checkpoints advance")
+				m.log.Info().Err(err).Msg("failed on waiting for global checkpoints advance")
 			}
 
 			// Delay next attempt


### PR DESCRIPTION
## What does this PR do?

* Reduces  the monitor long poll timeout to 4 minutes by default
* Change log message level from Error to Info 

## Why is it important?

This addresses https://github.com/elastic/fleet-server/issues/304

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Related issues

- Closes https://github.com/elastic/fleet-server/issues/304

