### PR TITLE
Fix issues with config reloading

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -511,6 +511,7 @@ LOOP:
 		}
 
 		curCfg = newCfg
+		f.cfg = curCfg
 
 		select {
 		case newCfg = <-f.cfgCh:
@@ -553,6 +554,34 @@ func configChangedProfiler(curCfg, newCfg *config.Config) bool {
 	return changed
 }
 
+func redactOutputCfg(cfg *config.Config) config.Output {
+	const kRedacted = "[redacted]"
+	redacted := cfg.Output
+
+	if redacted.Elasticsearch.Password != "" {
+		redacted.Elasticsearch.Password = kRedacted
+	}
+
+	if redacted.Elasticsearch.APIKey != "" {
+		redacted.Elasticsearch.APIKey = kRedacted
+	}
+
+	if redacted.Elasticsearch.TLS != nil {
+		newTLS := *redacted.Elasticsearch.TLS
+
+		if newTLS.Certificate.Key != "" {
+			newTLS.Certificate.Key = kRedacted
+		}
+		if newTLS.Certificate.Passphrase != "" {
+			newTLS.Certificate.Passphrase = kRedacted
+		}
+
+		redacted.Elasticsearch.TLS = &newTLS
+	}
+
+	return redacted
+}
+
 func redactServerCfg(cfg *config.Config) config.Server {
 	const kRedacted = "[redacted]"
 	redacted := cfg.Inputs[0].Server
@@ -581,6 +610,14 @@ func configChangedServer(curCfg, newCfg *config.Config) bool {
 	switch {
 	case curCfg == nil:
 		zlog.Info().Msg("initial server configuration")
+	case !reflect.DeepEqual(curCfg.Fleet, newCfg.Fleet):
+		zlog.Info().
+			Interface("old", curCfg).
+			Msg("fleet configuration has changed")
+	case !reflect.DeepEqual(curCfg.Output, newCfg.Output):
+		zlog.Info().
+			Interface("old", redactOutputCfg(curCfg)).
+			Msg("output configuration has changed")
 	case !reflect.DeepEqual(curCfg.Inputs[0].Server, newCfg.Inputs[0].Server):
 		zlog.Info().
 			Interface("old", redactServerCfg(curCfg)).

--- a/cmd/fleet/main_integration_test.go
+++ b/cmd/fleet/main_integration_test.go
@@ -1,0 +1,232 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build integration
+
+package fleet
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/server"
+	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
+	"github.com/elastic/go-ucfg"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/build"
+	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
+	"github.com/elastic/fleet-server/v7/internal/pkg/model"
+	ftesting "github.com/elastic/fleet-server/v7/internal/pkg/testing"
+	"github.com/elastic/fleet-server/v7/internal/pkg/testing/suite"
+)
+
+var biInfo = build.Info{
+	Version: "1.0.0",
+	Commit:  "integration",
+}
+
+var policyData = []byte(`
+{
+	"inputs": [
+		{
+			"type": "fleet-server"
+		}
+	]
+}
+`)
+
+var initialCfgData = `
+output:
+  elasticsearch:
+    hosts: '${ELASTICSEARCH_HOSTS:localhost:9200}'
+    username: '${ELASTICSEARCH_USERNAME:elastic}'
+    password: '${ELASTICSEARCH_PASSWORD:changeme}'
+`
+
+var agentIdCfgData = `
+output:
+  elasticsearch:
+    hosts: '${ELASTICSEARCH_HOSTS:localhost:9200}'
+    username: '${ELASTICSEARCH_USERNAME:elastic}'
+    password: '${ELASTICSEARCH_PASSWORD:changeme}'
+fleet:
+  agent:
+    id: 1e4954ce-af37-4731-9f4a-407b08e69e42
+`
+
+var badCfgData = `
+output:
+  elasticsearch:
+    hosts: 'localhost:63542'
+    username: '${ELASTICSEARCH_USERNAME:elastic}'
+    password: '${ELASTICSEARCH_PASSWORD:changeme}'
+fleet:
+  agent:
+    id: 1e4954ce-af37-4731-9f4a-407b08e69e42
+`
+
+type agentSuite struct {
+	suite.RunningSuite
+}
+
+func (s *agentSuite) TestAgentMode(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bulker := ftesting.SetupBulk(ctx, t)
+
+	// add a real default fleet server policy
+	policyId := uuid.Must(uuid.NewV4()).String()
+	_, err := dl.CreatePolicy(ctx, bulker, model.Policy{
+		PolicyId:           policyId,
+		RevisionIdx:        1,
+		DefaultFleetServer: true,
+		Data:               policyData,
+	})
+	require.NoError(t, err)
+
+	// add entry for enrollment key (doesn't have to be a real key)
+	_, err = dl.CreateEnrollmentAPIKey(ctx, bulker, model.EnrollmentApiKey{
+		Name:     "Default",
+		ApiKey:   "keyvalue",
+		ApiKeyId: "keyid",
+		PolicyId: policyId,
+		Active:   true,
+	})
+	require.NoError(t, err)
+
+	app := &StubApp{}
+	control := createAndStartControlServer(t, app)
+	defer control.Stop()
+	appState, err := control.Register(app, initialCfgData)
+	require.NoError(t, err)
+
+	r, w := io.Pipe()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		agent, err := NewAgentMode(ucfg.New(), r, biInfo)
+		require.NoError(t, err)
+		err = agent.Run(ctx)
+		assert.NoError(t, err)
+	}()
+
+	err = appState.WriteConnInfo(w)
+	require.NoError(t, err)
+
+	// wait for fleet-server to report as degraded (starting mode without agent.id)
+	ftesting.Retry(t, ctx, func(ctx context.Context) error {
+		status := app.Status()
+		if status != proto.StateObserved_DEGRADED {
+			return fmt.Errorf("should be reported as degraded; instead its %s", status)
+		}
+		return nil
+	}, ftesting.RetrySleep(100*time.Millisecond), ftesting.RetryCount(120))
+
+	// reconfigure with agent ID set
+	err = appState.UpdateConfig(agentIdCfgData)
+	require.NoError(t, err)
+
+	// wait for fleet-server to report as healthy
+	ftesting.Retry(t, ctx, func(ctx context.Context) error {
+		status := app.Status()
+		if status != proto.StateObserved_HEALTHY {
+			return fmt.Errorf("should be reported as healthy; instead its %s", status)
+		}
+		return nil
+	}, ftesting.RetrySleep(100*time.Millisecond), ftesting.RetryCount(120))
+
+	// trigger update with bad configuration
+	err = appState.UpdateConfig(badCfgData)
+	require.NoError(t, err)
+
+	// wait for fleet-server to report as failed
+	ftesting.Retry(t, ctx, func(ctx context.Context) error {
+		status := app.Status()
+		if status != proto.StateObserved_FAILED {
+			return fmt.Errorf("should be reported as failed; instead its %s", status)
+		}
+		return nil
+	}, ftesting.RetrySleep(100*time.Millisecond), ftesting.RetryCount(120))
+
+	// reconfigure to good config
+	err = appState.UpdateConfig(agentIdCfgData)
+	require.NoError(t, err)
+
+	// wait for fleet-server to report as healthy
+	ftesting.Retry(t, ctx, func(ctx context.Context) error {
+		status := app.Status()
+		if status != proto.StateObserved_HEALTHY {
+			return fmt.Errorf("should be reported as healthy; instead its %s", status)
+		}
+		return nil
+	}, ftesting.RetrySleep(100*time.Millisecond), ftesting.RetryCount(120))
+
+	// trigger stop
+	err = appState.Stop(10 * time.Second)
+	assert.NoError(t, err)
+
+	// wait for go routine to exit
+	wg.Wait()
+}
+
+func newDebugLogger(t *testing.T) *logger.Logger {
+	t.Helper()
+
+	loggerCfg := logger.DefaultLoggingConfig()
+	loggerCfg.Level = logp.DebugLevel
+
+	log, err := logger.NewFromConfig("", loggerCfg)
+	require.NoError(t, err)
+	return log
+}
+
+func createAndStartControlServer(t *testing.T, handler server.Handler, extraConfigs ...func(*server.Server)) *server.Server {
+	t.Helper()
+	srv, err := server.New(newDebugLogger(t), "localhost:0", handler)
+	require.NoError(t, err)
+	for _, extra := range extraConfigs {
+		extra(srv)
+	}
+	require.NoError(t, srv.Start())
+	return srv
+}
+
+type StubApp struct {
+	lock    sync.RWMutex
+	status  proto.StateObserved_Status
+	message string
+	payload map[string]interface{}
+}
+
+func (a *StubApp) Status() proto.StateObserved_Status {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+	return a.status
+}
+
+func (a *StubApp) Message() string {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+	return a.message
+}
+
+func (a *StubApp) OnStatusChange(_ *server.ApplicationState, status proto.StateObserved_Status, message string, payload map[string]interface{}) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+	a.status = status
+	a.message = message
+	a.payload = payload
+}

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -37,7 +37,7 @@ type ApiKey = apikey.ApiKey
 type SecurityInfo = apikey.SecurityInfo
 
 type CacheT struct {
-	cache CacheImpl
+	cache Cacher
 	cfg   Config
 	mut   sync.RWMutex
 }

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dgraph-io/ristretto"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
@@ -38,7 +37,7 @@ type ApiKey = apikey.ApiKey
 type SecurityInfo = apikey.SecurityInfo
 
 type CacheT struct {
-	cache *ristretto.Cache
+	cache CacheImpl
 	cfg   Config
 	mut   sync.RWMutex
 }
@@ -81,16 +80,6 @@ func New(cfg Config) (*CacheT, error) {
 	}
 
 	return &c, nil
-}
-
-func newCache(cfg Config) (*ristretto.Cache, error) {
-	rcfg := &ristretto.Config{
-		NumCounters: cfg.NumCounters,
-		MaxCost:     cfg.MaxCost,
-		BufferItems: 64,
-	}
-
-	return ristretto.NewCache(rcfg)
 }
 
 // Reconfigure will drop cache

--- a/internal/pkg/cache/impl.go
+++ b/internal/pkg/cache/impl.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-type CacheImpl interface {
+type Cacher interface {
 	Get(key interface{}) (interface{}, bool)
 	Set(key, value interface{}, cost int64) bool
 	SetWithTTL(key, value interface{}, cost int64, ttl time.Duration) bool

--- a/internal/pkg/cache/impl.go
+++ b/internal/pkg/cache/impl.go
@@ -1,0 +1,16 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cache
+
+import (
+	"time"
+)
+
+type CacheImpl interface {
+	Get(key interface{}) (interface{}, bool)
+	Set(key, value interface{}, cost int64) bool
+	SetWithTTL(key, value interface{}, cost int64, ttl time.Duration) bool
+	Close()
+}

--- a/internal/pkg/cache/impl_integration.go
+++ b/internal/pkg/cache/impl_integration.go
@@ -1,0 +1,32 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build integration
+
+package cache
+
+import (
+	"time"
+)
+
+func newCache(_ Config) (CacheImpl, error) {
+	return &NoCache{}, nil
+}
+
+type NoCache struct{}
+
+func (c *NoCache) Get(_ interface{}) (interface{}, bool) {
+	return nil, false
+}
+
+func (c *NoCache) Set(_ interface{}, _ interface{}, _ int64) bool {
+	return true
+}
+
+func (c *NoCache) SetWithTTL(_, _ interface{}, _ int64, _ time.Duration) bool {
+	return true
+}
+
+func (c *NoCache) Close() {
+}

--- a/internal/pkg/cache/impl_integration.go
+++ b/internal/pkg/cache/impl_integration.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-func newCache(_ Config) (CacheImpl, error) {
+func newCache(_ Config) (Cacher, error) {
 	return &NoCache{}, nil
 }
 

--- a/internal/pkg/cache/impl_ristretto.go
+++ b/internal/pkg/cache/impl_ristretto.go
@@ -10,7 +10,7 @@ import (
 	"github.com/dgraph-io/ristretto"
 )
 
-func newCache(cfg Config) (CacheImpl, error) {
+func newCache(cfg Config) (Cacher, error) {
 	rcfg := &ristretto.Config{
 		NumCounters: cfg.NumCounters,
 		MaxCost:     cfg.MaxCost,

--- a/internal/pkg/cache/impl_ristretto.go
+++ b/internal/pkg/cache/impl_ristretto.go
@@ -1,0 +1,21 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build !integration
+
+package cache
+
+import (
+	"github.com/dgraph-io/ristretto"
+)
+
+func newCache(cfg Config) (CacheImpl, error) {
+	rcfg := &ristretto.Config{
+		NumCounters: cfg.NumCounters,
+		MaxCost:     cfg.MaxCost,
+		BufferItems: 64,
+	}
+
+	return ristretto.NewCache(rcfg)
+}

--- a/internal/pkg/dl/enrollment_api_key.go
+++ b/internal/pkg/dl/enrollment_api_key.go
@@ -6,6 +6,7 @@ package dl
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
@@ -78,4 +79,14 @@ func findEnrollmentAPIKeys(ctx context.Context, bulker bulk.Bulk, index string, 
 		}
 	}
 	return recs, nil
+}
+
+// CreateEnrollmentAPIKey creates a new enrollment API key
+func CreateEnrollmentAPIKey(ctx context.Context, bulker bulk.Bulk, key model.EnrollmentApiKey, opt ...Option) (string, error) {
+	o := newOption(FleetEnrollmentAPIKeys, opt...)
+	data, err := json.Marshal(&key)
+	if err != nil {
+		return "", err
+	}
+	return bulker.Create(ctx, o.indexName, "", data, bulk.WithRefresh())
 }

--- a/internal/pkg/testing/suite/suite.go
+++ b/internal/pkg/testing/suite/suite.go
@@ -1,0 +1,56 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build integration
+
+package suite
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/require"
+	tsuite "github.com/stretchr/testify/suite"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
+	"github.com/elastic/fleet-server/v7/internal/pkg/es"
+	ftesting "github.com/elastic/fleet-server/v7/internal/pkg/testing"
+	"github.com/elastic/fleet-server/v7/internal/pkg/testing/esutil"
+)
+
+var prepareIndexes = map[string]string{
+	dl.FleetActions:           es.MappingAction,
+	dl.FleetActionsResults:    es.MappingActionResult,
+	dl.FleetAgents:            es.MappingAgent,
+	dl.FleetArtifacts:         es.MappingArtifact,
+	dl.FleetEnrollmentAPIKeys: es.MappingEnrollmentApiKey,
+	dl.FleetPolicies:          es.MappingPolicy,
+	dl.FleetPoliciesLeader:    es.MappingPolicyLeader,
+	dl.FleetServers:           es.MappingServer,
+}
+
+type RunningSuite struct {
+	tsuite.Suite
+}
+
+func (s *RunningSuite) SetupSuite() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := ftesting.SetupBulk(ctx, s.T())
+	for index, mapping := range prepareIndexes {
+		err := esutil.EnsureIndex(ctx, c, index, mapping)
+		require.NoError(s.T(), err)
+	}
+}
+
+func (s *RunningSuite) TearDownSuite() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := ftesting.SetupBulk(ctx, s.T())
+	names := make([]string, 0, len(prepareIndexes))
+	for index, _ := range prepareIndexes {
+		names = append(names, index)
+	}
+	err := esutil.DeleteIndices(ctx, c, names...)
+	require.NoError(s.T(), err)
+}

--- a/internal/pkg/testing/suite/suite.go
+++ b/internal/pkg/testing/suite/suite.go
@@ -36,7 +36,7 @@ type RunningSuite struct {
 func (s *RunningSuite) SetupSuite() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c := ftesting.SetupBulk(ctx, s.T())
+	c := ftesting.SetupES(ctx, s.T())
 	for index, mapping := range prepareIndexes {
 		err := esutil.EnsureIndex(ctx, c, index, mapping)
 		require.NoError(s.T(), err)
@@ -46,7 +46,7 @@ func (s *RunningSuite) SetupSuite() {
 func (s *RunningSuite) TearDownSuite() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c := ftesting.SetupBulk(ctx, s.T())
+	c := ftesting.SetupES(ctx, s.T())
 	names := make([]string, 0, len(prepareIndexes))
 	for index, _ := range prepareIndexes {
 		names = append(names, index)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

There are 3 problems that this PR solves:

1. Configurations changes to the `fleet.*` or the `output.*` sections of the Fleet configurations would not cause the Fleet Server to restart the required sections of the server for those changes to actually take affect.
2. In the case that the configuration change fails (maybe a transient elasticsearch connection problem) then the Fleet Server would roll all the way back to its initial configuration sent from Elastic Agent.
3. No integration tests existed for Fleet Server being controlled by Elastic Agent.

## How does this PR solve the problem?

This solves each problem as follows:

1. It adjusts the configuration change checking code to check for the `fleet.*` and `output.*` sections.
2. It always stores the last given configuration in the FleetServet struct so on restart it always goes back to the last configuration that Elastic Agent provided it.
3. Integration test was added.

This PR also has a side-effect change that I needed to make to get the `libbeat/v7/x-pack/elastic-agent/core/server` working (which controls the AgentMode, just like the real Elastic Agent does). It seems that the `ristretto` module that Fleet Server uses for caching registers global flags because it includes `golang/glog` and the `libbeat/v7/x-pack/elastic-agent/core/server` includes the `logp` from libbeat registering the same flag. So to get the integration tests working I had to remove the `ristretto` module only when running integration tests.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

`make test-int`

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #691 