### PR TITLE
Add action timeout

### DIFF
--- a/cmd/fleet/handleCheckin.go
+++ b/cmd/fleet/handleCheckin.go
@@ -388,6 +388,7 @@ func convertActions(agentId string, actions []model.Action) ([]ActionResp, strin
 			Id:        action.ActionId,
 			Type:      action.Type,
 			InputType: action.InputType,
+			Timeout:   action.Timeout,
 		})
 	}
 

--- a/cmd/fleet/schema.go
+++ b/cmd/fleet/schema.go
@@ -98,6 +98,7 @@ type ActionResp struct {
 	Id        string      `json:"id"`
 	Type      string      `json:"type"`
 	InputType string      `json:"input_type"`
+	Timeout   int64       `json:"timeout,omitempty"`
 }
 
 type Event struct {

--- a/internal/pkg/es/mapping.go
+++ b/internal/pkg/es/mapping.go
@@ -27,6 +27,9 @@ const (
 		"input_type": {
 			"type": "keyword"
 		},
+		"timeout": {
+			"type": "integer"
+		},
 		"@timestamp": {
 			"type": "date"
 		},

--- a/internal/pkg/model/schema.go
+++ b/internal/pkg/model/schema.go
@@ -48,6 +48,9 @@ type Action struct {
 	// The input type the actions should be routed to.
 	InputType string `json:"input_type,omitempty"`
 
+	// The optional action timeout in seconds
+	Timeout int64 `json:"timeout,omitempty"`
+
 	// Date/time the action was created
 	Timestamp string `json:"@timestamp,omitempty"`
 

--- a/model/schema.json
+++ b/model/schema.json
@@ -38,6 +38,10 @@
           "description": "The input type the actions should be routed to.",
           "type": "string"
         },
+        "timeout": {
+          "description": "The optional action timeout in seconds",
+          "type": "integer"
+        },
         "user_id": {
           "description": "The ID of the user who created the action.",
           "type": "string"


### PR DESCRIPTION
## What does this PR do?

Allows to specify the timeout on the the individual actions in seconds.
This will be applied when the agent calls PerformAction
https://github.com/elastic/beats/blob/master/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_application.go#L57
if the timeout is specified. Otherwise it will use the default 1 minute timeout. 

## Why is it important?

This should allow the actions such as containment to set the individual timeout if they expect the action to take longer than one minute.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas


## Related issues

- Relates https://github.com/elastic/kibana/issues/105477

## Screenshots

An example of the action POST with 30 secs timeout:
<img width="455" alt="Screen Shot 2021-07-20 at 10 40 39 AM" src="https://user-images.githubusercontent.com/872351/126362761-5fd3017e-fc7b-4c94-bdec-c46bfdfd488d.png">


