### PR TITLE
Automate the go version update

### DIFF
--- a/.ci/bump-go-release-version.sh
+++ b/.ci/bump-go-release-version.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Given the Golang release version this script will bump the version.
+#
+# This script is executed by the automation we are putting in place
+# and it requires the git add/commit commands.
+#
+# Parameters:
+#	$1 -> the Golang release version to be bumped. Mandatory.
+#
+set -euo pipefail
+MSG="parameter missing."
+GO_RELEASE_VERSION=${1:?$MSG}
+
+echo "Update go version ${GO_RELEASE_VERSION}"
+echo "${GO_RELEASE_VERSION}" > .go-version
+
+git add .go-version
+git diff --staged --quiet || git commit -m "[Automation] Update go release version to ${GO_RELEASE_VERSION}"
+git --no-pager log -1
+
+echo "You can now push and create a Pull Request"

--- a/.ci/jobs/fleet-server.yml
+++ b/.ci/jobs/fleet-server.yml
@@ -13,7 +13,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
-        head-filter-regex: '^(?!update-stack-version).*$'
+        head-filter-regex: '^(?!update-.*-version).*$'
         notification-context: 'fleet-server'
         repo: fleet-server
         repo-owner: elastic

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -75,11 +75,11 @@ pull_request_rules:
       merge:
         method: squash
         strict: smart+fasttrack
-  - name: delete upstream branch after merging changes on dev-tools/integration/.env
+  - name: delete upstream branch after merging changes on dev-tools/integration/.env or .go-version
     conditions:
       - merged
       - label=automation
-      - head~=^update-stack-version
-      - files~=^dev-tools/integration/.env$
+      - head~=^update-.*-version
+      - files~=^(dev-tools/integration/.env|.go-version)$
     actions:
       delete_head_branch:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -75,11 +75,14 @@ pull_request_rules:
       merge:
         method: squash
         strict: smart+fasttrack
-  - name: delete upstream branch after merging changes on dev-tools/integration/.env or .go-version
+  - name: delete upstream branch with changes on dev-tools/integration/.env or .go-version after merging/closing it
     conditions:
-      - merged
-      - label=automation
-      - head~=^update-.*-version
-      - files~=^(dev-tools/integration/.env|.go-version)$
+      - or:
+        - merged
+        - closed
+      - and:
+        - label=automation
+        - head~=^update-.*-version
+        - files~=^(dev-tools/integration/.env|.go-version)$
     actions:
       delete_head_branch:


### PR DESCRIPTION
## What does this PR do?

Delegate the update for the go-version to be done automatically.

You can use this script locally:

```bash
.ci/bump-go-release-version.sh <new-go-version>
```

NOTE: it will add and commit the changes in the existing branch. The push and PR creation is not done within this script.

## Why is it important?

No more manual actions.

## Further details

This automation will not merge the PR automatically, neither it will create any backports.
We do want the teams to do so:
- Review the changes and validate the CI status
- Create the relevant backports either with mergify or manually with some other tooling.

This particular automation will run on weekly basis. The pipeline is [bump-go-release-version-pipeline](https://apm-ci.elastic.co/job/apm-shared/job/bump-go-release-version-pipeline/)

## Tests


```bash
$ .ci/bump-go-release-version.sh 1.16.6
Update go version 1.16.6
[feature/upgrade-go-version-automation 4bdcc1a] [Automation] Update go release version to 1.16.6
 1 file changed, 1 insertion(+), 1 deletion(-)
commit 4bdcc1ad38d2b29ddc439216babdbfb05e09382e (HEAD -> feature/upgrade-go-version-automation)
Author: Victor Martinez <VictorMartinezRubio@gmail.com>
Date:   Wed Jun 16 13:31:08 2021 +0100

    [Automation] Update go release version to 1.16.6
You can now push and create a Pull Request

```

produces

```diff
diff --git a/.go-version b/.go-version
index 0d92a10..de646d2 100644
--- a/.go-version
+++ b/.go-version
@@ -1 +1 @@
-1.16.5
+1.16.6
```