### PR TITLE
Tweak server timeouts.  Limit body size to defend malicious agent

### DIFF
--- a/cmd/fleet/error.go
+++ b/cmd/fleet/error.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"os"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
 	"github.com/elastic/fleet-server/v7/internal/pkg/limit"
@@ -117,6 +118,15 @@ func NewErrorResp(err error) errResp {
 				"TooManyRequests",
 				"too many requests",
 				zerolog.DebugLevel,
+			},
+		},
+		{
+			os.ErrDeadlineExceeded,
+			errResp{
+				http.StatusRequestTimeout,
+				"RequestTimeout",
+				"timeout on request",
+				zerolog.InfoLevel,
 			},
 		},
 	}

--- a/cmd/fleet/server.go
+++ b/cmd/fleet/server.go
@@ -43,6 +43,8 @@ func runServer(ctx context.Context, router *httprouter.Router, cfg *config.Serve
 	addr := cfg.BindAddress()
 	rdto := cfg.Timeouts.Read
 	wrto := cfg.Timeouts.Write
+	idle := cfg.Timeouts.Idle
+	rdhr := cfg.Timeouts.ReadHeader
 	mhbz := cfg.Limits.MaxHeaderByteSize
 	bctx := func(net.Listener) context.Context { return ctx }
 
@@ -53,14 +55,16 @@ func runServer(ctx context.Context, router *httprouter.Router, cfg *config.Serve
 		Msg("server listening")
 
 	server := http.Server{
-		Addr:           addr,
-		ReadTimeout:    rdto,
-		WriteTimeout:   wrto,
-		Handler:        router,
-		BaseContext:    bctx,
-		ConnState:      diagConn,
-		MaxHeaderBytes: mhbz,
-		ErrorLog:       errLogger(),
+		Addr:              addr,
+		ReadTimeout:       rdto,
+		WriteTimeout:      wrto,
+		IdleTimeout:       idle,
+		ReadHeaderTimeout: rdhr,
+		Handler:           router,
+		BaseContext:       bctx,
+		ConnState:         diagConn,
+		MaxHeaderBytes:    mhbz,
+		ErrorLog:          errLogger(),
 	}
 
 	forceCh := make(chan struct{})

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -52,8 +52,10 @@ func TestConfig(t *testing.T) {
 							Host: kDefaultHost,
 							Port: kDefaultPort,
 							Timeouts: ServerTimeouts{
-								Read:             5 * time.Second,
-								Write:            60 * 10 * time.Second,
+								Read:             60 * time.Second,
+								ReadHeader:       5 * time.Second,
+								Idle:             30 * time.Second,
+								Write:            10 * time.Minute,
 								CheckinTimestamp: 30 * time.Second,
 								CheckinLongPoll:  5 * time.Minute,
 							},
@@ -70,6 +72,7 @@ func TestConfig(t *testing.T) {
 								CheckinLimit: Limit{
 									Interval: time.Millisecond,
 									Burst:    1000,
+									MaxBody:  1048576,
 								},
 								ArtifactLimit: Limit{
 									Interval: time.Millisecond * 5,
@@ -80,11 +83,13 @@ func TestConfig(t *testing.T) {
 									Interval: time.Millisecond * 10,
 									Burst:    100,
 									Max:      50,
+									MaxBody:  524288,
 								},
 								AckLimit: Limit{
 									Interval: time.Millisecond * 10,
 									Burst:    100,
 									Max:      50,
+									MaxBody:  2097152,
 								},
 							},
 						},
@@ -142,8 +147,10 @@ func TestConfig(t *testing.T) {
 							Host: kDefaultHost,
 							Port: kDefaultPort,
 							Timeouts: ServerTimeouts{
-								Read:             5 * time.Second,
-								Write:            60 * 10 * time.Second,
+								Read:             60 * time.Second,
+								ReadHeader:       5 * time.Second,
+								Idle:             30 * time.Second,
+								Write:            10 * time.Minute,
 								CheckinTimestamp: 30 * time.Second,
 								CheckinLongPoll:  5 * time.Minute,
 							},
@@ -160,6 +167,7 @@ func TestConfig(t *testing.T) {
 								CheckinLimit: Limit{
 									Interval: time.Millisecond,
 									Burst:    1000,
+									MaxBody:  1048576,
 								},
 								ArtifactLimit: Limit{
 									Interval: time.Millisecond * 5,
@@ -170,11 +178,13 @@ func TestConfig(t *testing.T) {
 									Interval: time.Millisecond * 10,
 									Burst:    100,
 									Max:      50,
+									MaxBody:  524288,
 								},
 								AckLimit: Limit{
 									Interval: time.Millisecond * 10,
 									Burst:    100,
 									Max:      50,
+									MaxBody:  2097152,
 								},
 							},
 						},
@@ -230,8 +240,10 @@ func TestConfig(t *testing.T) {
 							Host: kDefaultHost,
 							Port: kDefaultPort,
 							Timeouts: ServerTimeouts{
-								Read:             5 * time.Second,
-								Write:            60 * 10 * time.Second,
+								Read:             60 * time.Second,
+								ReadHeader:       5 * time.Second,
+								Idle:             30 * time.Second,
+								Write:            10 * time.Minute,
 								CheckinTimestamp: 30 * time.Second,
 								CheckinLongPoll:  5 * time.Minute,
 							},
@@ -248,6 +260,7 @@ func TestConfig(t *testing.T) {
 								CheckinLimit: Limit{
 									Interval: time.Millisecond,
 									Burst:    1000,
+									MaxBody:  1048576,
 								},
 								ArtifactLimit: Limit{
 									Interval: time.Millisecond * 5,
@@ -258,11 +271,13 @@ func TestConfig(t *testing.T) {
 									Interval: time.Millisecond * 10,
 									Burst:    100,
 									Max:      50,
+									MaxBody:  524288,
 								},
 								AckLimit: Limit{
 									Interval: time.Millisecond * 10,
 									Burst:    100,
 									Max:      50,
+									MaxBody:  2097152,
 								},
 							},
 						},
@@ -319,6 +334,8 @@ func TestConfig(t *testing.T) {
 							Port: 8888,
 							Timeouts: ServerTimeouts{
 								Read:             20 * time.Second,
+								ReadHeader:       5 * time.Second,
+								Idle:             30 * time.Second,
 								Write:            5 * time.Second,
 								CheckinTimestamp: 30 * time.Second,
 								CheckinLongPoll:  5 * time.Minute,
@@ -336,6 +353,7 @@ func TestConfig(t *testing.T) {
 								CheckinLimit: Limit{
 									Interval: time.Millisecond,
 									Burst:    1000,
+									MaxBody:  1048576,
 								},
 								ArtifactLimit: Limit{
 									Interval: time.Millisecond * 5,
@@ -346,11 +364,13 @@ func TestConfig(t *testing.T) {
 									Interval: time.Millisecond * 10,
 									Burst:    100,
 									Max:      50,
+									MaxBody:  524288,
 								},
 								AckLimit: Limit{
 									Interval: time.Millisecond * 10,
 									Burst:    100,
 									Max:      50,
+									MaxBody:  2097152,
 								},
 							},
 						},

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -25,14 +25,43 @@ type Policy struct {
 type ServerTimeouts struct {
 	Read             time.Duration `config:"read"`
 	Write            time.Duration `config:"write"`
+	Idle             time.Duration `config:"idle"`
+	ReadHeader       time.Duration `config:"read_header"`
 	CheckinTimestamp time.Duration `config:"checkin_timestamp"`
 	CheckinLongPoll  time.Duration `config:"checkin_long_poll"`
 }
 
 // InitDefaults initializes the defaults for the configuration.
 func (c *ServerTimeouts) InitDefaults() {
-	c.Read = 5 * time.Second
+	// see https://blog.gopheracademy.com/advent-2016/exposing-go-on-the-internet/
+
+	// The read timeout starts on ACCEPT of the connection, and includes
+	// the time to read the entire body (if the body is read, otherwise to the end of the headers).
+	// Note that for TLS, this include the TLS handshake as well.
+	// In most cases, we are authenticating the apikey and doing an agent record lookup
+	// *before* reading the body.  This is purposeful to avoid streaming data from an unauthenticated
+	// connection. However, the downside is that if the roundtrip to Elastic is slow, we may
+	// end up hitting the Read timeout before actually reading any data off the socket.
+	// Use a large timeout to accomodate the authentication lag.  Add a ReadHeader timeout
+	// below to handle preAuth.
+	c.Read = 60 * time.Second
+
+	// Read header timeout covers ACCEPT to the end of the HTTP headers.
+	// Note that for TLS, this include the TLS handshake as well.
+	// This is considered preauth in this server, so limit the timeout to something reasonable.
+	c.ReadHeader = 5 * time.Second
+
+	// IdleTimeout is the maximum amount of time to wait for the
+	// next request when keep-alives are enabled.   Because TLS handshakes are expensive
+	// for the server, avoid aggressive connection close with generous idle timeout.
+	c.Idle = 30 * time.Second
+
+	// The write timeout for HTTPS covers the time from ACCEPT to the end of the response write;
+	// so in that case it covers the TLS handshake.  If the connection is reused, the write timeout
+	// covers the time from the end of the request header to the end of the response write.
+	// Set to a very large timeout to allow for slow backend; must be at least as large as Read timeout plus Long Poll.
 	c.Write = 10 * time.Minute
+
 	c.CheckinTimestamp = 30 * time.Second
 	c.CheckinLongPoll = 5 * time.Minute
 }

--- a/internal/pkg/config/limits.go
+++ b/internal/pkg/config/limits.go
@@ -12,6 +12,7 @@ type Limit struct {
 	Interval time.Duration `config:"interval"`
 	Burst    int           `config:"burst"`
 	Max      int64         `config:"max"`
+	MaxBody  int64         `config:"max_body_byte_size"`
 }
 
 type ServerLimits struct {
@@ -35,6 +36,7 @@ func (c *ServerLimits) InitDefaults() {
 	c.CheckinLimit = Limit{
 		Interval: time.Millisecond,
 		Burst:    1000,
+		MaxBody:  1024 * 1024,
 	}
 	c.ArtifactLimit = Limit{
 		Interval: time.Millisecond * 5,
@@ -45,10 +47,12 @@ func (c *ServerLimits) InitDefaults() {
 		Interval: time.Millisecond * 10,
 		Burst:    100,
 		Max:      50,
+		MaxBody:  1024 * 512,
 	}
 	c.AckLimit = Limit{
 		Interval: time.Millisecond * 10,
 		Burst:    100,
 		Max:      50,
+		MaxBody:  1024 * 1024 * 2,
 	}
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Enforces configurable max body size limits on payloads.
Differentiates between header and read timeout.
Returns a non-400 error on a read timeout.  Read timeouts are typically due to elasticsearch not responding to auth requests quickly.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Necessary to fortify server against attack.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x ] My code follows the style guidelines of this project
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] I have made corresponding change to the default configuration files
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
