### PR TITLE
Conform error and hash fields to ECS.

### DIFF
--- a/cmd/fleet/handleCheckin.go
+++ b/cmd/fleet/handleCheckin.go
@@ -400,7 +400,7 @@ func processPolicy(ctx context.Context, bulker bulk.Bulk, agentId string, pp *po
 		}
 
 		zlog.Info().
-			Str("hash", defaultRole.Sha2).
+			Str("hash.sha256", defaultRole.Sha2).
 			Str("apiKeyId", defaultOutputApiKey.Id).
 			Msg("Updating agent record to pick up default output key.")
 

--- a/internal/pkg/logger/logger.go
+++ b/internal/pkg/logger/logger.go
@@ -80,9 +80,11 @@ func Init(cfg *config.Config) (*Logger, error) {
 
 		// override the field names for ECS
 		zerolog.LevelFieldName = "log.level"
+		zerolog.ErrorFieldName = "error.message"
 		zerolog.MessageFieldName = "message"
 		zerolog.TimeFieldFormat = "2006-01-02T15:04:05.999Z" // RFC3339 at millisecond resolution in zulu timezone
 		zerolog.TimestampFieldName = "@timestamp"
+
 		if !cfg.Logging.Pretty || !cfg.Logging.ToStderr {
 			zerolog.TimestampFunc = func() time.Time { return time.Now().UTC() }
 		}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Conforms the error field and the hash field in the logs to ECS.

## Why is it important?

Default is not ECS compliant and is breaking Elastic mapping.

## Checklist



- [x ] My code follows the style guidelines of this project
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] I have made corresponding change to the default configuration files
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
 
- Relates https://github.com/elastic/fleet-server/issues/358

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

```
{"log.level":"info","status":"FAILED","@timestamp":"2021-05-17T13:54:46.491Z","message":"Error - dial tcp 127.0.0.1:9200: connect: connection refused"}
{"log.level":"error","error.message":"dial tcp 127.0.0.1:9200: connect: connection refused","@timestamp":"2021-05-17T13:54:46.491Z","message":"Fleet Server failed"}
{"log.level":"error","error.message":"dial tcp 127.0.0.1:9200: connect: connection refused","@timestamp":"2021-05-17T13:54:46.491Z","message":"Exiting"}
```