### PR TITLE
Add unenroller based on unenroll_timeout from policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ generate: ## - Generate schema models
 	@printf "${CMD_COLOR_ON} Installing module for go generate\n${CMD_COLOR_OFF}"
 	env GOBIN=${GOBIN} go install github.com/aleksmaus/generate/cmd/schema-generate@latest
 	@printf "${CMD_COLOR_ON} Running go generate\n${CMD_COLOR_OFF}"
-	env PATH=${GOBIN}:${PATH} go generate ./...
+	env PATH="${GOBIN}:${PATH}" go generate ./...
 
 .PHONY: check
 check: ## - Run all checks
@@ -60,7 +60,7 @@ check: ## - Run all checks
 .PHONY: check-headers
 check-headers:  ## - Check copyright headers
 	@env GOBIN=${GOBIN} go install github.com/elastic/go-licenser@latest
-	@env PATH=${GOBIN}:${PATH} go-licenser -license Elastic
+	@env PATH="${GOBIN}:${PATH}" go-licenser -license Elastic
 
 .PHONY: check-go
 check-go: ## - Run go fmt, go vet, go mod tidy
@@ -74,7 +74,7 @@ notice: ## - Generates the NOTICE.txt file.
 	@go mod tidy
 	@go mod download all
 	@env GOBIN=${GOBIN} go install go.elastic.co/go-licence-detector@latest
-	go list -m -json all | env PATH=${GOBIN}:${PATH} go-licence-detector \
+	go list -m -json all | env PATH="${GOBIN}:${PATH}" go-licence-detector \
 		-includeIndirect \
 		-rules dev-tools/notice/rules.json \
 		-overrides dev-tools/notice/overrides.json \

--- a/internal/pkg/dl/agent.go
+++ b/internal/pkg/dl/agent.go
@@ -6,6 +6,7 @@ package dl
 
 import (
 	"context"
+	"time"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/dsl"
@@ -17,8 +18,9 @@ const (
 )
 
 var (
-	QueryAgentByAssessAPIKeyID = prepareAgentFindByAccessAPIKeyID()
-	QueryAgentByID             = prepareAgentFindByID()
+	QueryAgentByAssessAPIKeyID   = prepareAgentFindByAccessAPIKeyID()
+	QueryAgentByID               = prepareAgentFindByID()
+	QueryOfflineAgentsByPolicyID = prepareOfflineAgentsByPolicyID()
 )
 
 func prepareAgentFindByID() *dsl.Tmpl {
@@ -33,8 +35,22 @@ func prepareAgentFindByField(field string) *dsl.Tmpl {
 	return prepareFindByField(field, map[string]interface{}{"version": true})
 }
 
-func FindAgent(ctx context.Context, bulker bulk.Bulk, tmpl *dsl.Tmpl, name string, v interface{}) (agent model.Agent, err error) {
-	res, err := SearchWithOneParam(ctx, bulker, tmpl, FleetAgents, name, v)
+func prepareOfflineAgentsByPolicyID() *dsl.Tmpl {
+	tmpl := dsl.NewTmpl()
+
+	root := dsl.NewRoot()
+	filter := root.Query().Bool().Filter()
+	filter.Term(FieldActive, true, nil)
+	filter.Term(FieldPolicyId, tmpl.Bind(FieldPolicyId), nil)
+	filter.Range(FieldLastCheckin, dsl.WithRangeLTE(tmpl.Bind(FieldLastCheckin)))
+
+	tmpl.MustResolve(root)
+	return tmpl
+}
+
+func FindAgent(ctx context.Context, bulker bulk.Bulk, tmpl *dsl.Tmpl, name string, v interface{}, opt ...Option) (agent model.Agent, err error) {
+	o := newOption(FleetAgents, opt...)
+	res, err := SearchWithOneParam(ctx, bulker, tmpl, o.indexName, name, v)
 	if err != nil {
 		return
 	}
@@ -45,4 +61,28 @@ func FindAgent(ctx context.Context, bulker bulk.Bulk, tmpl *dsl.Tmpl, name strin
 
 	err = res.Hits[0].Unmarshal(&agent)
 	return agent, err
+}
+
+func FindOfflineAgents(ctx context.Context, bulker bulk.Bulk, policyId string, unenrollTimeout time.Duration, opt ...Option) ([]model.Agent, error) {
+	o := newOption(FleetAgents, opt...)
+	past := time.Now().UTC().Add(-unenrollTimeout).Format(time.RFC3339)
+	res, err := Search(ctx, bulker, QueryOfflineAgentsByPolicyID, o.indexName, map[string]interface{}{
+		FieldPolicyId:    policyId,
+		FieldLastCheckin: past,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(res.Hits) == 0 {
+		return nil, nil
+	}
+
+	agents := make([]model.Agent, len(res.Hits))
+	for i, hit := range res.Hits {
+		if err := hit.Unmarshal(&agents[i]); err != nil {
+			return nil, err
+		}
+	}
+	return agents, nil
 }

--- a/internal/pkg/dl/agent_integration_test.go
+++ b/internal/pkg/dl/agent_integration_test.go
@@ -1,0 +1,110 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build integration
+
+package dl
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
+	"github.com/elastic/fleet-server/v7/internal/pkg/es"
+	"github.com/elastic/fleet-server/v7/internal/pkg/model"
+	ftesting "github.com/elastic/fleet-server/v7/internal/pkg/testing"
+)
+
+func TestFindOfflineAgents(t *testing.T) {
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+
+	index, bulker := ftesting.SetupIndexWithBulk(ctx, t, es.MappingAgent)
+
+	now := time.Now().UTC()
+	nowStr := now.Format(time.RFC3339)
+
+	policyID := uuid.Must(uuid.NewV4()).String()
+	dayOld := now.Add(-24 * time.Hour).Format(time.RFC3339)
+	dayOldID := uuid.Must(uuid.NewV4()).String()
+	body, err := json.Marshal(model.Agent{
+		PolicyId:          policyID,
+		Active:            true,
+		LastCheckin:       dayOld,
+		LastCheckinStatus: "",
+		UpdatedAt:         dayOld,
+		EnrolledAt:        nowStr,
+	})
+	require.NoError(t, err)
+	_, err = bulker.Create(ctx, index, dayOldID, body, bulk.WithRefresh())
+	require.NoError(t, err)
+
+	twoDayOld := now.Add(-48 * time.Hour).Format(time.RFC3339)
+	twoDayOldID := uuid.Must(uuid.NewV4()).String()
+	body, err = json.Marshal(model.Agent{
+		PolicyId:          policyID,
+		Active:            true,
+		LastCheckin:       twoDayOld,
+		LastCheckinStatus: "",
+		UpdatedAt:         twoDayOld,
+		EnrolledAt:        nowStr,
+	})
+	require.NoError(t, err)
+	_, err = bulker.Create(ctx, index, twoDayOldID, body, bulk.WithRefresh())
+	require.NoError(t, err)
+
+	// not active (should not be included)
+	notActiveID := uuid.Must(uuid.NewV4()).String()
+	body, err = json.Marshal(model.Agent{
+		PolicyId:          policyID,
+		Active:            false,
+		LastCheckin:       twoDayOld,
+		LastCheckinStatus: "",
+		UpdatedAt:         twoDayOld,
+		EnrolledAt:        nowStr,
+	})
+	require.NoError(t, err)
+	_, err = bulker.Create(ctx, index, notActiveID, body, bulk.WithRefresh())
+	require.NoError(t, err)
+
+	threeDayOld := now.Add(-48 * time.Hour).Format(time.RFC3339)
+	threeDayOldID := uuid.Must(uuid.NewV4()).String()
+	body, err = json.Marshal(model.Agent{
+		PolicyId:          policyID,
+		Active:            true,
+		LastCheckin:       threeDayOld,
+		LastCheckinStatus: "",
+		UpdatedAt:         threeDayOld,
+		EnrolledAt:        nowStr,
+	})
+	require.NoError(t, err)
+	_, err = bulker.Create(ctx, index, threeDayOldID, body, bulk.WithRefresh())
+	require.NoError(t, err)
+
+	// add agent on a different policy; should not be returned (3 days old)
+	otherPolicyID := uuid.Must(uuid.NewV4()).String()
+	otherID := uuid.Must(uuid.NewV4()).String()
+	body, err = json.Marshal(model.Agent{
+		PolicyId:          otherPolicyID,
+		Active:            true,
+		LastCheckin:       threeDayOld,
+		LastCheckinStatus: "",
+		UpdatedAt:         threeDayOld,
+		EnrolledAt:        nowStr,
+	})
+	require.NoError(t, err)
+	_, err = bulker.Create(ctx, index, otherID, body, bulk.WithRefresh())
+	require.NoError(t, err)
+
+	agents, err := FindOfflineAgents(ctx, bulker, policyID, 36*time.Hour, WithIndexName(index))
+	require.NoError(t, err)
+	require.Len(t, agents, 2)
+	assert.EqualValues(t, []string{twoDayOldID, threeDayOldID}, []string{agents[0].Id, agents[1].Id})
+}

--- a/internal/pkg/dl/constants.go
+++ b/internal/pkg/dl/constants.go
@@ -39,6 +39,7 @@ const (
 	FieldDefaultApiKey               = "default_api_key"
 	FieldDefaultApiKeyId             = "default_api_key_id"
 	FieldPolicyOutputPermissionsHash = "policy_output_permissions_hash"
+	FieldUnenrolledReason            = "unenrolled_reason"
 
 	FieldActive           = "active"
 	FieldUpdatedAt        = "updated_at"

--- a/internal/pkg/es/mapping.go
+++ b/internal/pkg/es/mapping.go
@@ -146,6 +146,9 @@ const (
 		"unenrolled_at": {
 			"type": "date"
 		},
+		"unenrolled_reason": {
+			"type": "keyword"
+		},
 		"unenrollment_started_at": {
 			"type": "date"
 		},
@@ -304,6 +307,9 @@ const (
 		},
 		"@timestamp": {
 			"type": "date"
+		},
+		"unenroll_timeout": {
+			"type": "integer"
 		}		
 	}
 }`

--- a/internal/pkg/model/schema.go
+++ b/internal/pkg/model/schema.go
@@ -150,6 +150,9 @@ type Agent struct {
 	// Date/time the Elastic Agent unenrolled
 	UnenrolledAt string `json:"unenrolled_at,omitempty"`
 
+	// Reason the Elastic Agent was unenrolled
+	UnenrolledReason string `json:"unenrolled_reason,omitempty"`
+
 	// Date/time the Elastic Agent unenrolled started
 	UnenrollmentStartedAt string `json:"unenrollment_started_at,omitempty"`
 
@@ -281,6 +284,9 @@ type Policy struct {
 
 	// Date/time the policy revision was created
 	Timestamp string `json:"@timestamp,omitempty"`
+
+	// Timeout (seconds) that an Elastic Agent should be un-enrolled.
+	UnenrollTimeout int64 `json:"unenroll_timeout,omitempty"`
 }
 
 // PolicyLeader The current leader Fleet Server for a policy

--- a/model/schema.json
+++ b/model/schema.json
@@ -293,6 +293,10 @@
         "default_fleet_server": {
           "description": "True when this policy is the default policy to start Fleet Server",
           "type": "boolean"
+        },
+        "unenroll_timeout": {
+          "description": "Timeout (seconds) that an Elastic Agent should be un-enrolled.",
+          "type": "integer"
         }
       },
       "required": [
@@ -354,6 +358,11 @@
           "description": "Date/time the Elastic Agent unenrolled",
           "type": "string",
           "format": "date-time"
+        },
+        "unenrolled_reason": {
+          "description": "Reason the Elastic Agent was unenrolled",
+          "type": "string",
+          "enum": ["manual", "timeout"]
         },
         "unenrollment_started_at": {
           "description": "Date/time the Elastic Agent unenrolled started",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds an unenroller that automatically unenrolls agents when the policy has `unenroll_timeout` set and agents `last_checkin` timestamp is older than the defined timeout.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To support ephemeral Elastic Agent's, having the Elastic Agent's list automatically cleaned up.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #446 

