### PR TITLE
Add "hole" detection and refresh for the agent actions fetch upon initial check in

### DIFF
--- a/cmd/fleet/handleCheckin.go
+++ b/cmd/fleet/handleCheckin.go
@@ -375,14 +375,8 @@ func (ct *CheckinT) resolveSeqNo(ctx context.Context, req CheckinRequest, agent 
 }
 
 func (ct *CheckinT) fetchAgentPendingActions(ctx context.Context, seqno sqn.SeqNo, agentId string) ([]model.Action, error) {
-	now := time.Now().UTC().Format(time.RFC3339)
 
-	actions, err := dl.FindActions(ctx, ct.bulker, dl.QueryAgentActions, map[string]interface{}{
-		dl.FieldSeqNo:      seqno.Value(),
-		dl.FieldMaxSeqNo:   ct.gcp.GetCheckpoint().Value(),
-		dl.FieldExpiration: now,
-		dl.FieldAgents:     []string{agentId},
-	})
+	actions, err := dl.FindAgentActions(ctx, ct.bulker, seqno, ct.gcp.GetCheckpoint(), agentId)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "fetchAgentPendingActions")

--- a/internal/pkg/es/holes.go
+++ b/internal/pkg/es/holes.go
@@ -1,0 +1,37 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package es
+
+import "github.com/elastic/fleet-server/v7/internal/pkg/sqn"
+
+func HasHoles(checkpoint sqn.SeqNo, hits []HitT) bool {
+	sz := len(hits)
+	if sz == 0 {
+		return false
+	}
+
+	// Check if the hole is in the beginning of hits
+	seqNo := checkpoint.Value()
+	if seqNo != sqn.UndefinedSeqNo && (hits[0].SeqNo-seqNo) > 1 {
+		return true
+	}
+
+	// No holes in the beginning, check if size <= 1 then there is no holes
+	if sz <= 1 {
+		return false
+	}
+
+	// Set initial seqNo value from the last hit in the array
+	seqNo = hits[sz-1].SeqNo
+
+	// Iterate from the end since that's where it more likely to have holes
+	for i := sz - 2; i >= 0; i-- {
+		if (seqNo - hits[i].SeqNo) > 1 {
+			return true
+		}
+		seqNo = hits[i].SeqNo
+	}
+	return false
+}

--- a/internal/pkg/es/holes_test.go
+++ b/internal/pkg/es/holes_test.go
@@ -4,12 +4,11 @@
 
 // +build !integration
 
-package monitor
+package es
 
 import (
 	"testing"
 
-	"github.com/elastic/fleet-server/v7/internal/pkg/es"
 	"github.com/elastic/fleet-server/v7/internal/pkg/sqn"
 	"github.com/google/go-cmp/cmp"
 )
@@ -20,7 +19,7 @@ func TestHashHoles(t *testing.T) {
 	tests := []struct {
 		Name     string
 		SeqNo    sqn.SeqNo
-		Hits     []es.HitT
+		Hits     []HitT
 		HasHoles bool
 	}{
 		{
@@ -65,7 +64,7 @@ func TestHashHoles(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			diff := cmp.Diff(tc.HasHoles, hasHoles(tc.SeqNo, tc.Hits))
+			diff := cmp.Diff(tc.HasHoles, HasHoles(tc.SeqNo, tc.Hits))
 			if diff != "" {
 				t.Fatal(diff)
 			}
@@ -73,14 +72,14 @@ func TestHashHoles(t *testing.T) {
 	}
 }
 
-func genHitsSequence(seq []int64) []es.HitT {
+func genHitsSequence(seq []int64) []HitT {
 	if seq == nil {
 		return nil
 	}
 
-	hits := make([]es.HitT, 0, len(seq))
+	hits := make([]HitT, 0, len(seq))
 	for _, s := range seq {
-		hits = append(hits, es.HitT{
+		hits = append(hits, HitT{
 			SeqNo: s,
 		})
 	}

--- a/internal/pkg/es/refresh.go
+++ b/internal/pkg/es/refresh.go
@@ -1,0 +1,45 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package es
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/elastic/go-elasticsearch/v7"
+)
+
+// Refresh refreshes index. This is temporary code
+// TODO: Remove this when the refresh is properly implemented on Eleasticsearch side
+// The issue for "refresh" falls under phase 2 of https://github.com/elastic/elasticsearch/issues/71449.
+// Once the phase 2 is complete we can remove the refreshes from fleet-server.
+func Refresh(ctx context.Context, esCli *elasticsearch.Client, index string) error {
+	res, err := esCli.Indices.Refresh(
+		esCli.Indices.Refresh.WithContext(ctx),
+		esCli.Indices.Refresh.WithIndex(index),
+	)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	var esres Response
+	err = json.NewDecoder(res.Body).Decode(&esres)
+	if err != nil {
+		return err
+	}
+
+	if res.IsError() {
+		err = TranslateError(res.StatusCode, &esres.Error)
+	}
+
+	if err != nil {
+		if errors.Is(err, ErrIndexNotFound) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/pkg/monitor/monitor.go
+++ b/internal/pkg/monitor/monitor.go
@@ -52,23 +52,6 @@ const (
 	fieldExpiration = "expiration"
 )
 
-type HitT struct {
-	Id     string          `json:"_id"`
-	SeqNo  int64           `json:"_seq_no"`
-	Index  string          `json:"_index"`
-	Source json.RawMessage `json:"_source"`
-	Score  *float64        `json:"_score"`
-}
-
-type HitsT struct {
-	Hits  []HitT `json:"hits"`
-	Total struct {
-		Relation string `json:"relation"`
-		Value    uint64 `json:"value"`
-	} `json:"total"`
-	MaxScore *float64 `json:"max_score"`
-}
-
 type GlobalCheckpointProvider interface {
 	GetCheckpoint() sqn.SeqNo
 }


### PR DESCRIPTION
## What is the problem this PR solves?

This covers one more edge case for actions in multiple replica shards environment per discussion with Elasticsearch team

The edge use case:
1. the monitor fetches from one replica shard
2. result has no holes
3. the index refresh is skipped if there is no holes
4. the seqno is advanced forward as expected
5. the agent upon check-in, by the random draw of luck fetches actions from different replica shard that doesn't have all the documents indexed in that range
6. the result can have holes

In order to cover this use case need to add the holes detection and refresh upon the agent initial actions fetch during checkin.

## How does this PR solve the problem?

* Extracted HasHoles function into es package so it can be reused in two places: the monitor and the checking handler
* Extracted es.Refresh function so it can be reused in two places: the monitor and the checking handler
* Added FindAgentActions wrapper function with the holes check and refresh that is used to fetch the initial agent's actions upon check in.


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
