### PR TITLE
Encapsulate the agent new version safe check, full unit test coverage

### DIFF
--- a/cmd/fleet/handleCheckin.go
+++ b/cmd/fleet/handleCheckin.go
@@ -157,10 +157,8 @@ func (ct *CheckinT) _handleCheckin(zlog zerolog.Logger, w http.ResponseWriter, r
 		return err
 	}
 
-	var newVer string
-	if agent.Agent == nil || ver != agent.Agent.Version {
-		newVer = ver
-	}
+	// Safely check if the agent version is different, return empty string otherwise
+	newVer := agent.GetNewVersion(ver)
 
 	// Metrics; serenity now.
 	dfunc := cntCheckin.IncStart()

--- a/cmd/fleet/handleCheckin.go
+++ b/cmd/fleet/handleCheckin.go
@@ -158,7 +158,7 @@ func (ct *CheckinT) _handleCheckin(zlog zerolog.Logger, w http.ResponseWriter, r
 	}
 
 	// Safely check if the agent version is different, return empty string otherwise
-	newVer := agent.GetNewVersion(ver)
+	newVer := agent.CheckDifferentVersion(ver)
 
 	// Metrics; serenity now.
 	dfunc := cntCheckin.IncStart()

--- a/internal/pkg/model/ext.go
+++ b/internal/pkg/model/ext.go
@@ -32,10 +32,9 @@ func (m *Agent) GetNewVersion(ver string) string {
 		return ""
 	}
 
-	var newVer string
 	if m.Agent == nil || ver != m.Agent.Version {
-		newVer = ver
+		return ver
 	}
 
-	return newVer
+	return ""
 }

--- a/internal/pkg/model/ext.go
+++ b/internal/pkg/model/ext.go
@@ -26,8 +26,8 @@ func (m *Server) SetTime(t time.Time) {
 	m.Timestamp = t.Format(time.RFC3339Nano)
 }
 
-// GetNewVersion returns Agent version if it is different from ver, otherwise return empty string
-func (m *Agent) GetNewVersion(ver string) string {
+// CheckDifferentVersion returns Agent version if it is different from ver, otherwise return empty string
+func (m *Agent) CheckDifferentVersion(ver string) string {
 	if m == nil {
 		return ""
 	}

--- a/internal/pkg/model/ext.go
+++ b/internal/pkg/model/ext.go
@@ -25,3 +25,17 @@ func (m *Server) Time() (time.Time, error) {
 func (m *Server) SetTime(t time.Time) {
 	m.Timestamp = t.Format(time.RFC3339Nano)
 }
+
+// GetNewVersion returns Agent version if it is different from ver, otherwise return empty string
+func (m *Agent) GetNewVersion(ver string) string {
+	if m == nil {
+		return ""
+	}
+
+	var newVer string
+	if m.Agent == nil || ver != m.Agent.Version {
+		newVer = ver
+	}
+
+	return newVer
+}

--- a/internal/pkg/model/ext_test.go
+++ b/internal/pkg/model/ext_test.go
@@ -1,0 +1,86 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build !integration
+
+package model
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestAgentGetNewVersion(t *testing.T) {
+	tests := []struct {
+		Name    string
+		Agent   *Agent
+		Ver     string
+		WantVer string
+	}{
+		{
+			Name: "nil",
+		},
+		{
+			Name:  "agent no meta empty version",
+			Agent: &Agent{},
+		},
+		{
+			Name:    "agent no meta nonempty version",
+			Agent:   &Agent{},
+			Ver:     "7.14",
+			WantVer: "7.14",
+		},
+		{
+			Name: "agent with meta empty new version",
+			Agent: &Agent{
+				Agent: &AgentMetadata{
+					Version: "7.14",
+				},
+			},
+			Ver:     "",
+			WantVer: "",
+		},
+		{
+			Name: "agent with meta empty version",
+			Agent: &Agent{
+				Agent: &AgentMetadata{
+					Version: "",
+				},
+			},
+			Ver:     "7.15",
+			WantVer: "7.15",
+		},
+		{
+			Name: "agent with meta non empty version",
+			Agent: &Agent{
+				Agent: &AgentMetadata{
+					Version: "7.14",
+				},
+			},
+			Ver:     "7.14",
+			WantVer: "",
+		},
+		{
+			Name: "agent with meta new version",
+			Agent: &Agent{
+				Agent: &AgentMetadata{
+					Version: "7.14",
+				},
+			},
+			Ver:     "7.15",
+			WantVer: "7.15",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			newVer := tc.Agent.GetNewVersion(tc.Ver)
+			diff := cmp.Diff(tc.WantVer, newVer)
+			if diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/internal/pkg/model/ext_test.go
+++ b/internal/pkg/model/ext_test.go
@@ -76,7 +76,7 @@ func TestAgentGetNewVersion(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			newVer := tc.Agent.GetNewVersion(tc.Ver)
+			newVer := tc.Agent.CheckDifferentVersion(tc.Ver)
 			diff := cmp.Diff(tc.WantVer, newVer)
 			if diff != "" {
 				t.Error(diff)


### PR DESCRIPTION
## What is the problem this PR solves?

Addresses comment on previous PR:
https://github.com/elastic/fleet-server/pull/683#issuecomment-909984620

## How does this PR solve the problem?

* Extract the get agent new version into a function
* Add full unit test coverage for that part

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues

- Relates https://github.com/elastic/fleet-server/pull/683#issuecomment-909984620
