### PR TITLE
Streamline proxy settings with Beats/Agent

### DIFF
--- a/internal/pkg/config/output.go
+++ b/internal/pkg/config/output.go
@@ -38,6 +38,7 @@ type Elasticsearch struct {
 	ServiceToken   string            `config:"service_token"`
 	ProxyURL       string            `config:"proxy_url"`
 	ProxyDisable   bool              `config:"proxy_disable"`
+	ProxyHeaders   map[string]string `config:"proxy_headers"`
 	TLS            *tlscommon.Config `config:"ssl"`
 	MaxRetries     int               `config:"max_retries"`
 	MaxConnPerHost int               `config:"max_conn_per_host"`
@@ -124,6 +125,15 @@ func (c *Elasticsearch) ToESConfig(longPoll bool) (elasticsearch.Config, error) 
 			return elasticsearch.Config{}, err
 		}
 		httpTransport.Proxy = http.ProxyURL(proxyUrl)
+
+		var headers http.Header
+		if len(c.ProxyHeaders) > 0 {
+			headers = make(http.Header, len(c.ProxyHeaders))
+			for k, v := range c.ProxyHeaders {
+				headers.Add(k, v)
+			}
+		}
+		httpTransport.ProxyConnectHeader = headers
 	}
 
 	h := http.Header{}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->
- Enhancement

## What does this PR do?

Add `proxy_headers` setting to the output.elasticsearch configuration.

If proxy_disabled is not set, we will read the proxy settings from the environment variables HTTP_PROXY, HTTPS_PROXY, and NOPROXY.

## Why is it important?

Keep set of proxy settings in line with recent changes in Beats/Agent.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->