### PR TITLE
Set User-Agent in HTTP requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 .vscode/
 
 bin/
-build/
+/build/
 
 fleet-server
 fleet_server

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ endif
 
 PLATFORM_TARGETS=$(addprefix release-, $(PLATFORMS))
 COMMIT=$(shell git rev-parse --short HEAD)
-LDFLAGS=-w -s -X main.Version=${VERSION} -X main.Commit=${COMMIT}
+NOW=$(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
+LDFLAGS=-w -s -X main.Version=${VERSION} -X main.Commit=${COMMIT} -X main.BuildTime=$(NOW) 
 CMD_COLOR_ON=\033[32m\xE2\x9c\x93
 CMD_COLOR_OFF=\033[0m
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -483,11 +483,11 @@ SOFTWARE
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/go-elasticsearch/v7
-Version: v7.13.1
+Version: v7.5.1-0.20210823155509-845c8efe54a7
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/go-elasticsearch/v7@v7.13.1/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/go-elasticsearch/v7@v7.5.1-0.20210823155509-845c8efe54a7/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/cmd/fleet/metrics.go
+++ b/cmd/fleet/metrics.go
@@ -35,7 +35,7 @@ var (
 func (f *FleetServer) initMetrics(ctx context.Context, cfg *config.Config) (*api.Server, error) {
 	registry := monitoring.GetNamespace("info").GetRegistry()
 	if registry.Get("version") == nil {
-		monitoring.NewString(registry, "version").Set(f.ver)
+		monitoring.NewString(registry, "version").Set(f.bi.Version)
 	}
 	if registry.Get("name") == nil {
 		monitoring.NewString(registry, "name").Set(kServiceName)

--- a/cmd/fleet/server_integration_test.go
+++ b/cmd/fleet/server_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/elastic/fleet-server/v7/internal/pkg/build"
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
 	"github.com/elastic/fleet-server/v7/internal/pkg/logger"
 	"github.com/elastic/fleet-server/v7/internal/pkg/sleep"
@@ -76,7 +77,7 @@ func startTestServer(ctx context.Context) (*tserver, error) {
 	cfg.Inputs[0].Server = *srvcfg
 	log.Info().Uint16("port", port).Msg("Test fleet server")
 
-	srv, err := NewFleetServer(cfg, serverVersion, status.NewLog())
+	srv, err := NewFleetServer(cfg, build.Info{Version: serverVersion}, status.NewLog())
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/elastic/beats/v7 v7.11.1
 	github.com/elastic/elastic-agent-client/v7 v7.0.0-20210727140539-f0905d9377f6
-	github.com/elastic/go-elasticsearch/v7 v7.13.1
+	github.com/elastic/go-elasticsearch/v7 v7.5.1-0.20210823155509-845c8efe54a7
 	github.com/elastic/go-ucfg v0.8.3
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/google/go-cmp v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,8 @@ github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270 h1:cWPqxlPtir4RoQ
 github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270/go.mod h1:Msl1pdboCbArMF/nSCDUXgQuWTeoMmE/z8607X+k7ng=
 github.com/elastic/go-concert v0.0.4 h1:pzgYCmJ/xMJsW8PSk33inAWZ065hrwSeP79TpwAbsLE=
 github.com/elastic/go-concert v0.0.4/go.mod h1:9MtFarjXroUgmm0m6HY3NSe1XiKhdktiNRRj9hWvIaM=
-github.com/elastic/go-elasticsearch/v7 v7.13.1 h1:PaM3V69wPlnwR+ne50rSKKn0RNDYnnOFQcuGEI0ce80=
-github.com/elastic/go-elasticsearch/v7 v7.13.1/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
+github.com/elastic/go-elasticsearch/v7 v7.5.1-0.20210823155509-845c8efe54a7 h1:Nq382VeELkUSC7y8JIXBNj0YfOqmq/d8mX+crl4xdrM=
+github.com/elastic/go-elasticsearch/v7 v7.5.1-0.20210823155509-845c8efe54a7/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-libaudit/v2 v2.1.0 h1:yWSKoGaoWLGFPjqWrQ4gwtuM77pTk7K4CsPxXss8he4=
 github.com/elastic/go-libaudit/v2 v2.1.0/go.mod h1:MM/l/4xV7ilcl+cIblL8Zn448J7RZaDwgNLE4gNKYPg=
 github.com/elastic/go-licenser v0.3.1 h1:RmRukU/JUmts+rpexAw0Fvt2ly7VVu6mw8z4HrEzObU=

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -1,0 +1,20 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package build
+
+import "time"
+
+type Info struct {
+	Version, Commit string
+	BuildTime       time.Time
+}
+
+func Time(stime string) time.Time {
+	t, err := time.Parse(time.RFC3339, stime)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}

--- a/main.go
+++ b/main.go
@@ -14,17 +14,23 @@ import (
 	"os"
 
 	"github.com/elastic/fleet-server/v7/cmd/fleet"
+	"github.com/elastic/fleet-server/v7/internal/pkg/build"
 )
 
 const defaultVersion = "8.0.0"
 
 var (
-	Version string = defaultVersion
-	Commit  string
+	Version   string = defaultVersion
+	Commit    string
+	BuildTime string
 )
 
 func main() {
-	cmd := fleet.NewCommand(Version, Commit)
+	cmd := fleet.NewCommand(build.Info{
+		Version:   Version,
+		Commit:    Commit,
+		BuildTime: build.Time(BuildTime),
+	})
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)


### PR DESCRIPTION
## What does this PR do?

* Set User-Agent in HTTP requests that looks like the following:
```
User-Agent: Elastic-Fleet-Server/8.0.0 (darwin; amd64; b1fef53; 2021-08-23 18:50:14 +0000 UTC)
```
* Update elasticsearch client on the 7.x branch commit that implemented the addition of the User-Agent https://github.com/elastic/go-elasticsearch/commit/845c8efe54a7a8fd0f43cf6f9b33e53371d2c237
* Add built time for consistency with the libbeat user agent

## Why is it important?

Not sure how important this is, but it addresses https://github.com/elastic/fleet-server/issues/636
Leaving up to the Fleet/Agent team to decide if this is needed or not.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues

- Closes https://github.com/elastic/fleet-server/issues/636

## Screenshots
Wireshark capture
<img width="769" alt="Screen Shot 2021-08-23 at 2 51 45 PM" src="https://user-images.githubusercontent.com/872351/130504079-137d0d75-b141-44a8-bd40-3889b86cf63f.png">
