### PR TITLE
Add index refresh call after fetch if the list of hits has holes

### DIFF
--- a/internal/pkg/monitor/monitor.go
+++ b/internal/pkg/monitor/monitor.go
@@ -369,7 +369,7 @@ func (m *simpleMonitorT) fetch(ctx context.Context, checkpoint, maxCheckpoint sq
 }
 
 // Refreshes index. This is temporary code
-// TODO: Remove this when the refresh is properly imlemented on Eleasticsearch side
+// TODO: Remove this when the refresh is properly implemented on Eleasticsearch side
 func (m *simpleMonitorT) refresh(ctx context.Context) error {
 	res, err := m.esCli.Indices.Refresh(
 		m.esCli.Indices.Refresh.WithContext(ctx),

--- a/internal/pkg/monitor/monitor.go
+++ b/internal/pkg/monitor/monitor.go
@@ -370,6 +370,8 @@ func (m *simpleMonitorT) fetch(ctx context.Context, checkpoint, maxCheckpoint sq
 
 // Refreshes index. This is temporary code
 // TODO: Remove this when the refresh is properly implemented on Eleasticsearch side
+// The issue for "refresh" falls under phase 2 of https://github.com/elastic/elasticsearch/issues/71449.
+// Once the phase 2 is complete we can remove the refreshes from fleet-server.
 func (m *simpleMonitorT) refresh(ctx context.Context) error {
 	res, err := m.esCli.Indices.Refresh(
 		m.esCli.Indices.Refresh.WithContext(ctx),

--- a/internal/pkg/monitor/monitor_test.go
+++ b/internal/pkg/monitor/monitor_test.go
@@ -1,0 +1,74 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build !integration
+
+package monitor
+
+import (
+	"testing"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/es"
+	"github.com/google/go-cmp/cmp"
+)
+
+// Sanity test of interal check if hits lits has holes
+func TestHashHoles(t *testing.T) {
+
+	tests := []struct {
+		Name     string
+		Hits     []es.HitT
+		HasHoles bool
+	}{
+		{
+			Name: "nil",
+			Hits: genHitsSequence(nil),
+		},
+		{
+			Name: "empty",
+			Hits: genHitsSequence([]int64{}),
+		},
+		{
+			Name: "one",
+			Hits: genHitsSequence([]int64{1}),
+		},
+		{
+			Name: "two",
+			Hits: genHitsSequence([]int64{1, 2}),
+		},
+		{
+			Name:     "two with hole",
+			Hits:     genHitsSequence([]int64{1, 3}),
+			HasHoles: true,
+		},
+		{
+			Name:     "holed",
+			Hits:     genHitsSequence([]int64{2, 3, 4, 6}),
+			HasHoles: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			diff := cmp.Diff(tc.HasHoles, hasHoles(tc.Hits))
+			if diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func genHitsSequence(seq []int64) []es.HitT {
+	if seq == nil {
+		return nil
+	}
+
+	hits := make([]es.HitT, 0, len(seq))
+	for _, s := range seq {
+		hits = append(hits, es.HitT{
+			SeqNo: s,
+		})
+	}
+	return hits
+}


### PR DESCRIPTION
## What does this PR do?

Adds index refresh call after fetch if the list of hits/results has holes.

After discussion with Elasticsearch team it looks like the current global checkpoints
API doesn't not gurantee the list of document without holes on
subsequent index search and there is still a slim chance of this with
our current implementation. Elastisearch team is working on getting the
refresh implemented on thier side, and for now recommended to do the
refresh before fetch if there are holes detected in the result.

Added the check for the holes and refetch, here are the steps:
1. Call Global checkpoints = 5
2. Search = 1, 2, 3, 5.
3. Manual refresh
4. Search and get 4,5
5. Return to step 1


## Why is it important?

Covers the edge case where the fetched documents lists after checkpoint API could still potentially have holes.
In practice we haven't seen this happening, but this change was recommended by Elasticsearch team.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

