### PR TITLE
Move Fleet Server specific config from elastic search section to server section.

### DIFF
--- a/example/fleet-server-100.yml
+++ b/example/fleet-server-100.yml
@@ -6,8 +6,6 @@ output:
     hosts: '${ELASTICSEARCH_HOSTS:localhost:9200}'
     username: '${ELASTICSEARCH_USERNAME:elastic}'
     password: '${ELASTICSEARCH_PASSWORD:changeme}'
-    bulk_flush_max_pending: 8     # Limit the number of pending ES bulk operations
-    bulk_flush_interval: 100ms    # Flush ES bulk queues on this interval.
 
 fleet:
   agent:
@@ -41,6 +39,9 @@ inputs:
         enabled: true
         key: /path/to/key.pem   # To support TLS, server needs cert, key pair
         certificate: /path/to/cert.pem
+      bulk:
+        flush_max_pending: 8    # Limit the number of pending ES bulk operations
+        flush_interval: 100ms   # Flush ES bulk queues on this interval.
       runtime:
         gc_percent: 20          # Force the GC to execute more frequently: see https://golang.org/pkg/runtime/debug/#SetGCPercent
  

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -127,11 +127,19 @@ func (o *bulkOptT) MarshalZerologObject(e *zerolog.Event) {
 // Bridge to configuration subsystem
 func BulkOptsFromCfg(cfg *config.Config) []BulkOpt {
 
+	bulkCfg := cfg.Inputs[0].Server.Bulk
+
+	// Attempt to slice the max number of connections to leave room for the bulk flush queues
+	maxKeyParallel := cfg.Output.Elasticsearch.MaxConnPerHost
+	if cfg.Output.Elasticsearch.MaxConnPerHost > bulkCfg.FlushMaxPending {
+		maxKeyParallel = cfg.Output.Elasticsearch.MaxConnPerHost - bulkCfg.FlushMaxPending
+	}
+
 	return []BulkOpt{
-		WithFlushInterval(cfg.Output.Elasticsearch.BulkFlushInterval),
-		WithFlushThresholdCount(cfg.Output.Elasticsearch.BulkFlushThresholdCount),
-		WithFlushThresholdSize(cfg.Output.Elasticsearch.BulkFlushThresholdSize),
-		WithMaxPending(cfg.Output.Elasticsearch.BulkFlushMaxPending),
-		WithApiKeyMaxParallel(cfg.Output.Elasticsearch.MaxConnPerHost - cfg.Output.Elasticsearch.BulkFlushMaxPending),
+		WithFlushInterval(bulkCfg.FlushInterval),
+		WithFlushThresholdCount(bulkCfg.FlushThresholdCount),
+		WithFlushThresholdSize(bulkCfg.FlushThresholdSize),
+		WithMaxPending(bulkCfg.FlushMaxPending),
+		WithApiKeyMaxParallel(maxKeyParallel),
 	}
 }

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -120,6 +120,7 @@ func TestConfig(t *testing.T) {
 							CompressionLevel:  1,
 							CompressionThresh: 1024,
 							Limits:            defaultServerLimits(),
+							Bulk:              defaultServerBulk(),
 						},
 						Cache: defaultCache(),
 						Monitor: Monitor{
@@ -190,6 +191,12 @@ func defaultServerLimits() ServerLimits {
 	return d
 }
 
+func defaultServerBulk() ServerBulk {
+	var d ServerBulk
+	d.InitDefaults()
+	return d
+}
+
 func defaultLogging() Logging {
 	var d Logging
 	d.InitDefaults()
@@ -213,17 +220,13 @@ func defaultFleet() Fleet {
 
 func defaultElastic() Elasticsearch {
 	return Elasticsearch{
-		Protocol:                "http",
-		Hosts:                   []string{"localhost:9200"},
-		Username:                "elastic",
-		Password:                "changeme",
-		MaxRetries:              3,
-		MaxConnPerHost:          128,
-		BulkFlushInterval:       250 * time.Millisecond,
-		BulkFlushThresholdCount: 2048,
-		BulkFlushThresholdSize:  1048576,
-		BulkFlushMaxPending:     8,
-		Timeout:                 90 * time.Second,
+		Protocol:       "http",
+		Hosts:          []string{"localhost:9200"},
+		Username:       "elastic",
+		Password:       "changeme",
+		MaxRetries:     3,
+		MaxConnPerHost: 128,
+		Timeout:        90 * time.Second,
 	}
 }
 

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -8,6 +8,7 @@ import (
 	"compress/flate"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 )
@@ -38,6 +39,20 @@ type ServerTLS struct {
 	Cert string `config:"cert"`
 }
 
+type ServerBulk struct {
+	FlushInterval       time.Duration `config:"flush_interval"`
+	FlushThresholdCount int           `config:"flush_threshold_cnt"`
+	FlushThresholdSize  int           `config:"flush_threshold_size"`
+	FlushMaxPending     int           `config:"flush_max_pending"`
+}
+
+func (c *ServerBulk) InitDefaults() {
+	c.FlushInterval = 250 * time.Millisecond
+	c.FlushThresholdCount = 2048
+	c.FlushThresholdSize = 1024 * 1024
+	c.FlushMaxPending = 8
+}
+
 // Server is the configuration for the server
 type Server struct {
 	Host              string            `config:"host"`
@@ -49,6 +64,7 @@ type Server struct {
 	CompressionThresh int               `config:"compression_threshold"`
 	Limits            ServerLimits      `config:"limits"`
 	Runtime           Runtime           `config:"runtime"`
+	Bulk              ServerBulk        `config:"bulk"`
 }
 
 // InitDefaults initializes the defaults for the configuration.
@@ -61,6 +77,7 @@ func (c *Server) InitDefaults() {
 	c.Profiler.InitDefaults()
 	c.Limits.InitDefaults()
 	c.Runtime.InitDefaults()
+	c.Bulk.InitDefaults()
 }
 
 // BindAddress returns the binding address for the HTTP server.

--- a/internal/pkg/config/output.go
+++ b/internal/pkg/config/output.go
@@ -28,24 +28,20 @@ var hasScheme = regexp.MustCompile(`^([a-z][a-z0-9+\-.]*)://`)
 
 // Elasticsearch is the configuration for elasticsearch.
 type Elasticsearch struct {
-	Protocol                string            `config:"protocol"`
-	Hosts                   []string          `config:"hosts"`
-	Path                    string            `config:"path"`
-	Headers                 map[string]string `config:"headers"`
-	Username                string            `config:"username"`
-	Password                string            `config:"password"`
-	APIKey                  string            `config:"api_key"`
-	ServiceToken            string            `config:"service_token"`
-	ProxyURL                string            `config:"proxy_url"`
-	ProxyDisable            bool              `config:"proxy_disable"`
-	TLS                     *tlscommon.Config `config:"ssl"`
-	MaxRetries              int               `config:"max_retries"`
-	MaxConnPerHost          int               `config:"max_conn_per_host"`
-	BulkFlushInterval       time.Duration     `config:"bulk_flush_interval"`
-	BulkFlushThresholdCount int               `config:"bulk_flush_threshold_cnt"`
-	BulkFlushThresholdSize  int               `config:"bulk_flush_threshold_size"`
-	BulkFlushMaxPending     int               `config:"bulk_flush_max_pending"`
-	Timeout                 time.Duration     `config:"timeout"`
+	Protocol       string            `config:"protocol"`
+	Hosts          []string          `config:"hosts"`
+	Path           string            `config:"path"`
+	Headers        map[string]string `config:"headers"`
+	Username       string            `config:"username"`
+	Password       string            `config:"password"`
+	APIKey         string            `config:"api_key"`
+	ServiceToken   string            `config:"service_token"`
+	ProxyURL       string            `config:"proxy_url"`
+	ProxyDisable   bool              `config:"proxy_disable"`
+	TLS            *tlscommon.Config `config:"ssl"`
+	MaxRetries     int               `config:"max_retries"`
+	MaxConnPerHost int               `config:"max_conn_per_host"`
+	Timeout        time.Duration     `config:"timeout"`
 }
 
 // InitDefaults initializes the defaults for the configuration.
@@ -55,10 +51,6 @@ func (c *Elasticsearch) InitDefaults() {
 	c.Timeout = 90 * time.Second
 	c.MaxRetries = 3
 	c.MaxConnPerHost = 128
-	c.BulkFlushInterval = 250 * time.Millisecond
-	c.BulkFlushThresholdCount = 2048
-	c.BulkFlushThresholdSize = 1024 * 1024
-	c.BulkFlushMaxPending = 8
 }
 
 // Validate ensures that the configuration is valid.

--- a/internal/pkg/config/output_test.go
+++ b/internal/pkg/config/output_test.go
@@ -27,14 +27,13 @@ func TestToESConfig(t *testing.T) {
 	}{
 		"http": {
 			cfg: Elasticsearch{
-				Protocol:          "http",
-				Hosts:             []string{"localhost:9200"},
-				Username:          "elastic",
-				Password:          "changeme",
-				MaxRetries:        3,
-				MaxConnPerHost:    128,
-				BulkFlushInterval: 250 * time.Millisecond,
-				Timeout:           90 * time.Second,
+				Protocol:       "http",
+				Hosts:          []string{"localhost:9200"},
+				Username:       "elastic",
+				Password:       "changeme",
+				MaxRetries:     3,
+				MaxConnPerHost: 128,
+				Timeout:        90 * time.Second,
 			},
 			result: elasticsearch.Config{
 				Addresses:  []string{"http://localhost:9200"},
@@ -62,10 +61,9 @@ func TestToESConfig(t *testing.T) {
 				Headers: map[string]string{
 					"X-Custom-Header": "Header-Value",
 				},
-				MaxRetries:        6,
-				MaxConnPerHost:    256,
-				BulkFlushInterval: 250 * time.Millisecond,
-				Timeout:           120 * time.Second,
+				MaxRetries:     6,
+				MaxConnPerHost: 256,
+				Timeout:        120 * time.Second,
 			},
 			result: elasticsearch.Config{
 				Addresses:  []string{"http://localhost:9200", "http://other-host:9200"},
@@ -93,10 +91,9 @@ func TestToESConfig(t *testing.T) {
 				Headers: map[string]string{
 					"X-Custom-Header": "Header-Value",
 				},
-				MaxRetries:        6,
-				MaxConnPerHost:    256,
-				BulkFlushInterval: 250 * time.Millisecond,
-				Timeout:           120 * time.Second,
+				MaxRetries:     6,
+				MaxConnPerHost: 256,
+				Timeout:        120 * time.Second,
 				TLS: &tlscommon.Config{
 					VerificationMode: tlscommon.VerifyNone,
 				},
@@ -132,10 +129,9 @@ func TestToESConfig(t *testing.T) {
 				Headers: map[string]string{
 					"X-Custom-Header": "Header-Value",
 				},
-				MaxRetries:        6,
-				MaxConnPerHost:    256,
-				BulkFlushInterval: 250 * time.Millisecond,
-				Timeout:           120 * time.Second,
+				MaxRetries:     6,
+				MaxConnPerHost: 256,
+				Timeout:        120 * time.Second,
 				TLS: &tlscommon.Config{
 					VerificationMode: tlscommon.VerifyNone,
 				},


### PR DESCRIPTION

The elastic search section is an "output" section and has the side effect of being
applied to all agents when changed in Kibana.  The bulk section only applies to Fleet
Server so should be located in the input section configuration the server.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Moves the bulk config section around so more easily configurable in Kibana.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Previous location was not strictly correct and had operational side effect of being applied to every policy when changed in Kibana.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x ] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] I have made corresponding change to the default configuration files
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
