### PR TITLE
Fix the comparison between a MaxUint32 and the len of the slice

### DIFF
--- a/internal/pkg/bulk/opMulti.go
+++ b/internal/pkg/bulk/opMulti.go
@@ -7,6 +7,7 @@ package bulk
 import (
 	"context"
 	"errors"
+	"math"
 )
 
 func (b *Bulker) MCreate(ctx context.Context, ops []MultiOp, opts ...Opt) ([]BulkIndexerResponseItem, error) {
@@ -30,9 +31,7 @@ func (b *Bulker) multiWaitBulkOp(ctx context.Context, action actionT, ops []Mult
 		return nil, nil
 	}
 
-	const kMaxBulk = (1 << 32) - 1
-
-	if len(ops) > kMaxBulk {
+	if uint(len(ops)) > math.MaxUint32 {
 		return nil, errors.New("too many bulk ops")
 	}
 


### PR DESCRIPTION
received..

Ok, this seems to be a problem with the int vs uint check that we do.
I am not sure why this was raised now / today. I event check older 1.15
version of golang and I had the same issue.

Before the fix
```
 ❯ make release-manager-snapshot                                                                                                                                                                                                    [22:46:57]
./dev-tools/run_with_go_ver /Applications/Xcode.app/Contents/Developer/usr/bin/make release
v0.1.0
GOOS=darwin GOARCH=amd64 go build -ldflags="-w -s -X main.Version=8.0.0-SNAPSHOT" -buildmode=pie -o build/binaries/fleet-server-8.0.0-SNAPSHOT-darwin-x86_64/fleet-server .
GOOS=darwin GOARCH=arm64 go build -ldflags="-w -s -X main.Version=8.0.0-SNAPSHOT" -buildmode=pie -o build/binaries/fleet-server-8.0.0-SNAPSHOT-darwin-arm64/fleet-server .
GOOS=linux GOARCH=386 go build -ldflags="-w -s -X main.Version=8.0.0-SNAPSHOT"  -o build/binaries/fleet-server-8.0.0-SNAPSHOT-linux-x86/fleet-server .
internal/pkg/bulk/opMulti.go:35:14: constant 4294967295 overflows int
make[2]: *** [release-linux/386] Error 2
make[1]: *** [release-manager-release] Error 2
make: *** [release-manager-snapshot] Error 2
```

After:
```
 ❯ make release-manager-snapshot                                                                                                                                                                                                    [22:49:11]
./dev-tools/run_with_go_ver /Applications/Xcode.app/Contents/Developer/usr/bin/make release
v0.1.0
GOOS=darwin GOARCH=amd64 go build -ldflags="-w -s -X main.Version=8.0.0-SNAPSHOT" -buildmode=pie -o build/binaries/fleet-server-8.0.0-SNAPSHOT-darwin-x86_64/fleet-server .
GOOS=darwin GOARCH=arm64 go build -ldflags="-w -s -X main.Version=8.0.0-SNAPSHOT" -buildmode=pie -o build/binaries/fleet-server-8.0.0-SNAPSHOT-darwin-arm64/fleet-server .
GOOS=linux GOARCH=386 go build -ldflags="-w -s -X main.Version=8.0.0-SNAPSHOT"  -o build/binaries/fleet-server-8.0.0-SNAPSHOT-linux-x86/fleet-server .
GOOS=linux GOARCH=amd64 go build -ldflags="-w -s -X main.Version=8.0.0-SNAPSHOT" -buildmode=pie -o build/binaries/fleet-server-8.0.0-SNAPSHOT-linux-x86_64/fleet-server .
GOOS=linux GOARCH=arm64 go build -ldflags="-w -s -X main.Version=8.0.0-SNAPSHOT" -buildmode=pie -o build/binaries/fleet-server-8.0.0-SNAPSHOT-linux-arm64/fleet-server .
GOOS=windows GOARCH=386 go build -ldflags="-w -s -X main.Version=8.0.0-SNAPSHOT" -buildmode=pie -o build/binaries/fleet-server-8.0.0-SNAPSHOT-windows-x86/fleet-server .
GOOS=windows GOARCH=amd64 go build -ldflags="-w -s -X main.Version=8.0.0-SNAPSHOT" -buildmode=pie -o build/binaries/fleet-server-8.0.0-SNAPSHOT-windows-x86_64/fleet-server .
>>> elapsed time 31s
```

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
