### PR TITLE
Policy changes can be dropped during policy rollouts to large number …

### DIFF
--- a/cmd/fleet/server.go
+++ b/cmd/fleet/server.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
+	"github.com/elastic/fleet-server/v7/internal/pkg/logger"
 
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 	"github.com/julienschmidt/httprouter"
@@ -142,7 +143,7 @@ type stubLogger struct {
 }
 
 func (s *stubLogger) Write(p []byte) (n int, err error) {
-	log.Error().Bytes("msg", p).Send()
+	log.Error().Bytes(logger.EcsMessage, p).Send()
 	return len(p), nil
 }
 

--- a/internal/pkg/monitor/subscription_monitor.go
+++ b/internal/pkg/monitor/subscription_monitor.go
@@ -145,10 +145,11 @@ func (m *monitorT) notify(ctx context.Context, hits []es.HitT) {
 				select {
 				case s.c <- hits:
 				case <-lc.Done():
-					err := ctx.Err()
-					if err == context.DeadlineExceeded {
-						log.Err(err).Str("ctx", "subscription monitor").Dur("timeout", m.subTimeout).Msg("dropped notification")
-					}
+					log.Error().
+						Err(lc.Err()).
+						Str("ctx", "subscription monitor").
+						Dur("timeout", m.subTimeout).
+						Msg("dropped notification")
 				}
 			}(s)
 		}


### PR DESCRIPTION
…of agents.  Aggregates changes to avoid missing updates.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Works around race condition where internal notifications on policy update were dropped.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Policies can appear stuck at scale.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x ] My code follows the style guidelines of this project
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] I have made corresponding change to the default configuration files
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Follow instructions in related issue.  Check the logs.  

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #522 



## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->


```
10:53:08.821 INF Received hits on local monitor ctx="policy agent monitor" nHits=1 service.name=fleet-server
10:53:09.052 INF Received hits on local monitor ctx="policy agent monitor" nHits=1 service.name=fleet-server
10:54:44.821 INF policy rollout end coordinatorIdx=1 ctx="policy agent monitor" policyId=d43cd250-df22-11eb-9c07-7d2f0052b4b7 revisionIdx=18 service.name=fleet-server tdiff=99004.626266
10:54:44.822 INF Hits dispatched to main loop ctx="policy agent monitor" nHits=2 service.name=fleet-server
10:54:44.823 INF policy revised ctx="policy agent monitor" ncoord=1 nrev=19 ocoord=1 orev=18 policyId=d43cd250-df22-11eb-9c07-7d2f0052b4b7 service.name=fleet-server
10:54:44.824 INF policy rollout begin coordinatorIdx=1 ctx="policy agent monitor" nSubs=4940 policyId=d43cd250-df22-11eb-9c07-7d2f0052b4b7 revisionIdx=19 service.name=fleet-server throttle=20
10:56:23.628 INF policy rollout end coordinatorIdx=1 ctx="policy agent monitor" policyId=d43cd250-df22-11eb-9c07-7d2f0052b4b7 revisionIdx=19 service.name=fleet-server tdiff=98801.968635
```
