### PR TITLE
Log version and commit at boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ VERSION=${DEFAULT_VERSION}
 endif
 
 PLATFORM_TARGETS=$(addprefix release-, $(PLATFORMS))
-LDFLAGS=-w -s -X main.Version=${VERSION}
+COMMIT=$(shell git rev-parse --short HEAD)
+LDFLAGS=-w -s -X main.Version=${VERSION} -X main.Commit=${COMMIT}
 CMD_COLOR_ON=\033[32m\xE2\x9c\x93
 CMD_COLOR_OFF=\033[0m
 

--- a/internal/pkg/logger/logger.go
+++ b/internal/pkg/logger/logger.go
@@ -88,14 +88,6 @@ func Init(cfg *config.Config) (*Logger, error) {
 		if !cfg.Logging.Pretty || !cfg.Logging.ToStderr {
 			zerolog.TimestampFunc = func() time.Time { return time.Now().UTC() }
 		}
-
-		log.Info().
-			Int("pid", os.Getpid()).
-			Int("ppid", os.Getppid()).
-			Str("exe", os.Args[0]).
-			Strs("args", os.Args[1:]).
-			Msg("boot")
-		log.Debug().Strs("env", os.Environ()).Msg("environment")
 	})
 	return gLogger, err
 }

--- a/main.go
+++ b/main.go
@@ -23,10 +23,11 @@ const defaultVersion = "8.0.0"
 
 var (
 	Version string = defaultVersion
+	Commit  string
 )
 
 func main() {
-	cmd := fleet.NewCommand(Version)
+	cmd := fleet.NewCommand(Version, Commit)
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Adds the short form of the git commit id and the version to the boot message.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

It remains difficult to know what specific version of code is installed in the cloud during beta cycles.  
This will allow the developer to examine the logs to figure out the specific version of the code used in the build.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x ] My code follows the style guidelines of this project
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] I have made corresponding change to the default configuration files
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

{"log.level":"info","version":"7.13.0","commit":"34e4a3c","pid":68004,"ppid":19730,"exe":"./bin/fleet-server","args":[],"@timestamp":"2021-05-19T09:52:25.125Z","message":"boot"}


