### PR TITLE
[mergify] notify if no backport labels on the PRs targeting the master branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -55,34 +55,6 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to 7.13 branch
-    conditions:
-      - merged
-      - base=master
-      - label=v7.13.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "7.13"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to 7.12 branch
-    conditions:
-      - merged
-      - base=master
-      - label=v7.12.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "7.12"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: automatic merge for 7\. branches when CI passes
     conditions:
       - check-success=fleet-server/pr-merge

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -55,6 +55,22 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: notify the backport policy
+    conditions:
+      - -label~=(^v\d|backport-skip)
+      - base=master
+    actions:
+      comment:
+        message: |
+          This pull request does not have a backport label. Could you fix it @{{author}}? 🙏
+          To fixup this pull request, you need to add the backport labels for the needed
+          branches, such as:
+          * `v./d./d./d` is the label to automatically backport to the `7./d` branch. `/d` is the digit
+
+          **NOTE**: `backport-skip` has been added to this pull request.
+      label:
+        add:
+          - backport-skip
   - name: automatic merge for 7\. branches when CI passes
     conditions:
       - check-success=fleet-server/pr-merge


### PR DESCRIPTION
## Motivation/summary

1. Tidy up old branches.
2. Notify PR contributors about the backport policy.

This policy will notify what are the different backport options and tag the PR with the `backport-skip`.

## Test

See https://github.com/elastic/apm-pipeline-library/pull/1281#issuecomment-922766344 and https://github.com/elastic/apm-pipeline-library/pull/1281#event-5327050151