### PR TITLE
Remove zap stub logger bleed through.

### DIFF
--- a/internal/pkg/logger/ecs.go
+++ b/internal/pkg/logger/ecs.go
@@ -6,6 +6,15 @@ package logger
 
 const (
 
+	// Basic logging
+	EcsLogLevel      = "log.level"
+	EcsLogName       = "log.logger"
+	EcsLogCaller     = "log.origin"
+	EcsLogStackTrace = "log.origin.stack_trace"
+	EcsMessage       = "message"
+	EcsTimestamp     = "@timestamp"
+	EcsErrorMessage  = "error.message"
+
 	// HTTP
 	EcsHttpVersion           = "http.version"
 	EcsHttpRequestId         = "http.request.id"

--- a/internal/pkg/logger/logger.go
+++ b/internal/pkg/logger/logger.go
@@ -79,11 +79,11 @@ func Init(cfg *config.Config) (*Logger, error) {
 		}
 
 		// override the field names for ECS
-		zerolog.LevelFieldName = "log.level"
-		zerolog.ErrorFieldName = "error.message"
-		zerolog.MessageFieldName = "message"
+		zerolog.LevelFieldName = EcsLogLevel
+		zerolog.ErrorFieldName = EcsErrorMessage
+		zerolog.MessageFieldName = EcsMessage
 		zerolog.TimeFieldFormat = "2006-01-02T15:04:05.999Z" // RFC3339 at millisecond resolution in zulu timezone
-		zerolog.TimestampFieldName = "@timestamp"
+		zerolog.TimestampFieldName = EcsTimestamp
 
 		if !cfg.Logging.Pretty || !cfg.Logging.ToStderr {
 			zerolog.TimestampFunc = func() time.Time { return time.Now().UTC() }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Promotes zap logger keys to top level.  Aligns with ECS.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The zap logger stub is necessary because some reused components in beats require it.  To conform with ECS, the fields logged through the zap stub must be at the top level.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x ] My code follows the style guidelines of this project
- [x ] I have commented my code, particularly in hard-to-understand areas


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Should see the new log lines on fleet server boot.  Only two lines are affected in initial boot.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/fleet-server/issues/305


## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
```
{"log.logger":"fleet-metrics.api","message":"Starting stats endpoint","log.level":"info","@timestamp":"2021-06-02T20:14:48.544Z"}
{"log.level":"debug","addr":["https://sgc-security-41.es.us-central1.gcp.qa.cld.elstc.co:9243"],"user":"elastic","maxConnsPersHost":128,"@timestamp":"2021-06-02T20:14:48.544Z","message":"init es"}
{"log.level":"info","log.logger":"fleet-metrics.api","message":"Metrics endpoint listening on: 127.0.0.1:5066 (configured: localhost)","@timestamp":"2021-06-02T20:14:48.544Z"}
{"log.level":"info","name":"c68d74aa4bae46d38d1625c2e25f73a1","uuid":"wetcTQYQTJ60-FUZBTUlbw","vers":"7.14.0-SNAPSHOT","@timestamp":"2021-06-02T20:14:48.843Z","message":"Cluster Info"}
```
