### PR TITLE
Accept version qualifier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,15 @@ BUILDMODE_windows_amd64=-buildmode=pie
 BUILDMODE_darwin_amd64=-buildmode=pie
 BUILDMODE_darwin_arm64=-buildmode=pie
 
+
+ifdef VERSION_QUALIFIER
+DEFAULT_VERSION:=${DEFAULT_VERSION}-${VERSION_QUALIFIER}
+endif
+
 ifeq ($(SNAPSHOT),true)
 VERSION=${DEFAULT_VERSION}-SNAPSHOT
 else
 VERSION=${DEFAULT_VERSION}
-endif
-
-ifdef VERSION_QUALIFIER
-VERSION:=${VERSION}-${VERSION_QUALIFIER}
 endif
 
 PLATFORM_TARGETS=$(addprefix release-, $(PLATFORMS))

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ else
 VERSION=${DEFAULT_VERSION}
 endif
 
+ifdef VERSION_QUALIFIER
+VERSION:=${VERSION}-${VERSION_QUALIFIER}
+endif
+
 PLATFORM_TARGETS=$(addprefix release-, $(PLATFORMS))
 COMMIT=$(shell git rev-parse --short HEAD)
 LDFLAGS=-w -s -X main.Version=${VERSION} -X main.Commit=${COMMIT}


### PR DESCRIPTION
## What does this PR do?

This enabled to specify Version qualifier which will result in a package in following format
`fleet-server-{VERSION}-{VERSION_QUALIFIER}-{IS_SNAPSHOT}-darwin-x86_64.tar.gz `
e.g
`fleet-server-8.0.0-alpha1-SNAPSHOT-darwin-x86_64.tar.gz `

when variable is not present name follows notation as before

test by running `SNAPSHOT=true PLATFORMS=darwin/amd64 VERSION_QUALIFIER=alpha1 make release`

## Why is it important?

Conforming with release process and to be on par with other products.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
