### PR TITLE
chore: separate unit tests from integration tests in CI pipeline

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -58,14 +58,32 @@ pipeline {
         }
       }
     }
-    stage('Test') {
+    stage('Unit Test') {
+      options { skipDefaultCheckout() }
+      steps {
+        cleanup()
+        dir("${BASE_DIR}"){
+          withGoEnv(){
+            sh(label: 'test', script: 'make test-unit')
+            sh(label: 'test', script: 'make junit-report')
+          }
+        }
+      }
+      post {
+        always {
+          junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/build/*.xml")
+        }
+      }
+    }
+    stage('Integration Test') {
       options { skipDefaultCheckout() }
       steps {
         cleanup()
         dir("${BASE_DIR}"){
           withGoEnv(){
             retryWithSleep(retries: 2, seconds: 5, backoff: true){ sh(label: "Install Docker", script: '.ci/scripts/install-docker-compose.sh') }
-            sh(label: 'test', script: 'make test')
+            sh(label: 'test', script: 'make test-int')
+            sh(label: 'test', script: 'make junit-report')
           }
         }
       }

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ int-docker-stop: ## - Stop docker environment for integration tests
 .PHONY: test-int
 test-int: prepare-test-context  ## - Run integration tests with full setup (slow!)
 	@$(MAKE) int-docker-start
-	@set -o pipefail; $(MAKE) test-int-set | tee build/test-init.out
+	@set -o pipefail; $(MAKE) test-int-set | tee build/test-int.out
 	@$(MAKE) int-docker-stop
 
 # Run integration tests without starting/stopping docker


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
It creates a new stage in the CI pipeline separating the unit tests from the integration ones.

Finally, we renamed the jUnit output file to be consistent with the Make goal.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
Separation of concerns. From a delivery pipeline stand point, we would like to differenciate the execution of the different test suite with the sole goal of providing fast feedback to the developers when problems occur. At the moment a unit test fails, the pipeline will display that information with a red flag in the unit tests stage, stopping the pipeline at that moment.

On the same hand, integration tests usually come with the preparation of third-party services (in this particular case in the way of docker-compose services) that could cost heavy amount of time/resources, and we want to delay that preparation until the unit test stage tells us that it's OK to continue in the delivery pipeline. And that's exactly right because a failure in the unit test stage should tells us to stop machines the soonest.

This particular project has the unit/integration test separated by build tags (which is awesome!), let's leverage that separation in the delivery pipeline too, also preparing the future with those two stages clearly separated.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally
The pipeline UI should display two stages, one for unit and another for integration tests.

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Discovered while testing #346


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<img width="1775" alt="Screenshot 2021-05-14 at 09 39 16" src="https://user-images.githubusercontent.com/951580/118238051-4c1e1280-b498-11eb-9542-d8a2730711d2.png">

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->