### PR TITLE
Limit const size on 32bit arch to fit int32

### DIFF
--- a/dev-tools/buildlimits/buildlimits.go
+++ b/dev-tools/buildlimits/buildlimits.go
@@ -36,6 +36,9 @@ var tmpl = template.Must(template.New("specs").Parse(`
 package config
 
 import (
+	"math"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/packer"
@@ -84,10 +87,15 @@ type envLimits struct {
 }
 
 func defaultEnvLimits() *envLimits {
+	maxInt := math.MaxInt32
+	if strings.HasSuffix(runtime.GOARCH, "64") {
+		maxInt = 17179869184
+	}
+
 	return &envLimits{
 		RAM: valueRange{
 			Min: 0,
-			Max: 17179869184,
+			Max: maxInt,
 		},
 		Server: defaultserverLimitDefaults(),
 		Cache:  defaultCacheLimits(),

--- a/internal/pkg/config/env_defaults.go
+++ b/internal/pkg/config/env_defaults.go
@@ -7,6 +7,9 @@
 package config
 
 import (
+	"math"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/packer"
@@ -55,10 +58,15 @@ type envLimits struct {
 }
 
 func defaultEnvLimits() *envLimits {
+	maxInt := math.MaxInt32
+	if strings.HasSuffix(runtime.GOARCH, "64") {
+		maxInt = 17179869184
+	}
+
 	return &envLimits{
 		RAM: valueRange{
 			Min: 0,
-			Max: 17179869184,
+			Max: maxInt,
 		},
 		Server: defaultserverLimitDefaults(),
 		Cache:  defaultCacheLimits(),

--- a/internal/pkg/config/env_defaults_test.go
+++ b/internal/pkg/config/env_defaults_test.go
@@ -7,12 +7,20 @@
 package config
 
 import (
+	"math"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestLoadLimits(t *testing.T) {
+	maxInt := math.MaxInt32
+	if strings.HasSuffix(runtime.GOARCH, "64") {
+		maxInt = 17179869184
+	}
+
 	testCases := []struct {
 		Name           string
 		CurrentRAM     int
@@ -23,7 +31,7 @@ func TestLoadLimits(t *testing.T) {
 		{"precise", 1024, 1024},
 		{"2-to-4", 2650, 4096},
 		{"close to max", 16383, 16384},
-		{"above max", 16385, 17179869184},
+		{"above max", 16385, maxInt},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## What is the problem this PR solves?

Build is broken because const size exceeds 32bit int. 
This PR limits it for 32 bit architectures

Broken in: #762 

## How does this PR solve the problem?

If arch is 64 we use previously used limit, otherwise MaxInt32


## How to test this PR locally


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
