### PR TITLE
Configure cache

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -72,11 +72,11 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/dgraph-io/ristretto
-Version: v0.0.3
+Version: v0.1.0
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/dgraph-io/ristretto@v0.0.3/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/dgraph-io/ristretto@v0.1.0/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004
@@ -35585,11 +35585,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 Dependency : golang.org/x/sys
-Version: v0.0.0-20200625212154-ddb9806d33ae
+Version: v0.0.0-20200930185726-fdedc70b468f
 Licence type (autodetected): BSD-3-Clause
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/golang.org/x/sys@v0.0.0-20200625212154-ddb9806d33ae/LICENSE:
+Contents of probable licence file $GOMODCACHE/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f/LICENSE:
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
 

--- a/cmd/fleet/handleAck.go
+++ b/cmd/fleet/handleAck.go
@@ -158,7 +158,7 @@ func (ack *AckT) handleAckEvents(ctx context.Context, agent *model.Agent, events
 				return errors.New("no matching action")
 			}
 			action = actions[0]
-			ack.cache.SetAction(action, time.Minute)
+			ack.cache.SetAction(action)
 		}
 
 		acr := model.ActionResult{

--- a/cmd/fleet/handleArtifacts.go
+++ b/cmd/fleet/handleArtifacts.go
@@ -31,9 +31,8 @@ import (
 )
 
 const (
-	defaultMaxParallel = 8              // TODO: configurable
-	defaultCacheTTL    = time.Hour * 24 // TODO: configurable
-	defaultThrottleTTL = time.Minute    // TODO: configurable
+	defaultMaxParallel = 8           // TODO: configurable
+	defaultThrottleTTL = time.Minute // TODO: configurable
 )
 
 var (
@@ -244,7 +243,7 @@ func (at ArtifactT) getArtifact(ctx context.Context, zlog zerolog.Logger, ident,
 	art.Body = dstPayload
 
 	// Update the cache.
-	at.cache.SetArtifact(*art, defaultCacheTTL)
+	at.cache.SetArtifact(*art)
 
 	return art, nil
 }

--- a/cmd/fleet/handleCheckin.go
+++ b/cmd/fleet/handleCheckin.go
@@ -432,7 +432,7 @@ func processPolicy(ctx context.Context, bulker bulk.Bulk, agentId, reqId string,
 			Str("newHash", defaultRole.Sha2).
 			Msg("Generating a new API key")
 
-		defaultOutputApiKey, err := generateOutputApiKey(ctx, bulker.Client(), agent.Id, policy.DefaultOutputName, defaultRole.Raw)
+		defaultOutputApiKey, err := generateOutputApiKey(ctx, bulker, agent.Id, policy.DefaultOutputName, defaultRole.Raw)
 		if err != nil {
 			zlog.Error().Err(err).Msg("fail generate output key")
 			return nil, err

--- a/cmd/fleet/handleEnroll.go
+++ b/cmd/fleet/handleEnroll.go
@@ -127,6 +127,7 @@ func (rt Router) handleEnroll(w http.ResponseWriter, r *http.Request, ps httprou
 }
 
 func (et *EnrollerT) handleEnroll(w http.ResponseWriter, r *http.Request) (*EnrollResponse, error) {
+
 	limitF, err := et.limit.Acquire()
 	if err != nil {
 		return nil, err

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -663,7 +663,7 @@ func (f *FleetServer) runSubsystems(ctx context.Context, cfg *config.Config, g *
 	// Check version compatibility with Elasticsearch
 	err = ver.CheckCompatibility(ctx, esCli, f.ver)
 	if err != nil {
-		//		return fmt.Errorf("failed version compatibility check with elasticsearch: %w", err)
+		return fmt.Errorf("failed version compatibility check with elasticsearch: %w", err)
 	}
 
 	// Monitoring es client, longer timeout, no retries

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -663,7 +663,7 @@ func (f *FleetServer) runSubsystems(ctx context.Context, cfg *config.Config, g *
 	// Check version compatibility with Elasticsearch
 	err = ver.CheckCompatibility(ctx, esCli, f.ver)
 	if err != nil {
-		return fmt.Errorf("failed version compatibility check with elasticsearch: %w", err)
+		//		return fmt.Errorf("failed version compatibility check with elasticsearch: %w", err)
 	}
 
 	// Monitoring es client, longer timeout, no retries

--- a/cmd/fleet/server_integration_test.go
+++ b/cmd/fleet/server_integration_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/elastic/fleet-server/v7/internal/pkg/cache"
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
 	"github.com/elastic/fleet-server/v7/internal/pkg/logger"
 	"github.com/elastic/fleet-server/v7/internal/pkg/sleep"
@@ -63,11 +62,6 @@ func startTestServer(ctx context.Context) (*tserver, error) {
 		return nil, err
 	}
 
-	c, err := cache.New(cache.Config{NumCounters: 100, MaxCost: 100000})
-	if err != nil {
-		return nil, err
-	}
-
 	logger.Init(cfg)
 
 	port, err := ftesting.FreePort()
@@ -82,7 +76,7 @@ func startTestServer(ctx context.Context) (*tserver, error) {
 	cfg.Inputs[0].Server = *srvcfg
 	log.Info().Uint16("port", port).Msg("Test fleet server")
 
-	srv, err := NewFleetServer(cfg, c, serverVersion, status.NewLog())
+	srv, err := NewFleetServer(cfg, serverVersion, status.NewLog())
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/aleksmaus/generate v0.0.0-20210326194607-c630e07a2742
-	github.com/dgraph-io/ristretto v0.0.3
+	github.com/dgraph-io/ristretto v0.1.0
 	github.com/elastic/beats/v7 v7.11.1
 	github.com/elastic/elastic-agent-client/v7 v7.0.0-20200709172729-d43b7ad5833a
 	github.com/elastic/go-elasticsearch/v7 v7.13.1

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,8 @@ github.com/devigned/tab v0.1.2-0.20190607222403-0c15cf42f9a2/go.mod h1:XG9mPq0dF
 github.com/dgraph-io/badger/v2 v2.2007.3-0.20201012072640-f5a7e0a1c83b h1:mUDs72Rlzv6A4YN8w3Ra3hU9x/plOQPcQjZYL/1f5SM=
 github.com/dgraph-io/badger/v2 v2.2007.3-0.20201012072640-f5a7e0a1c83b/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
 github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
-github.com/dgraph-io/ristretto v0.0.3 h1:jh22xisGBjrEVnRZ1DVTpBVQm0Xndu8sMl0CWDzSIBI=
-github.com/dgraph-io/ristretto v0.0.3/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
+github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/LuerPI=
+github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.1-0.20190620180102-5e25c22bd5d6+incompatible h1:4jGdduO4ceTJFKf0IhgaB8NJapGqKHwC2b4xQ/cXujM=
 github.com/dgrijalva/jwt-go v3.2.1-0.20190620180102-5e25c22bd5d6+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
@@ -922,8 +922,9 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/internal/pkg/apikey/apikey_integration_test.go
+++ b/internal/pkg/apikey/apikey_integration_test.go
@@ -46,7 +46,7 @@ func TestCreateApiKeyWithMetadata(t *testing.T) {
 	// Create the key
 	agentId := uuid.Must(uuid.NewV4()).String()
 	name := uuid.Must(uuid.NewV4()).String()
-	akey, err := Create(ctx, es, name, "", []byte(testFleetRoles),
+	akey, err := Create(ctx, es, name, "", "true", []byte(testFleetRoles),
 		NewMetadata(agentId, TypeAccess))
 	if err != nil {
 		t.Fatal(err)

--- a/internal/pkg/apikey/create.go
+++ b/internal/pkg/apikey/create.go
@@ -14,7 +14,7 @@ import (
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 )
 
-func Create(ctx context.Context, client *elasticsearch.Client, name, ttl string, roles []byte, meta interface{}) (*ApiKey, error) {
+func Create(ctx context.Context, client *elasticsearch.Client, name, ttl, refresh string, roles []byte, meta interface{}) (*ApiKey, error) {
 	payload := struct {
 		Name       string          `json:"name,omitempty"`
 		Expiration string          `json:"expiration,omitempty"`
@@ -34,7 +34,7 @@ func Create(ctx context.Context, client *elasticsearch.Client, name, ttl string,
 
 	opts := []func(*esapi.SecurityCreateAPIKeyRequest){
 		client.Security.CreateAPIKey.WithContext(ctx),
-		client.Security.CreateAPIKey.WithRefresh("true"),
+		client.Security.CreateAPIKey.WithRefresh(refresh),
 	}
 
 	res, err := client.Security.CreateAPIKey(

--- a/internal/pkg/bulk/opApiKey.go
+++ b/internal/pkg/bulk/opApiKey.go
@@ -29,7 +29,7 @@ func (b *Bulker) ApiKeyCreate(ctx context.Context, name, ttl string, roles []byt
 	}
 	defer b.apikeyLimit.Release(1)
 
-	return apikey.Create(ctx, b.Client(), name, ttl, roles, meta)
+	return apikey.Create(ctx, b.Client(), name, ttl, "false", roles, meta)
 }
 
 func (b *Bulker) ApiKeyRead(ctx context.Context, id string) (*ApiKeyMetadata, error) {

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -6,25 +6,61 @@ package cache
 
 import (
 	"fmt"
+	"math/rand"
+	"sync"
 	"time"
 
 	"github.com/dgraph-io/ristretto"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
 	"github.com/elastic/fleet-server/v7/internal/pkg/model"
 )
 
+type Cache interface {
+	Reconfigure(Config) error
+
+	SetAction(model.Action)
+	GetAction(id string) (model.Action, bool)
+
+	SetApiKey(key ApiKey, enabled bool)
+	ValidApiKey(key ApiKey) bool
+
+	SetEnrollmentApiKey(id string, key model.EnrollmentApiKey, cost int64)
+	GetEnrollmentApiKey(id string) (model.EnrollmentApiKey, bool)
+
+	SetArtifact(artifact model.Artifact)
+	GetArtifact(ident, sha2 string) (model.Artifact, bool)
+}
+
 type ApiKey = apikey.ApiKey
 type SecurityInfo = apikey.SecurityInfo
 
-type Cache struct {
+type CacheT struct {
 	cache *ristretto.Cache
+	cfg   Config
+	mut   sync.RWMutex
 }
 
 type Config struct {
-	NumCounters int64 // number of keys to track frequency of
-	MaxCost     int64 // maximum cost of cache in 'cost' units
+	NumCounters  int64 // number of keys to track frequency of
+	MaxCost      int64 // maximum cost of cache in 'cost' units
+	ActionTTL    time.Duration
+	ApiKeyTTL    time.Duration
+	EnrollKeyTTL time.Duration
+	ArtifactTTL  time.Duration
+	ApiKeyJitter time.Duration
+}
+
+func (c *Config) MarshalZerologObject(e *zerolog.Event) {
+	e.Int64("numCounters", c.NumCounters)
+	e.Int64("maxCost", c.MaxCost)
+	e.Dur("actionTTL", c.ActionTTL)
+	e.Dur("enrollTTL", c.EnrollKeyTTL)
+	e.Dur("artifactTTL", c.ArtifactTTL)
+	e.Dur("apiKeyTTL", c.ApiKeyTTL)
+	e.Dur("apiKeyJitter", c.ApiKeyJitter)
 }
 
 type actionCache struct {
@@ -33,28 +69,64 @@ type actionCache struct {
 }
 
 // New creates a new cache.
-func New(cfg Config) (Cache, error) {
+func New(cfg Config) (*CacheT, error) {
+	cache, err := newCache(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	c := CacheT{
+		cache: cache,
+		cfg:   cfg,
+	}
+
+	return &c, nil
+}
+
+func newCache(cfg Config) (*ristretto.Cache, error) {
 	rcfg := &ristretto.Config{
 		NumCounters: cfg.NumCounters,
 		MaxCost:     cfg.MaxCost,
 		BufferItems: 64,
 	}
 
-	cache, err := ristretto.NewCache(rcfg)
-	return Cache{cache}, err
+	return ristretto.NewCache(rcfg)
+}
+
+// Reconfigure will drop cache
+func (c *CacheT) Reconfigure(cfg Config) error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	cache, err := newCache(cfg)
+	if err != nil {
+		return err
+	}
+
+	// Close down previous cache
+	c.cache.Close()
+
+	// And assign new one
+	c.cfg = cfg
+	c.cache = cache
+	return nil
 }
 
 // SetAction sets an action in the cache.
 //
 // This will only cache the action ID and action Type. So `GetAction` will only
 // return a `model.Action` with `ActionId` and `Type` set.
-func (c Cache) SetAction(action model.Action, ttl time.Duration) {
+func (c *CacheT) SetAction(action model.Action) {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+
 	scopedKey := "action:" + action.ActionId
 	v := actionCache{
 		actionId:   action.ActionId,
 		actionType: action.Type,
 	}
 	cost := len(action.ActionId) + len(action.Type)
+	ttl := c.cfg.ActionTTL
 	ok := c.cache.SetWithTTL(scopedKey, v, int64(cost), ttl)
 	log.Trace().
 		Bool("ok", ok).
@@ -67,7 +139,10 @@ func (c Cache) SetAction(action model.Action, ttl time.Duration) {
 //
 // This will only return a `model.Action` with the action ID and action Type set.
 // This is because `SetAction` So `GetAction` will only cache the action ID and action Type.
-func (c Cache) GetAction(id string) (model.Action, bool) {
+func (c *CacheT) GetAction(id string) (model.Action, bool) {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+
 	scopedKey := "action:" + id
 	if v, ok := c.cache.Get(scopedKey); ok {
 		log.Trace().Str("id", id).Msg("Action cache HIT")
@@ -87,12 +162,36 @@ func (c Cache) GetAction(id string) (model.Action, bool) {
 }
 
 // SetApiKey sets the API key in the cache.
-func (c Cache) SetApiKey(key ApiKey, ttl time.Duration) {
+func (c *CacheT) SetApiKey(key ApiKey, enabled bool) {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+
 	scopedKey := "api:" + key.Id
-	cost := len(scopedKey) + len(key.Key)
-	ok := c.cache.SetWithTTL(scopedKey, key.Key, int64(cost), ttl)
+
+	// Use the valid key as the payload of the record;
+	// If caller has marked key as not enabled, use empty string.
+	val := key.Key
+	if !enabled {
+		val = ""
+	}
+
+	// If enabled, jitter allows us to randomize the expirtion of the artifact
+	// across time, which is helpful if a bunch of agents came on at the same time,
+	// say during a network restoration.  With some jitter, we avoid having to
+	// revalidate  the API Keys all at the same time, which we know causes load on Elastic.
+	ttl := c.cfg.ApiKeyTTL
+	if c.cfg.ApiKeyJitter != 0 {
+		jitter := time.Duration(rand.Int63n(int64(c.cfg.ApiKeyJitter)))
+		if jitter < ttl {
+			ttl = ttl - jitter
+		}
+	}
+
+	cost := len(scopedKey) + len(val)
+	ok := c.cache.SetWithTTL(scopedKey, val, int64(cost), ttl)
 	log.Trace().
 		Bool("ok", ok).
+		Bool("enabled", enabled).
 		Str("key", key.Id).
 		Dur("ttl", ttl).
 		Int("cost", cost).
@@ -100,13 +199,19 @@ func (c Cache) SetApiKey(key ApiKey, ttl time.Duration) {
 }
 
 // ValidApiKey returns true if the ApiKey is valid (aka. also present in cache).
-func (c Cache) ValidApiKey(key ApiKey) bool {
+func (c *CacheT) ValidApiKey(key ApiKey) bool {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+
 	scopedKey := "api:" + key.Id
 	v, ok := c.cache.Get(scopedKey)
 	if ok {
-		if v == key.Key {
+		switch v {
+		case "":
+			log.Trace().Str("id", key.Id).Msg("ApiKey cache HIT on disabled KEY")
+		case key.Key:
 			log.Trace().Str("id", key.Id).Msg("ApiKey cache HIT")
-		} else {
+		default:
 			log.Trace().Str("id", key.Id).Msg("ApiKey cache MISMATCH")
 			ok = false
 		}
@@ -117,7 +222,10 @@ func (c Cache) ValidApiKey(key ApiKey) bool {
 }
 
 // GetEnrollmentApiKey returns the enrollment API key by ID.
-func (c Cache) GetEnrollmentApiKey(id string) (model.EnrollmentApiKey, bool) {
+func (c *CacheT) GetEnrollmentApiKey(id string) (model.EnrollmentApiKey, bool) {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+
 	scopedKey := "record:" + id
 	if v, ok := c.cache.Get(scopedKey); ok {
 		log.Trace().Str("id", id).Msg("Enrollment cache HIT")
@@ -135,8 +243,12 @@ func (c Cache) GetEnrollmentApiKey(id string) (model.EnrollmentApiKey, bool) {
 }
 
 // SetEnrollmentApiKey adds the enrollment API key into the cache.
-func (c Cache) SetEnrollmentApiKey(id string, key model.EnrollmentApiKey, cost int64, ttl time.Duration) {
+func (c *CacheT) SetEnrollmentApiKey(id string, key model.EnrollmentApiKey, cost int64) {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+
 	scopedKey := "record:" + id
+	ttl := c.cfg.EnrollKeyTTL
 	ok := c.cache.SetWithTTL(scopedKey, key, cost, ttl)
 	log.Trace().
 		Bool("ok", ok).
@@ -150,7 +262,10 @@ func makeArtifactKey(ident, sha2 string) string {
 	return fmt.Sprintf("artifact:%s:%s", ident, sha2)
 }
 
-func (c Cache) GetArtifact(ident, sha2 string) (model.Artifact, bool) {
+func (c *CacheT) GetArtifact(ident, sha2 string) (model.Artifact, bool) {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+
 	scopedKey := makeArtifactKey(ident, sha2)
 	if v, ok := c.cache.Get(scopedKey); ok {
 		log.Trace().Str("key", scopedKey).Msg("Artifact cache HIT")
@@ -168,9 +283,14 @@ func (c Cache) GetArtifact(ident, sha2 string) (model.Artifact, bool) {
 }
 
 // TODO: strip body and spool to on disk cache if larger than a size threshold
-func (c Cache) SetArtifact(artifact model.Artifact, ttl time.Duration) {
+func (c *CacheT) SetArtifact(artifact model.Artifact) {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+
 	scopedKey := makeArtifactKey(artifact.Identifier, artifact.DecodedSha256)
 	cost := int64(len(artifact.Body))
+	ttl := c.cfg.ArtifactTTL
+
 	ok := c.cache.SetWithTTL(scopedKey, artifact, cost, ttl)
 	log.Trace().
 		Bool("ok", ok).

--- a/internal/pkg/config/cache.go
+++ b/internal/pkg/config/cache.go
@@ -4,17 +4,36 @@
 
 package config
 
+import (
+	"time"
+)
+
 const (
 	defaultCacheNumCounters = 500000           // 10x times expected count
 	defaultCacheMaxCost     = 50 * 1024 * 1024 // 50MiB cache size
+	defaultActionTTL        = time.Minute * 5
+	defaultEnrollKeyTTL     = time.Minute
+	defaultArtifactTTL      = time.Hour * 24
+	defaultApiKeyTTL        = time.Minute * 15 // ApiKey validation is a bottleneck.
+	defaultApiKeyJitter     = time.Minute * 5  // Jitter allows some randomness on ApiKeyTTL, zero to disable
 )
 
 type Cache struct {
-	NumCounters int64 `config:"num_counters"`
-	MaxCost     int64 `config:"max_cost"`
+	NumCounters  int64         `config:"num_counters"`
+	MaxCost      int64         `config:"max_cost"`
+	ActionTTL    time.Duration `config:"ttl_action"`
+	EnrollKeyTTL time.Duration `config:"ttl_enroll_key"`
+	ArtifactTTL  time.Duration `config:"ttl_artifact"`
+	ApiKeyTTL    time.Duration `config:"ttl_api_key"`
+	ApiKeyJitter time.Duration `config:"jitter_api_key"`
 }
 
 func (c *Cache) InitDefaults() {
 	c.NumCounters = defaultCacheNumCounters
 	c.MaxCost = defaultCacheMaxCost
+	c.ActionTTL = defaultActionTTL
+	c.EnrollKeyTTL = defaultEnrollKeyTTL
+	c.ArtifactTTL = defaultArtifactTTL
+	c.ApiKeyTTL = defaultApiKeyTTL
+	c.ApiKeyJitter = defaultApiKeyJitter
 }

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -24,95 +24,23 @@ func TestConfig(t *testing.T) {
 	}{
 		"basic": {
 			cfg: &Config{
-				Fleet: Fleet{
-					Agent: Agent{
-						ID:      "1e4954ce-af37-4731-9f4a-407b08e69e42",
-						Logging: AgentLogging{},
-					},
-				},
+				Fleet: defaultFleet(),
 				Output: Output{
-					Elasticsearch: Elasticsearch{
-						Protocol:                "http",
-						Hosts:                   []string{"localhost:9200"},
-						Username:                "elastic",
-						Password:                "changeme",
-						MaxRetries:              3,
-						MaxConnPerHost:          128,
-						BulkFlushInterval:       250 * time.Millisecond,
-						BulkFlushThresholdCount: 2048,
-						BulkFlushThresholdSize:  1048576,
-						BulkFlushMaxPending:     8,
-						Timeout:                 90 * time.Second,
-					},
+					Elasticsearch: defaultElastic(),
 				},
 				Inputs: []Input{
 					{
-						Type: "fleet-server",
-						Server: Server{
-							Host: kDefaultHost,
-							Port: kDefaultPort,
-							Timeouts: ServerTimeouts{
-								Read:             60 * time.Second,
-								ReadHeader:       5 * time.Second,
-								Idle:             30 * time.Second,
-								Write:            10 * time.Minute,
-								CheckinTimestamp: 30 * time.Second,
-								CheckinLongPoll:  5 * time.Minute,
-							},
-							Profiler: ServerProfiler{
-								Enabled: false,
-								Bind:    "localhost:6060",
-							},
-							CompressionLevel:  1,
-							CompressionThresh: 1024,
-							Limits: ServerLimits{
-								MaxHeaderByteSize: 8192,
-								MaxConnections:    0,
-								PolicyThrottle:    5 * time.Millisecond,
-								CheckinLimit: Limit{
-									Interval: time.Millisecond,
-									Burst:    1000,
-									MaxBody:  1048576,
-								},
-								ArtifactLimit: Limit{
-									Interval: time.Millisecond * 5,
-									Burst:    25,
-									Max:      50,
-								},
-								EnrollLimit: Limit{
-									Interval: time.Millisecond * 10,
-									Burst:    100,
-									Max:      50,
-									MaxBody:  524288,
-								},
-								AckLimit: Limit{
-									Interval: time.Millisecond * 10,
-									Burst:    100,
-									Max:      50,
-									MaxBody:  2097152,
-								},
-							},
-						},
-						Cache: Cache{
-							NumCounters: defaultCacheNumCounters,
-							MaxCost:     defaultCacheMaxCost,
-						},
+						Type:   "fleet-server",
+						Server: defaultServer(),
+						Cache:  defaultCache(),
 						Monitor: Monitor{
 							FetchSize:   defaultFetchSize,
 							PollTimeout: defaultPollTimeout,
 						},
 					},
 				},
-				Logging: Logging{
-					Level:    "info",
-					ToStderr: false,
-					ToFiles:  true,
-					Files:    nil,
-				},
-				HTTP: HTTP{
-					Host: kDefaultHTTPHost,
-					Port: kDefaultHTTPPort,
-				},
+				Logging: defaultLogging(),
+				HTTP:    defaultHTTP(),
 			},
 		},
 		"fleet-logging": {
@@ -126,205 +54,49 @@ func TestConfig(t *testing.T) {
 					},
 				},
 				Output: Output{
-					Elasticsearch: Elasticsearch{
-						Protocol:                "http",
-						Hosts:                   []string{"localhost:9200"},
-						Username:                "elastic",
-						Password:                "changeme",
-						MaxRetries:              3,
-						MaxConnPerHost:          128,
-						BulkFlushInterval:       250 * time.Millisecond,
-						BulkFlushThresholdCount: 2048,
-						BulkFlushThresholdSize:  1048576,
-						BulkFlushMaxPending:     8,
-						Timeout:                 90 * time.Second,
-					},
+					Elasticsearch: defaultElastic(),
 				},
 				Inputs: []Input{
 					{
-						Type: "fleet-server",
-						Server: Server{
-							Host: kDefaultHost,
-							Port: kDefaultPort,
-							Timeouts: ServerTimeouts{
-								Read:             60 * time.Second,
-								ReadHeader:       5 * time.Second,
-								Idle:             30 * time.Second,
-								Write:            10 * time.Minute,
-								CheckinTimestamp: 30 * time.Second,
-								CheckinLongPoll:  5 * time.Minute,
-							},
-							Profiler: ServerProfiler{
-								Enabled: false,
-								Bind:    "localhost:6060",
-							},
-							CompressionLevel:  1,
-							CompressionThresh: 1024,
-							Limits: ServerLimits{
-								MaxHeaderByteSize: 8192,
-								MaxConnections:    0,
-								PolicyThrottle:    5 * time.Millisecond,
-								CheckinLimit: Limit{
-									Interval: time.Millisecond,
-									Burst:    1000,
-									MaxBody:  1048576,
-								},
-								ArtifactLimit: Limit{
-									Interval: time.Millisecond * 5,
-									Burst:    25,
-									Max:      50,
-								},
-								EnrollLimit: Limit{
-									Interval: time.Millisecond * 10,
-									Burst:    100,
-									Max:      50,
-									MaxBody:  524288,
-								},
-								AckLimit: Limit{
-									Interval: time.Millisecond * 10,
-									Burst:    100,
-									Max:      50,
-									MaxBody:  2097152,
-								},
-							},
-						},
-						Cache: Cache{
-							NumCounters: defaultCacheNumCounters,
-							MaxCost:     defaultCacheMaxCost,
-						},
+						Type:   "fleet-server",
+						Server: defaultServer(),
+						Cache:  defaultCache(),
 						Monitor: Monitor{
 							FetchSize:   defaultFetchSize,
 							PollTimeout: defaultPollTimeout,
 						},
 					},
 				},
-				Logging: Logging{
-					Level:    "info",
-					ToStderr: false,
-					ToFiles:  true,
-					Files:    nil,
-				},
-				HTTP: HTTP{
-					Host: kDefaultHTTPHost,
-					Port: kDefaultHTTPPort,
-				},
+				Logging: defaultLogging(),
+				HTTP:    defaultHTTP(),
 			},
 		},
 		"input": {
 			cfg: &Config{
-				Fleet: Fleet{
-					Agent: Agent{
-						ID:      "1e4954ce-af37-4731-9f4a-407b08e69e42",
-						Logging: AgentLogging{},
-					},
-				},
+				Fleet: defaultFleet(),
 				Output: Output{
-					Elasticsearch: Elasticsearch{
-						Protocol:                "http",
-						Hosts:                   []string{"localhost:9200"},
-						Username:                "elastic",
-						Password:                "changeme",
-						MaxRetries:              3,
-						MaxConnPerHost:          128,
-						BulkFlushInterval:       250 * time.Millisecond,
-						BulkFlushThresholdCount: 2048,
-						BulkFlushThresholdSize:  1048576,
-						BulkFlushMaxPending:     8,
-						Timeout:                 90 * time.Second,
-					},
+					Elasticsearch: defaultElastic(),
 				},
 				Inputs: []Input{
 					{
-						Type: "fleet-server",
-						Server: Server{
-							Host: kDefaultHost,
-							Port: kDefaultPort,
-							Timeouts: ServerTimeouts{
-								Read:             60 * time.Second,
-								ReadHeader:       5 * time.Second,
-								Idle:             30 * time.Second,
-								Write:            10 * time.Minute,
-								CheckinTimestamp: 30 * time.Second,
-								CheckinLongPoll:  5 * time.Minute,
-							},
-							Profiler: ServerProfiler{
-								Enabled: false,
-								Bind:    "localhost:6060",
-							},
-							CompressionLevel:  1,
-							CompressionThresh: 1024,
-							Limits: ServerLimits{
-								MaxHeaderByteSize: 8192,
-								MaxConnections:    0,
-								PolicyThrottle:    5 * time.Millisecond,
-								CheckinLimit: Limit{
-									Interval: time.Millisecond,
-									Burst:    1000,
-									MaxBody:  1048576,
-								},
-								ArtifactLimit: Limit{
-									Interval: time.Millisecond * 5,
-									Burst:    25,
-									Max:      50,
-								},
-								EnrollLimit: Limit{
-									Interval: time.Millisecond * 10,
-									Burst:    100,
-									Max:      50,
-									MaxBody:  524288,
-								},
-								AckLimit: Limit{
-									Interval: time.Millisecond * 10,
-									Burst:    100,
-									Max:      50,
-									MaxBody:  2097152,
-								},
-							},
-						},
-						Cache: Cache{
-							NumCounters: defaultCacheNumCounters,
-							MaxCost:     defaultCacheMaxCost,
-						},
+						Type:   "fleet-server",
+						Server: defaultServer(),
+						Cache:  defaultCache(),
 						Monitor: Monitor{
 							FetchSize:   defaultFetchSize,
 							PollTimeout: defaultPollTimeout,
 						},
 					},
 				},
-				Logging: Logging{
-					Level:    "info",
-					ToStderr: false,
-					ToFiles:  true,
-					Files:    nil,
-				},
-				HTTP: HTTP{
-					Host: kDefaultHTTPHost,
-					Port: kDefaultHTTPPort,
-				},
+				Logging: defaultLogging(),
+				HTTP:    defaultHTTP(),
 			},
 		},
 		"input-config": {
 			cfg: &Config{
-				Fleet: Fleet{
-					Agent: Agent{
-						ID:      "1e4954ce-af37-4731-9f4a-407b08e69e42",
-						Logging: AgentLogging{},
-					},
-				},
+				Fleet: defaultFleet(),
 				Output: Output{
-					Elasticsearch: Elasticsearch{
-						Protocol:                "http",
-						Hosts:                   []string{"localhost:9200"},
-						Username:                "elastic",
-						Password:                "changeme",
-						MaxRetries:              3,
-						MaxConnPerHost:          128,
-						BulkFlushInterval:       250 * time.Millisecond,
-						BulkFlushThresholdCount: 2048,
-						BulkFlushThresholdSize:  1048576,
-						BulkFlushMaxPending:     8,
-						Timeout:                 90 * time.Second,
-					},
+					Elasticsearch: defaultElastic(),
 				},
 				Inputs: []Input{
 					{
@@ -346,54 +118,17 @@ func TestConfig(t *testing.T) {
 							},
 							CompressionLevel:  1,
 							CompressionThresh: 1024,
-							Limits: ServerLimits{
-								MaxHeaderByteSize: 8192,
-								MaxConnections:    0,
-								PolicyThrottle:    5 * time.Millisecond,
-								CheckinLimit: Limit{
-									Interval: time.Millisecond,
-									Burst:    1000,
-									MaxBody:  1048576,
-								},
-								ArtifactLimit: Limit{
-									Interval: time.Millisecond * 5,
-									Burst:    25,
-									Max:      50,
-								},
-								EnrollLimit: Limit{
-									Interval: time.Millisecond * 10,
-									Burst:    100,
-									Max:      50,
-									MaxBody:  524288,
-								},
-								AckLimit: Limit{
-									Interval: time.Millisecond * 10,
-									Burst:    100,
-									Max:      50,
-									MaxBody:  2097152,
-								},
-							},
+							Limits:            defaultServerLimits(),
 						},
-						Cache: Cache{
-							NumCounters: defaultCacheNumCounters,
-							MaxCost:     defaultCacheMaxCost,
-						},
+						Cache: defaultCache(),
 						Monitor: Monitor{
 							FetchSize:   defaultFetchSize,
 							PollTimeout: defaultPollTimeout,
 						},
 					},
 				},
-				Logging: Logging{
-					Level:    "info",
-					ToStderr: false,
-					ToFiles:  true,
-					Files:    nil,
-				},
-				HTTP: HTTP{
-					Host: kDefaultHTTPHost,
-					Port: kDefaultHTTPPort,
-				},
+				Logging: defaultLogging(),
+				HTTP:    defaultHTTP(),
 			},
 		},
 		"bad-input": {
@@ -432,4 +167,67 @@ func TestConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Stub out the defaults so that the above is easier to maintain
+
+func defaultCache() Cache {
+	var d Cache
+	d.InitDefaults()
+	return d
+}
+
+func defaultServerTimeouts() ServerTimeouts {
+	var d ServerTimeouts
+	d.InitDefaults()
+	return d
+}
+
+func defaultServerLimits() ServerLimits {
+	var d ServerLimits
+	d.InitDefaults()
+	return d
+}
+
+func defaultLogging() Logging {
+	var d Logging
+	d.InitDefaults()
+	return d
+}
+
+func defaultHTTP() HTTP {
+	var d HTTP
+	d.InitDefaults()
+	return d
+}
+
+func defaultFleet() Fleet {
+	return Fleet{
+		Agent: Agent{
+			ID:      "1e4954ce-af37-4731-9f4a-407b08e69e42",
+			Logging: AgentLogging{},
+		},
+	}
+}
+
+func defaultElastic() Elasticsearch {
+	return Elasticsearch{
+		Protocol:                "http",
+		Hosts:                   []string{"localhost:9200"},
+		Username:                "elastic",
+		Password:                "changeme",
+		MaxRetries:              3,
+		MaxConnPerHost:          128,
+		BulkFlushInterval:       250 * time.Millisecond,
+		BulkFlushThresholdCount: 2048,
+		BulkFlushThresholdSize:  1048576,
+		BulkFlushMaxPending:     8,
+		Timeout:                 90 * time.Second,
+	}
+}
+
+func defaultServer() Server {
+	var d Server
+	d.InitDefaults()
+	return d
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Makes the TTL values on the cache objects configurable.  Allows cache to be reconfigured without restarting the process.  Cache is dropped on reconfiguration.

Increate the TTL on the api key to 15m with optional jitter.   This is to work around latency issues at scale with validating API .  In addition, validate that 'enabled' flag on the agent during auth.   Between the 'enabled' flag, and the ability to drop the cache by reconfiguration in a break glass scenario, it seems minimize auth round trips to elastic.  This takes load off the fleet-server as well as elastic.

Also, cache the case when an api key is not valid.  This avoids roundtrip for an already disabled api key.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The server runs into issues at large scale while trying to validate many ApiKeys at once.  Particularly when a policy changes and there are many GET requests for artifacts. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x ] My code follows the style guidelines of this project
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] I have made corresponding change to the default configuration files
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

