### PR TITLE
Policy tests occasionally fail in jenkins.  Force init to be determin…

### DIFF
--- a/internal/pkg/policy/monitor_test.go
+++ b/internal/pkg/policy/monitor_test.go
@@ -45,6 +45,10 @@ func TestMonitor_NewPolicy(t *testing.T) {
 		merr = monitor.Run(ctx)
 	}()
 
+	if err := monitor.(*monitorT).waitStart(ctx); err != nil {
+		t.Fatal(err)
+	}
+
 	agentId := uuid.Must(uuid.NewV4()).String()
 	policyId := uuid.Must(uuid.NewV4()).String()
 	s, err := monitor.Subscribe(agentId, policyId, 0, 0)

--- a/internal/pkg/policy/self_test.go
+++ b/internal/pkg/policy/self_test.go
@@ -53,6 +53,10 @@ func TestSelfMonitor_DefaultPolicy(t *testing.T) {
 		merr = monitor.Run(ctx)
 	}()
 
+	if err := monitor.(*selfMonitorT).waitStart(ctx); err != nil {
+		t.Fatal(err)
+	}
+
 	// should be set to starting
 	ftesting.Retry(t, ctx, func(ctx context.Context) error {
 		status, msg, _ := reporter.Current()
@@ -160,6 +164,10 @@ func TestSelfMonitor_DefaultPolicy_Degraded(t *testing.T) {
 		defer mwg.Done()
 		merr = monitor.Run(ctx)
 	}()
+
+	if err := monitor.(*selfMonitorT).waitStart(ctx); err != nil {
+		t.Fatal(err)
+	}
 
 	// should be set to starting
 	ftesting.Retry(t, ctx, func(ctx context.Context) error {
@@ -312,6 +320,10 @@ func TestSelfMonitor_SpecificPolicy(t *testing.T) {
 		merr = monitor.Run(ctx)
 	}()
 
+	if err := monitor.(*selfMonitorT).waitStart(ctx); err != nil {
+		t.Fatal(err)
+	}
+
 	// should be set to starting
 	ftesting.Retry(t, ctx, func(ctx context.Context) error {
 		status, msg, _ := reporter.Current()
@@ -419,6 +431,10 @@ func TestSelfMonitor_SpecificPolicy_Degraded(t *testing.T) {
 		defer mwg.Done()
 		merr = monitor.Run(ctx)
 	}()
+
+	if err := monitor.(*selfMonitorT).waitStart(ctx); err != nil {
+		t.Fatal(err)
+	}
 
 	// should be set to starting
 	ftesting.Retry(t, ctx, func(ctx context.Context) error {


### PR DESCRIPTION
…istic.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Several of the policy unit tests are non-deterministic and may fail in jenkins bulid.  Force deterministic startup sequence.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Sporadic failed unit tests are annoying.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x ] My code follows the style guidelines of this project
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] I have made corresponding change to the default configuration files
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

