### PR TITLE
Populate agent.id field in .fleet-agents index

### DIFF
--- a/cmd/fleet/handleEnroll.go
+++ b/cmd/fleet/handleEnroll.go
@@ -135,7 +135,7 @@ func (et *EnrollerT) handleEnroll(w http.ResponseWriter, r *http.Request) (*Enro
 		return nil, err
 	}
 
-	err = validateUserAgent(r, et.verCon)
+	ver, err := validateUserAgent(r, et.verCon)
 	if err != nil {
 		return nil, err
 	}
@@ -167,10 +167,10 @@ func (et *EnrollerT) handleEnroll(w http.ResponseWriter, r *http.Request) (*Enro
 
 	cntEnroll.bodyIn.Add(readCounter.Count())
 
-	return _enroll(r.Context(), et.bulker, et.cache, *req, *erec)
+	return _enroll(r.Context(), et.bulker, et.cache, *req, *erec, ver)
 }
 
-func _enroll(ctx context.Context, bulker bulk.Bulk, c cache.Cache, req EnrollRequest, erec model.EnrollmentApiKey) (*EnrollResponse, error) {
+func _enroll(ctx context.Context, bulker bulk.Bulk, c cache.Cache, req EnrollRequest, erec model.EnrollmentApiKey, ver string) (*EnrollResponse, error) {
 
 	if req.SharedId != "" {
 		// TODO: Support pre-existing install
@@ -210,6 +210,10 @@ func _enroll(ctx context.Context, bulker bulk.Bulk, c cache.Cache, req EnrollReq
 		LocalMetadata:  localMeta,
 		AccessApiKeyId: accessApiKey.Id,
 		ActionSeqNo:    []int64{sqn.UndefinedSeqNo},
+		Agent: &model.AgentMetadata{
+			Id:      agentId,
+			Version: ver,
+		},
 	}
 
 	err = createFleetAgent(ctx, bulker, agentId, agentData)

--- a/cmd/fleet/userAgent.go
+++ b/cmd/fleet/userAgent.go
@@ -73,7 +73,10 @@ func validateUserAgent(r *http.Request, verConst version.Constraints) (string, e
 	// Split the version to accommodate versions with suffixes such as v8.0.0-snapshot v8.0.0-alpha1
 	verSep := strings.Split(s, "-")
 
-	ver, err := version.NewVersion(verSep[0])
+	// Trim leading and traling spaces
+	verStr := strings.TrimSpace(verSep[0])
+
+	ver, err := version.NewVersion(verStr)
 	if err != nil {
 		return "", ErrInvalidUserAgent
 	}

--- a/cmd/fleet/userAgent.go
+++ b/cmd/fleet/userAgent.go
@@ -66,7 +66,14 @@ func validateUserAgent(r *http.Request, verConst version.Constraints) (string, e
 	if !strings.HasPrefix(userAgent, userAgentPrefix) {
 		return "", ErrInvalidUserAgent
 	}
-	verStr := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(userAgent, userAgentPrefix), "-snapshot"))
+
+	// Trim "elastic agent " prefix
+	s := strings.TrimPrefix(userAgent, userAgentPrefix)
+	// Trim "-snapshot" suffix
+	s = strings.TrimSuffix(s, "-snapshot")
+	// Trim leading and traling spaces
+	verStr := strings.TrimSpace(s)
+
 	ver, err := version.NewVersion(verStr)
 	if err != nil {
 		return "", ErrInvalidUserAgent
@@ -74,5 +81,5 @@ func validateUserAgent(r *http.Request, verConst version.Constraints) (string, e
 	if !verConst.Check(ver) {
 		return "", ErrUnsupportedVersion
 	}
-	return strings.TrimPrefix(verStr, "v"), nil
+	return ver.String(), nil
 }

--- a/cmd/fleet/userAgent.go
+++ b/cmd/fleet/userAgent.go
@@ -57,22 +57,22 @@ func maximizePatch(ver *version.Version) string {
 
 // validateUserAgent validates that the User-Agent of the connecting Elastic Agent is valid and that the version is
 // supported for this Fleet Server.
-func validateUserAgent(r *http.Request, verConst version.Constraints) error {
+func validateUserAgent(r *http.Request, verConst version.Constraints) (string, error) {
 	userAgent := r.Header.Get("User-Agent")
 	if userAgent == "" {
-		return ErrInvalidUserAgent
+		return "", ErrInvalidUserAgent
 	}
 	userAgent = strings.ToLower(userAgent)
 	if !strings.HasPrefix(userAgent, userAgentPrefix) {
-		return ErrInvalidUserAgent
+		return "", ErrInvalidUserAgent
 	}
 	verStr := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(userAgent, userAgentPrefix), "-snapshot"))
 	ver, err := version.NewVersion(verStr)
 	if err != nil {
-		return ErrInvalidUserAgent
+		return "", ErrInvalidUserAgent
 	}
 	if !verConst.Check(ver) {
-		return ErrUnsupportedVersion
+		return "", ErrUnsupportedVersion
 	}
-	return nil
+	return strings.TrimPrefix(verStr, "v"), nil
 }

--- a/cmd/fleet/userAgent_test.go
+++ b/cmd/fleet/userAgent_test.go
@@ -82,7 +82,7 @@ func TestValidateUserAgent(t *testing.T) {
 		t.Run(tr.userAgent, func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/", nil)
 			req.Header.Set("User-Agent", tr.userAgent)
-			res := validateUserAgent(req, tr.verCon)
+			_, res := validateUserAgent(req, tr.verCon)
 			if tr.err != res {
 				t.Fatalf("err mismatch: %v != %v", tr.err, res)
 			}

--- a/internal/pkg/checkin/bulk_test.go
+++ b/internal/pkg/checkin/bulk_test.go
@@ -43,12 +43,14 @@ func TestBulkSimple(t *testing.T) {
 
 	bc := NewBulk(&mockBulk)
 
+	const ver = "8.0.0"
 	cases := []struct {
 		desc   string
 		id     string
 		status string
 		meta   []byte
 		seqno  sqn.SeqNo
+		ver    string
 	}{
 		{
 			"Simple case",
@@ -56,6 +58,7 @@ func TestBulkSimple(t *testing.T) {
 			"online",
 			nil,
 			nil,
+			"",
 		},
 		{
 			"Singled field case",
@@ -63,6 +66,7 @@ func TestBulkSimple(t *testing.T) {
 			"online",
 			[]byte(`{"hey":"now"}`),
 			nil,
+			"",
 		},
 		{
 			"Multi field case",
@@ -70,6 +74,7 @@ func TestBulkSimple(t *testing.T) {
 			"online",
 			[]byte(`{"hey":"now","brown":"cow"}`),
 			nil,
+			ver,
 		},
 		{
 			"Multi field nested case",
@@ -77,6 +82,7 @@ func TestBulkSimple(t *testing.T) {
 			"online",
 			[]byte(`{"hey":"now","wee":{"little":"doggie"}}`),
 			nil,
+			"",
 		},
 		{
 			"Simple case with seqNo",
@@ -84,6 +90,7 @@ func TestBulkSimple(t *testing.T) {
 			"online",
 			nil,
 			sqn.SeqNo{1, 2, 3, 4},
+			ver,
 		},
 		{
 			"Field case with seqNo",
@@ -91,6 +98,7 @@ func TestBulkSimple(t *testing.T) {
 			"online",
 			[]byte(`{"uncle":"fester"}`),
 			sqn.SeqNo{5, 6, 7, 8},
+			ver,
 		},
 		{
 			"Unusual status",
@@ -98,6 +106,7 @@ func TestBulkSimple(t *testing.T) {
 			"unusual",
 			nil,
 			nil,
+			"",
 		},
 		{
 			"Empty status",
@@ -105,13 +114,14 @@ func TestBulkSimple(t *testing.T) {
 			"",
 			nil,
 			nil,
+			"",
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
 
-			if err := bc.CheckIn(c.id, c.status, c.meta, c.seqno); err != nil {
+			if err := bc.CheckIn(c.id, c.status, c.meta, c.seqno, c.ver); err != nil {
 				t.Fatal(err)
 			}
 
@@ -205,7 +215,7 @@ func benchmarkBulk(n int, flush bool, b *testing.B) {
 	for i := 0; i < b.N; i++ {
 
 		for _, id := range ids {
-			err := bc.CheckIn(id, "", nil, nil)
+			err := bc.CheckIn(id, "", nil, nil, "")
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/internal/pkg/dl/constants.go
+++ b/internal/pkg/dl/constants.go
@@ -40,6 +40,7 @@ const (
 	FieldDefaultApiKeyId             = "default_api_key_id"
 	FieldPolicyOutputPermissionsHash = "policy_output_permissions_hash"
 	FieldUnenrolledReason            = "unenrolled_reason"
+	FieldAgentVersion                = "agent.version"
 
 	FieldActive           = "active"
 	FieldUpdatedAt        = "updated_at"


### PR DESCRIPTION
## What does this PR do?

Populate agent.id field in .fleet-agents index as requested here:
https://github.com/elastic/fleet-server/issues/595

@scunningham The current agent schema/mapping has "version" field along with "id", if we populate only the "agent.id" it will save the version as "" empty string, so I updated the code to capture the "agent.version" too. Also assumed that the version could be updated for the same "agent.id".
Could you check if my assumptions are correct there? Thanks!

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues

- Closes https://github.com/elastic/fleet-server/issues/595

## Screenshots
<img width="638" alt="Screen Shot 2021-08-02 at 8 50 46 AM" src="https://user-images.githubusercontent.com/872351/127866248-cb126c9e-0371-4e40-886c-a072bea8f997.png">
