### PR TITLE
Fix self monitor to report starting waiting on fleet-server input

### DIFF
--- a/internal/pkg/policy/self.go
+++ b/internal/pkg/policy/self.go
@@ -218,7 +218,14 @@ func (m *selfMonitorT) updateStatus(ctx context.Context) (proto.StateObserved_St
 		return proto.StateObserved_FAILED, err
 	}
 	if !data.HasType("fleet-server") {
-		return proto.StateObserved_FAILED, errors.New("assigned policy does not have fleet-server input")
+		// no fleet-server input
+		m.status = proto.StateObserved_STARTING
+		if m.policyId == "" {
+			m.reporter.Status(proto.StateObserved_STARTING, "Waiting on fleet-server input to be added to default policy", nil)
+		} else {
+			m.reporter.Status(proto.StateObserved_STARTING, fmt.Sprintf("Waiting on fleet-server input to be added to policy: %s", m.policyId), nil)
+		}
+		return proto.StateObserved_STARTING, nil
 	}
 
 	status := proto.StateObserved_HEALTHY

--- a/internal/pkg/policy/self_test.go
+++ b/internal/pkg/policy/self_test.go
@@ -71,11 +71,7 @@ func TestSelfMonitor_DefaultPolicy(t *testing.T) {
 
 	policyId := uuid.Must(uuid.NewV4()).String()
 	rId := xid.New().String()
-	policyContents, err := json.Marshal(&policyData{Inputs: []policyInput{
-		{
-			Type: "fleet-server",
-		},
-	}})
+	policyContents, err := json.Marshal(&policyData{Inputs: []policyInput{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +87,7 @@ func TestSelfMonitor_DefaultPolicy(t *testing.T) {
 		RevisionIdx:        1,
 		DefaultFleetServer: true,
 	}
-	policyData, err := json.Marshal(&policy)
+	pData, err := json.Marshal(&policy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +97,55 @@ func TestSelfMonitor_DefaultPolicy(t *testing.T) {
 				Id:      rId,
 				SeqNo:   1,
 				Version: 1,
-				Source:  policyData,
+				Source:  pData,
+			},
+		})
+	}()
+
+	// should still be set to starting
+	ftesting.Retry(t, ctx, func(ctx context.Context) error {
+		status, msg, _ := reporter.Current()
+		if status != proto.StateObserved_STARTING {
+			return fmt.Errorf("should be reported as starting; instead its %s", status)
+		}
+		if msg != "Waiting on fleet-server input to be added to default policy" {
+			return fmt.Errorf("should be matching with default policy")
+		}
+		return nil
+	})
+
+	rId = xid.New().String()
+	policyContents, err = json.Marshal(&policyData{Inputs: []policyInput{
+		{
+			Type: "fleet-server",
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy = model.Policy{
+		ESDocument: model.ESDocument{
+			Id:      rId,
+			Version: 1,
+			SeqNo:   1,
+		},
+		PolicyId:           policyId,
+		CoordinatorIdx:     1,
+		Data:               policyContents,
+		RevisionIdx:        2,
+		DefaultFleetServer: true,
+	}
+	pData, err = json.Marshal(&policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		mm.Notify(ctx, []es.HitT{
+			{
+				Id:      rId,
+				SeqNo:   2,
+				Version: 1,
+				Source:  pData,
 			},
 		})
 	}()
@@ -337,11 +381,7 @@ func TestSelfMonitor_SpecificPolicy(t *testing.T) {
 	}, ftesting.RetrySleep(1*time.Second))
 
 	rId := xid.New().String()
-	policyContents, err := json.Marshal(&policyData{Inputs: []policyInput{
-		{
-			Type: "fleet-server",
-		},
-	}})
+	policyContents, err := json.Marshal(&policyData{Inputs: []policyInput{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -354,10 +394,10 @@ func TestSelfMonitor_SpecificPolicy(t *testing.T) {
 		PolicyId:           policyId,
 		CoordinatorIdx:     1,
 		Data:               policyContents,
-		RevisionIdx:        1,
+		RevisionIdx:        2,
 		DefaultFleetServer: true,
 	}
-	policyData, err := json.Marshal(&policy)
+	pData, err := json.Marshal(&policy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -367,7 +407,55 @@ func TestSelfMonitor_SpecificPolicy(t *testing.T) {
 				Id:      rId,
 				SeqNo:   1,
 				Version: 1,
-				Source:  policyData,
+				Source:  pData,
+			},
+		})
+	}()
+
+	// should still be set to starting
+	ftesting.Retry(t, ctx, func(ctx context.Context) error {
+		status, msg, _ := reporter.Current()
+		if status != proto.StateObserved_STARTING {
+			return fmt.Errorf("should be reported as starting; instead its %s", status)
+		}
+		if msg != fmt.Sprintf("Waiting on fleet-server input to be added to policy: %s", policyId) {
+			return fmt.Errorf("should be matching with specific policy")
+		}
+		return nil
+	}, ftesting.RetrySleep(1*time.Second))
+
+	rId = xid.New().String()
+	policyContents, err = json.Marshal(&policyData{Inputs: []policyInput{
+		{
+			Type: "fleet-server",
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy = model.Policy{
+		ESDocument: model.ESDocument{
+			Id:      rId,
+			Version: 1,
+			SeqNo:   2,
+		},
+		PolicyId:           policyId,
+		CoordinatorIdx:     1,
+		Data:               policyContents,
+		RevisionIdx:        1,
+		DefaultFleetServer: true,
+	}
+	pData, err = json.Marshal(&policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		mm.Notify(ctx, []es.HitT{
+			{
+				Id:      rId,
+				SeqNo:   2,
+				Version: 1,
+				Source:  pData,
 			},
 		})
 	}()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

This solves the issue where Kibana could create the policy that fleet-server is waiting to exist, but when Kibana creates it, it doesn't add the `fleet-server` input to it. Before fleet-server would report this as an error and would cause the Elastic Agent to keep restarting the `fleet-server` constantly.

## How does this PR solve the problem?

This solves the issue by changing the logic to report the missing input as starting. This will allow the Elastic Agent to keep the `fleet-server` process running (removing the constant restart loop). Elastic Agent will also print the nice message that fleet-server provides back to the user.

Once the `fleet-server` input is added to the policy, `fleet-server` will notice that it now exists and will continue to normal operation.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #763 