### PR TITLE
feat: support building a release in a dockerised environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.ci
+.github
+build

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,8 @@
+ARG GO_VERSION
+FROM golang:${GO_VERSION}-stretch
+
+RUN apt-get update && apt-get install -y zip
+
+WORKDIR /go/src/github.com/elastic/fleet-server
+
+ENTRYPOINT [ "make", "release" ]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SHELL=/bin/bash
+GO_VERSION=$(shell cat '.go-version')
 DEFAULT_VERSION=$(shell awk '/const defaultVersion/{print $$NF}' main.go | tr -d '"')
 TARGET_ARCH_386=x86
 TARGET_ARCH_amd64=x86_64
@@ -11,6 +12,7 @@ BUILDMODE_windows_amd64=-buildmode=pie
 BUILDMODE_darwin_amd64=-buildmode=pie
 BUILDMODE_darwin_arm64=-buildmode=pie
 
+BUILDER_IMAGE=docker.elastic.co/observability-ci/fleet-server-builder:latest
 
 ifdef VERSION_QUALIFIER
 DEFAULT_VERSION:=${DEFAULT_VERSION}-${VERSION_QUALIFIER}
@@ -139,6 +141,13 @@ else
 	@tar -C build/binaries -zcf build/distributions/fleet-server-$(VERSION)-$(OS)-$(ARCH).tar.gz fleet-server-$(VERSION)-$(OS)-$(ARCH)
 	@cd build/distributions && shasum -a 512 fleet-server-$(VERSION)-$(OS)-$(ARCH).tar.gz > fleet-server-$(VERSION)-$(OS)-$(ARCH).tar.gz.sha512
 endif
+
+build-releaser: ## - Build a Docker image to run make package including all build tools
+	docker build -t $(BUILDER_IMAGE) -f Dockerfile.build --build-arg GO_VERSION=$(GO_VERSION) .
+
+.PHONY: docker-release
+docker-release: build-releaser ## - Builds a release for all platforms in a dockerised environment
+	docker run --rm -it --volume $(PWD):/go/src/github.com/elastic/fleet-server $(BUILDER_IMAGE)
 
 .PHONY: release
 release: $(PLATFORM_TARGETS) ## - Builds a release. Specify exact platform with PLATFORMS env.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?
This PR support building a release in an idempotent manner, where all build dependencies (Go and ZIP at this moment) are already present in the builder machine.

While building Fleet Server in a CI worker, we noticed that ZIP was not installed, and instead of creating "pet" workers with all tools installed, I considered automating the build at the project side, so that the build system is self-content, alowing developers to generate builds in a consistent manner.

// Please do not just reference an issue. Explain WHAT the problem this PR solves here.

## How does this PR solve the problem?
It adds two make goals:

1. Build a Docker image based in a Docker image for building the release (uses `make release` as ENTRYPOINT). See `Dockerfile.build` for content
1. Run an ephemeral container of the above builder image, mounting project's workspace into the Go path, so that the entrypoint is satisfied

// Explain HOW you solved the problem in your code. It is possible that during PR reviews this changes and then this section should be updated.


## How to test this PR locally

```shell
make docker-release
```

It will create all binaries under the `build/distributions` directory (as expected)

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->