### PR TITLE
Refactor bulk engine startup and add bulk ApiKey 

### DIFF
--- a/cmd/fleet/handleEnroll.go
+++ b/cmd/fleet/handleEnroll.go
@@ -124,7 +124,7 @@ func (et *EnrollerT) handleEnroll(r *http.Request) ([]byte, error) {
 	}
 	defer limitF()
 
-	key, err := authApiKey(r, et.bulker.Client(), et.cache)
+	key, err := authApiKey(r, et.bulker, et.cache)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/fleet/server.go
+++ b/cmd/fleet/server.go
@@ -98,7 +98,7 @@ func runServer(ctx context.Context, router *httprouter.Router, cfg *config.Serve
 	}
 
 	ln = wrapConnLimitter(ctx, ln, cfg)
-	if err := server.Serve(ln); err != nil && err != context.Canceled {
+	if err := server.Serve(ln); err != nil && err != http.ErrServerClosed {
 		return err
 	}
 

--- a/internal/pkg/apikey/apikey_integration_test.go
+++ b/internal/pkg/apikey/apikey_integration_test.go
@@ -11,8 +11,7 @@ import (
 	"errors"
 	"testing"
 
-	ftesting "github.com/elastic/fleet-server/v7/internal/pkg/testing"
-
+	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/gofrs/uuid"
 	"github.com/google/go-cmp/cmp"
 )
@@ -34,19 +33,27 @@ func TestCreateApiKeyWithMetadata(t *testing.T) {
 	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 
-	bulker := ftesting.SetupBulk(ctx, t)
+	cfg := elasticsearch.Config{
+		Username: "elastic",
+		Password: "changeme",
+	}
+
+	es, err := elasticsearch.NewClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Create the key
 	agentId := uuid.Must(uuid.NewV4()).String()
 	name := uuid.Must(uuid.NewV4()).String()
-	akey, err := Create(ctx, bulker.Client(), name, "", []byte(testFleetRoles),
+	akey, err := Create(ctx, es, name, "", []byte(testFleetRoles),
 		NewMetadata(agentId, TypeAccess))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Get the key and verify that metadata was saved correctly
-	aKeyMeta, err := Get(ctx, bulker.Client(), akey.Id)
+	aKeyMeta, err := Read(ctx, es, akey.Id)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +79,7 @@ func TestCreateApiKeyWithMetadata(t *testing.T) {
 	}
 
 	// Try to get the key that doesn't exists, expect ErrApiKeyNotFound
-	aKeyMeta, err = Get(ctx, bulker.Client(), "0000000000000")
+	aKeyMeta, err = Read(ctx, es, "0000000000000")
 	if !errors.Is(err, ErrApiKeyNotFound) {
 		t.Errorf("Unexpected error type: %v", err)
 	}

--- a/internal/pkg/apikey/auth.go
+++ b/internal/pkg/apikey/auth.go
@@ -24,9 +24,7 @@ type SecurityInfo struct {
 	LookupRealm map[string]string `json:"lookup_realm"`
 }
 
-// Kibana:
-// https://github.com/elastic/kibana/blob/master/x-pack/plugins/security/server/authentication/authenticator.ts#L308
-// NOTE: Bulk request currently not available.
+// Note: Prefer the bulk wrapper on this API
 func (k ApiKey) Authenticate(ctx context.Context, es *elasticsearch.Client) (*SecurityInfo, error) {
 
 	token := fmt.Sprintf("%s%s", authPrefix, k.Token())

--- a/internal/pkg/apikey/get.go
+++ b/internal/pkg/apikey/get.go
@@ -18,7 +18,7 @@ type ApiKeyMetadata struct {
 	Metadata Metadata
 }
 
-func Get(ctx context.Context, client *elasticsearch.Client, id string) (apiKey ApiKeyMetadata, err error) {
+func Read(ctx context.Context, client *elasticsearch.Client, id string) (apiKey *ApiKeyMetadata, err error) {
 
 	opts := []func(*esapi.SecurityGetAPIKeyRequest){
 		client.Security.GetAPIKey.WithContext(ctx),
@@ -36,7 +36,8 @@ func Get(ctx context.Context, client *elasticsearch.Client, id string) (apiKey A
 	defer res.Body.Close()
 
 	if res.IsError() {
-		return apiKey, fmt.Errorf("fail GetAPIKey: %s, %w", res.String(), ErrApiKeyNotFound)
+		err = fmt.Errorf("fail GetAPIKey: %s, %w", res.String(), ErrApiKeyNotFound)
+		return
 	}
 
 	type APIKeyResponse struct {
@@ -59,8 +60,10 @@ func Get(ctx context.Context, client *elasticsearch.Client, id string) (apiKey A
 
 	first := resp.ApiKeys[0]
 
-	return ApiKeyMetadata{
+	apiKey = &ApiKeyMetadata{
 		Id:       first.Id,
 		Metadata: first.Metadata,
-	}, nil
+	}
+
+	return
 }

--- a/internal/pkg/bulk/bulk_test.go
+++ b/internal/pkg/bulk/bulk_test.go
@@ -291,15 +291,14 @@ func benchmarkMockBulk(b *testing.B, samples [][]byte) {
 	ctx, cancelF := context.WithCancel(context.Background())
 	defer cancelF()
 
-	bulker := NewBulker(mock)
-
 	n := len(samples)
+	bulker := NewBulker(mock, WithFlushThresholdCount(n))
 
 	var waitBulker sync.WaitGroup
 	waitBulker.Add(1)
 	go func() {
 		defer waitBulker.Done()
-		if err := bulker.Run(ctx, WithFlushThresholdCount(n)); err != context.Canceled {
+		if err := bulker.Run(ctx); err != context.Canceled {
 			b.Error(err)
 		}
 	}()

--- a/internal/pkg/bulk/opApiKey.go
+++ b/internal/pkg/bulk/opApiKey.go
@@ -1,0 +1,51 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package bulk
+
+import (
+	"context"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
+)
+
+// The ApiKey API's are not yet bulk enabled.  Stub the calls in the bulker
+// and limit parallel access to prevent many requests from overloading
+// the connection pool in the elastic search client.
+
+func (b *Bulker) ApiKeyAuth(ctx context.Context, key ApiKey) (*SecurityInfo, error) {
+	if err := b.apikeyLimit.Acquire(ctx, 1); err != nil {
+		return nil, err
+	}
+	defer b.apikeyLimit.Release(1)
+
+	return key.Authenticate(ctx, b.Client())
+}
+
+func (b *Bulker) ApiKeyCreate(ctx context.Context, name, ttl string, roles []byte, meta interface{}) (*ApiKey, error) {
+	if err := b.apikeyLimit.Acquire(ctx, 1); err != nil {
+		return nil, err
+	}
+	defer b.apikeyLimit.Release(1)
+
+	return apikey.Create(ctx, b.Client(), name, ttl, roles, meta)
+}
+
+func (b *Bulker) ApiKeyRead(ctx context.Context, id string) (*ApiKeyMetadata, error) {
+	if err := b.apikeyLimit.Acquire(ctx, 1); err != nil {
+		return nil, err
+	}
+	defer b.apikeyLimit.Release(1)
+
+	return apikey.Read(ctx, b.Client(), id)
+}
+
+func (b *Bulker) ApiKeyInvalidate(ctx context.Context, ids ...string) error {
+	if err := b.apikeyLimit.Acquire(ctx, 1); err != nil {
+		return err
+	}
+	defer b.apikeyLimit.Release(1)
+
+	return apikey.Invalidate(ctx, b.Client(), ids...)
+}

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -48,6 +48,7 @@ type bulkOptT struct {
 	flushThresholdCnt int
 	flushThresholdSz  int
 	maxPending        int
+	apikeyMaxParallel int
 }
 
 type BulkOpt func(*bulkOptT)
@@ -80,9 +81,17 @@ func WithMaxPending(max int) BulkOpt {
 	}
 }
 
+// Max number of api key operations outstanding
+func WithApiKeyMaxParallel(max int) BulkOpt {
+	return func(opt *bulkOptT) {
+		opt.apikeyMaxParallel = max
+	}
+}
+
 func (o *bulkOptT) MarshalZerologObject(e *zerolog.Event) {
 	e.Dur("flushInterval", o.flushInterval)
 	e.Int("flushThresholdCnt", o.flushThresholdCnt)
 	e.Int("flushThresholdSz", o.flushThresholdSz)
 	e.Int("maxPending", o.maxPending)
+	e.Int("apikeyMaxParallel", o.apikeyMaxParallel)
 }

--- a/internal/pkg/bulk/setup_test.go
+++ b/internal/pkg/bulk/setup_test.go
@@ -115,10 +115,17 @@ func init() {
 
 func SetupBulk(ctx context.Context, t testing.TB, opts ...BulkOpt) Bulk {
 	t.Helper()
-	_, bulker, err := InitES(ctx, &defaultCfg, opts...)
+
+	cli, err := es.NewClient(ctx, &defaultCfg, false)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	opts = append(opts, BulkOptsFromCfg(&defaultCfg)...)
+
+	bulker := NewBulker(cli, opts...)
+	go bulker.Run(ctx)
+
 	return bulker
 }
 

--- a/internal/pkg/monitor/monitor.go
+++ b/internal/pkg/monitor/monitor.go
@@ -205,6 +205,9 @@ func (m *simpleMonitorT) loadCheckpoint() sqn.SeqNo {
 func (m *simpleMonitorT) Run(ctx context.Context) (err error) {
 	m.log.Info().Msg("start")
 	defer func() {
+		if err == context.Canceled {
+			err = nil
+		}
 		m.log.Info().Err(err).Msg("exited")
 	}()
 
@@ -242,6 +245,8 @@ func (m *simpleMonitorT) Run(ctx context.Context) (err error) {
 				// Timed out, wait again
 				m.log.Debug().Msg("timeout on global checkpoints advance, poll again")
 				continue
+			} else if errors.Is(err, context.Canceled) {
+				m.log.Info().Msg("context closed waiting for global checkpoints advance")
 			} else {
 				// Log the error and keep trying
 				m.log.Info().Err(err).Msg("failed on waiting for global checkpoints advance")

--- a/internal/pkg/testing/bulk.go
+++ b/internal/pkg/testing/bulk.go
@@ -70,4 +70,20 @@ func (m MockBulk) Client() *elasticsearch.Client {
 	return nil
 }
 
+func (m MockBulk) ApiKeyCreate(ctx context.Context, name, ttl string, roles []byte, meta interface{}) (*bulk.ApiKey, error) {
+	return nil, nil
+}
+
+func (m MockBulk) ApiKeyRead(ctx context.Context, id string) (*bulk.ApiKeyMetadata, error) {
+	return nil, nil
+}
+
+func (m MockBulk) ApiKeyAuth(ctx context.Context, key bulk.ApiKey) (*bulk.SecurityInfo, error) {
+	return nil, nil
+}
+
+func (m MockBulk) ApiKeyInvalidate(ctx context.Context, ids ...string) error {
+	return nil
+}
+
 var _ bulk.Bulk = (*MockBulk)(nil)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

1) Add bulk API key to bulk interface.  We don't have bulk api upstream, but this allows us to control the concurrence of the calls without having a separate pool.  When/If we get bulk calls, we can swap out transparently.
2) Refactor bulk engine startup.  Properly handle the case where the engine throws an error.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The ApiKey auth and create calls are slow; they are backing up and consuming all the connections to elastic search, starving the normal bulk api calls.
The bulk startup refactor was done largely to accommodate properly error handling when the bulk engine fails.  In addition, the process was not waiting for a clean shutdown on exit.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x ] My code follows the style guidelines of this project
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] I have made corresponding change to the default configuration files
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

