### PR TITLE
Add context to errors for better visibility in logs. Add http access …

### DIFF
--- a/cmd/fleet/error.go
+++ b/cmd/fleet/error.go
@@ -5,24 +5,144 @@
 package fleet
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
+	"github.com/elastic/fleet-server/v7/internal/pkg/limit"
+	"github.com/elastic/fleet-server/v7/internal/pkg/logger"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+// Alias useful ECS headers
+const (
+	EcsHttpRequestId         = logger.EcsHttpRequestId
+	EcsEventDuration         = logger.EcsEventDuration
+	EcsHttpResponseCode      = logger.EcsHttpResponseCode
+	EcsHttpResponseBodyBytes = logger.EcsHttpResponseBodyBytes
 )
 
 type errResp struct {
-	StatusCode int    `json:"statusCode"`
-	Error      string `json:"error"`
-	Message    string `json:"message"`
+	StatusCode int           `json:"statusCode"`
+	Error      string        `json:"error"`
+	Message    string        `json:"message,omitempty"`
+	Level      zerolog.Level `json:"-"`
 }
 
-func WriteError(w http.ResponseWriter, code int, errStr string, msg string) error {
-	data, err := json.Marshal(&errResp{StatusCode: code, Error: errStr, Message: msg})
+func NewErrorResp(err error) errResp {
+
+	errTable := []struct {
+		target error
+		meta   errResp
+	}{
+		{
+			ErrAgentNotFound,
+			errResp{
+				http.StatusNotFound,
+				"AgentNotFound",
+				"agent could not be found",
+				zerolog.WarnLevel,
+			},
+		},
+		{
+			limit.ErrRateLimit,
+			errResp{
+				http.StatusTooManyRequests,
+				"RateLimit",
+				"exceeded the rate limit",
+				zerolog.DebugLevel,
+			},
+		},
+		{
+			limit.ErrMaxLimit,
+			errResp{
+				http.StatusTooManyRequests,
+				"MaxLimit",
+				"exceeded the max limit",
+				zerolog.DebugLevel,
+			},
+		},
+		{
+			ErrApiKeyNotEnabled,
+			errResp{
+				http.StatusUnauthorized,
+				"Unauthorized",
+				"ApiKey not enabled",
+				zerolog.InfoLevel,
+			},
+		},
+		{
+			context.Canceled,
+			errResp{
+				http.StatusServiceUnavailable,
+				"ServiceUnavailable",
+				"server is stopping",
+				zerolog.DebugLevel,
+			},
+		},
+		{
+			ErrInvalidUserAgent,
+			errResp{
+				http.StatusBadRequest,
+				"InvalidUserAgent",
+				"user-agent is invalid",
+				zerolog.InfoLevel,
+			},
+		},
+		{
+			ErrUnsupportedVersion,
+			errResp{
+				http.StatusBadRequest,
+				"UnsupportedVersion",
+				"version is not supported",
+				zerolog.InfoLevel,
+			},
+		},
+		{
+			dl.ErrNotFound,
+			errResp{
+				http.StatusNotFound,
+				"NotFound",
+				"not found",
+				zerolog.WarnLevel,
+			},
+		},
+		{
+			ErrorThrottle,
+			errResp{
+				http.StatusTooManyRequests,
+				"TooManyRequests",
+				"too many requests",
+				zerolog.DebugLevel,
+			},
+		},
+	}
+
+	for _, e := range errTable {
+		if errors.Is(err, e.target) {
+			return e.meta
+		}
+	}
+
+	// Default
+	return errResp{
+		StatusCode: http.StatusBadRequest,
+		Error:      "BadRequest",
+		Level:      zerolog.InfoLevel,
+	}
+}
+
+func (er errResp) Write(w http.ResponseWriter) error {
+	data, err := json.Marshal(&er)
 	if err != nil {
 		return err
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
-	w.WriteHeader(code)
-	w.Write(data)
-	return nil
+	w.WriteHeader(er.StatusCode)
+	_, err = w.Write(data)
+	return err
 }

--- a/cmd/fleet/schema.go
+++ b/cmd/fleet/schema.go
@@ -117,7 +117,6 @@ type Event struct {
 }
 
 type StatusResponse struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
-	Status  string `json:"status"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
 }

--- a/internal/pkg/action/dispatcher.go
+++ b/internal/pkg/action/dispatcher.go
@@ -65,7 +65,7 @@ func (d *Dispatcher) Subscribe(agentId string, seqNo sqn.SeqNo) *Sub {
 	sz := len(d.subs)
 	d.mx.Unlock()
 
-	log.Debug().Str("agentId", agentId).Int("sz", sz).Msg("Subscribed to action dispatcher")
+	log.Trace().Str("agentId", agentId).Int("sz", sz).Msg("Subscribed to action dispatcher")
 
 	return &sub
 }
@@ -80,7 +80,7 @@ func (d *Dispatcher) Unsubscribe(sub *Sub) {
 	sz := len(d.subs)
 	d.mx.Unlock()
 
-	log.Debug().Str("agentId", sub.agentId).Int("sz", sz).Msg("Unsubscribed from action dispatcher")
+	log.Trace().Str("agentId", sub.agentId).Int("sz", sz).Msg("Unsubscribed from action dispatcher")
 }
 
 func (d *Dispatcher) process(ctx context.Context, hits []es.HitT) {

--- a/internal/pkg/apikey/invalidate.go
+++ b/internal/pkg/apikey/invalidate.go
@@ -27,7 +27,7 @@ func Invalidate(ctx context.Context, client *elasticsearch.Client, ids ...string
 
 	body, err := json.Marshal(&payload)
 	if err != nil {
-		return err
+		return fmt.Errorf("InvalidateAPIKey: %w", err)
 	}
 
 	opts := []func(*esapi.SecurityInvalidateAPIKeyRequest){
@@ -40,7 +40,7 @@ func Invalidate(ctx context.Context, client *elasticsearch.Client, ids ...string
 	)
 
 	if err != nil {
-		return err
+		return fmt.Errorf("InvalidateAPIKey: %w", err)
 	}
 
 	defer res.Body.Close()
@@ -48,5 +48,6 @@ func Invalidate(ctx context.Context, client *elasticsearch.Client, ids ...string
 	if res.IsError() {
 		return fmt.Errorf("fail InvalidateAPIKey: %s", res.String())
 	}
+
 	return nil
 }

--- a/internal/pkg/logger/ecs.go
+++ b/internal/pkg/logger/ecs.go
@@ -1,0 +1,32 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package logger
+
+const (
+
+	// HTTP
+	EcsHttpVersion           = "http.version"
+	EcsHttpRequestId         = "http.request.id"
+	EcsHttpRequestMethod     = "http.request.method"
+	EcsHttpRequestBodyBytes  = "http.request.body.bytes"
+	EcsHttpResponseCode      = "http.response.status_code"
+	EcsHttpResponseBodyBytes = "http.response.body.bytes"
+
+	// URL
+	EcsUrlFull   = "url.full"
+	EcsUrlDomain = "url.domain"
+	EcsUrlPort   = "url.port"
+
+	// Client
+	EcsClientAddress = "client.address"
+	EcsClientIp      = "client.ip"
+	EcsClientPort    = "client.port"
+
+	// TLS
+	EcsTlsEstablished = "tls.established"
+
+	// Event
+	EcsEventDuration = "event.duration"
+)

--- a/internal/pkg/logger/http.go
+++ b/internal/pkg/logger/http.go
@@ -1,0 +1,165 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package logger
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	HeaderRequestID = "X-Request-ID"
+	httpSlashPrefix = "HTTP/"
+)
+
+type ReaderCounter struct {
+	io.ReadCloser
+	count uint64
+}
+
+func NewReaderCounter(r io.ReadCloser) *ReaderCounter {
+	return &ReaderCounter{
+		ReadCloser: r,
+	}
+}
+
+func (rd *ReaderCounter) Read(buf []byte) (int, error) {
+	n, err := rd.ReadCloser.Read(buf)
+	atomic.AddUint64(&rd.count, uint64(n))
+	return n, err
+}
+
+func (rd *ReaderCounter) Count() uint64 {
+	return atomic.LoadUint64(&rd.count)
+}
+
+type ResponseCounter struct {
+	http.ResponseWriter
+	count       uint64
+	statusCode  int
+	wroteHeader bool
+}
+
+func NewResponseCounter(w http.ResponseWriter) *ResponseCounter {
+	return &ResponseCounter{
+		ResponseWriter: w,
+	}
+}
+
+func (rc *ResponseCounter) Write(buf []byte) (int, error) {
+	if !rc.wroteHeader {
+		rc.wroteHeader = true
+		rc.statusCode = 200
+	}
+	n, err := rc.ResponseWriter.Write(buf)
+	atomic.AddUint64(&rc.count, uint64(n))
+	return n, err
+}
+
+func (rc *ResponseCounter) WriteHeader(statusCode int) {
+	rc.ResponseWriter.WriteHeader(statusCode)
+
+	// Defend unsupported multiple calls to WriteHeader
+	if !rc.wroteHeader {
+		rc.statusCode = statusCode
+		rc.wroteHeader = true
+	}
+}
+
+func (rc *ResponseCounter) Count() uint64 {
+	return atomic.LoadUint64(&rc.count)
+}
+
+func splitAddr(addr string) (host string, port int) {
+
+	host, portS, err := net.SplitHostPort(addr)
+
+	if err == nil {
+		if v, err := strconv.Atoi(portS); err == nil {
+			port = v
+		}
+	}
+
+	return
+}
+
+// Expects HTTP version in form of HTTP/x.y
+func stripHTTP(h string) string {
+	if strings.HasPrefix(h, httpSlashPrefix) {
+		return h[len(httpSlashPrefix):]
+	}
+
+	return h
+}
+
+// ECS HTTP log wrapper
+func HttpHandler(next httprouter.Handle) httprouter.Handle {
+
+	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+		e := log.Debug()
+
+		if !e.Enabled() {
+			next(w, r, p)
+			return
+		}
+
+		start := time.Now()
+
+		rdCounter := NewReaderCounter(r.Body)
+		r.Body = rdCounter
+
+		wrCounter := NewResponseCounter(w)
+
+		next(wrCounter, r, p)
+
+		// Look for request id
+		if reqID := r.Header.Get(HeaderRequestID); reqID != "" {
+			e.Str(EcsHttpRequestId, reqID)
+		}
+
+		// URL info
+		e.Str(EcsUrlFull, r.URL.String())
+
+		if domain := r.URL.Hostname(); domain != "" {
+			e.Str(EcsUrlDomain, domain)
+		}
+
+		port := r.URL.Port()
+		if port != "" {
+			if v, err := strconv.Atoi(port); err != nil {
+				e.Int(EcsUrlPort, v)
+			}
+		}
+
+		// HTTP info
+		e.Str(EcsHttpVersion, stripHTTP(r.Proto))
+		e.Str(EcsHttpRequestMethod, r.Method)
+		e.Int(EcsHttpResponseCode, wrCounter.statusCode)
+		e.Uint64(EcsHttpRequestBodyBytes, rdCounter.Count())
+		e.Uint64(EcsHttpResponseBodyBytes, wrCounter.Count())
+
+		// Client info
+		remoteIP, remotePort := splitAddr(r.RemoteAddr)
+		e.Str(EcsClientAddress, r.RemoteAddr)
+		e.Str(EcsClientIp, remoteIP)
+		e.Int(EcsClientPort, remotePort)
+
+		// TLS info
+		e.Bool(EcsTlsEstablished, (r.TLS != nil))
+
+		// Event info
+		e.Int64(EcsEventDuration, time.Since(start).Nanoseconds())
+
+		e.Msg("HTTP handler")
+	}
+}


### PR DESCRIPTION
…logging in debug mode.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

- Adds contextual information to errors for bubbling up into logs.  In particular, allows us to better differentiate errors from upstream or downstream.
- Propagate value of "X-Request-ID" HTTP header into log to better align with agent.  @blakerouse will add agent support for 7.14.
- Convert log fields to ECS equivalents to support mapping out of the box.
- Also, add debug level access logging of HTTP requests.

## Why is it important?

Cloud diagnostics are pretty difficult with only the sentinel errors bubbling up the logs.  We need more visibility into the context around each error.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x ] My code follows the style guidelines of this project
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] I have made corresponding change to the default configuration files
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

```
10:43:45.285 DBG fail checkin error.message="context canceled" event.duration=56294866216 http.code=503 http.request.id=363b7c49-4378-4e41-bc3d-63ca171e71a3 id=0e3a3684-fbe5-45d2-ae13-c0a72fcc1aa4
10:43:45.285 DBG HTTP handler client.address=[::1]:60973 client.ip=::1 client.port=60973 event.duration=85050704849 http.request.body.bytes=602 http.request.id=cdf694af-a0d1-45b6-a50f-517d91505c9c http.request.method=POST http.response.body.bytes=78 http.response.status_code=503 http.version=1.1 tls.established=false url.full=/api/fleet/agents/43ae8a11-81ba-47c9-8b73-2fedec9aa02b/checkin
```

