### PR TITLE
[mergify] remove backport-skip if added a backport label

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -71,6 +71,13 @@ pull_request_rules:
       label:
         add:
           - backport-skip
+  - name: remove backport-skip label
+    conditions:
+      - label~=^v\d
+    actions:
+      label:
+        remove:
+          - backport-skip
   - name: automatic merge for 7\. branches when CI passes
     conditions:
       - check-success=fleet-server/pr-merge

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -65,7 +65,7 @@ pull_request_rules:
           This pull request does not have a backport label. Could you fix it @{{author}}? 🙏
           To fixup this pull request, you need to add the backport labels for the needed
           branches, such as:
-          * `v./d./d./d` is the label to automatically backport to the `7./d` branch. `/d` is the digit
+          * `v/d./d./d` is the label to automatically backport to the `7./d` branch. `/d` is the digit
 
           **NOTE**: `backport-skip` has been added to this pull request.
       label:


### PR DESCRIPTION
## What is the problem this PR solves?

Keep tidy the GItHub labels in the PRs.

## How does this PR solve the problem?

Remove `backport-skip` label when the backport labels have been added.

## How to test this PR locally

NA

## Test

![image](https://user-images.githubusercontent.com/2871786/136009191-20909c29-d1e3-441c-8bf0-106a29993890.png)

https://github.com/v1v/poc-bump-automation/pull/13

## Related issues

Similar to https://github.com/elastic/beats/pull/28235