### PR TITLE
mergify: fix delete_head_branch condition

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -79,7 +79,7 @@ pull_request_rules:
     conditions:
       - merged
       - label=automation
-      - base~=^update-stack-version
+      - head~=^update-stack-version
       - files~=^dev-tools/integration/.env$
     actions:
       delete_head_branch:


### PR DESCRIPTION
## What does this PR do?

Check that the name of "head" matches, rather than "base".

## Why is it important?

Otherwise the branches are not deleted 