### PR TITLE
Propagate checkin status to agent record

### DIFF
--- a/cmd/fleet/schema.go
+++ b/cmd/fleet/schema.go
@@ -71,6 +71,7 @@ type EnrollResponse struct {
 }
 
 type CheckinRequest struct {
+	Status    string          `json:"status"`
 	AckToken  string          `json:"ack_token,omitempty"`
 	Events    []Event         `json:"events"`
 	LocalMeta json.RawMessage `json:"local_metadata"`

--- a/internal/pkg/dl/constants.go
+++ b/internal/pkg/dl/constants.go
@@ -32,6 +32,7 @@ const (
 	FieldRevisionIdx                 = "revision_idx"
 	FieldCoordinatorIdx              = "coordinator_idx"
 	FieldLastCheckin                 = "last_checkin"
+	FieldLastCheckinStatus           = "last_checkin_status"
 	FieldLocalMetadata               = "local_metadata"
 	FieldPolicyRevisionIdx           = "policy_revision_idx"
 	FieldPolicyCoordinatorIdx        = "policy_coordinator_idx"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Writes out the checkin status field to the last_checkin_status field in the agent record.  This is necessary to support UX changes.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

UX needs it.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x ] My code follows the style guidelines of this project
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] I have made corresponding change to the default configuration files
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Setup local fleet server and point an agent at it.  You can validate field change using the dev tools in kibana.

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

![Screen Shot 2021-06-02 at 3 40 57 PM](https://user-images.githubusercontent.com/294689/120542922-afc19e80-c3b9-11eb-8f14-02875167e92f.png)
