### PR TITLE
Add action_response field into .fleet-actions-results

### DIFF
--- a/cmd/fleet/handleAck.go
+++ b/cmd/fleet/handleAck.go
@@ -162,13 +162,14 @@ func (ack *AckT) handleAckEvents(ctx context.Context, agent *model.Agent, events
 		}
 
 		acr := model.ActionResult{
-			ActionId:    ev.ActionId,
-			AgentId:     agent.Id,
-			StartedAt:   ev.StartedAt,
-			CompletedAt: ev.CompletedAt,
-			ActionData:  ev.ActionData,
-			Data:        ev.Data,
-			Error:       ev.Error,
+			ActionId:       ev.ActionId,
+			AgentId:        agent.Id,
+			StartedAt:      ev.StartedAt,
+			CompletedAt:    ev.CompletedAt,
+			ActionData:     ev.ActionData,
+			ActionResponse: ev.ActionResponse,
+			Data:           ev.Data,
+			Error:          ev.Error,
 		}
 		if _, err := dl.CreateActionResult(ctx, ack.bulk, acr); err != nil {
 			return errors.Wrap(err, "create action result")

--- a/cmd/fleet/schema.go
+++ b/cmd/fleet/schema.go
@@ -102,20 +102,21 @@ type ActionResp struct {
 }
 
 type Event struct {
-	Type        string          `json:"type"`
-	SubType     string          `json:"subtype"`
-	AgentId     string          `json:"agent_id"`
-	ActionId    string          `json:"action_id"`
-	PolicyId    string          `json:"policy_id"`
-	StreamId    string          `json:"stream_id"`
-	Timestamp   string          `json:"timestamp"`
-	Message     string          `json:"message"`
-	Payload     json.RawMessage `json:"payload,omitempty"`
-	StartedAt   string          `json:"started_at"`
-	CompletedAt string          `json:"completed_at"`
-	ActionData  json.RawMessage `json:"action_data,omitempty"`
-	Data        json.RawMessage `json:"data,omitempty"`
-	Error       string          `json:"error,omitempty"`
+	Type           string          `json:"type"`
+	SubType        string          `json:"subtype"`
+	AgentId        string          `json:"agent_id"`
+	ActionId       string          `json:"action_id"`
+	PolicyId       string          `json:"policy_id"`
+	StreamId       string          `json:"stream_id"`
+	Timestamp      string          `json:"timestamp"`
+	Message        string          `json:"message"`
+	Payload        json.RawMessage `json:"payload,omitempty"`
+	StartedAt      string          `json:"started_at"`
+	CompletedAt    string          `json:"completed_at"`
+	ActionData     json.RawMessage `json:"action_data,omitempty"`
+	ActionResponse json.RawMessage `json:"action_response,omitempty"`
+	Data           json.RawMessage `json:"data,omitempty"`
+	Error          string          `json:"error,omitempty"`
 }
 
 type StatusResponse struct {

--- a/internal/pkg/es/mapping.go
+++ b/internal/pkg/es/mapping.go
@@ -49,6 +49,13 @@ const (
 	}
 }`
 
+	// ActionResponse The custom action response payload.
+	MappingActionResponse = `{
+	"properties": {
+		
+	}
+}`
+
 	// ActionResult An Elastic Agent action results
 	MappingActionResult = `{
 	"properties": {
@@ -58,6 +65,10 @@ const (
 		},
 		"action_id": {
 			"type": "keyword"
+		},
+		"action_response": {
+			"enabled" : false,
+			"type": "object"
 		},
 		"agent_id": {
 			"type": "keyword"

--- a/internal/pkg/model/schema.go
+++ b/internal/pkg/model/schema.go
@@ -65,6 +65,10 @@ type Action struct {
 type ActionData struct {
 }
 
+// ActionResponse The custom action response payload.
+type ActionResponse struct {
+}
+
 // ActionResult An Elastic Agent action results
 type ActionResult struct {
 	ESDocument
@@ -74,6 +78,9 @@ type ActionResult struct {
 
 	// The action id.
 	ActionId string `json:"action_id,omitempty"`
+
+	// The custom action response payload.
+	ActionResponse json.RawMessage `json:"action_response,omitempty"`
 
 	// The agent id.
 	AgentId string `json:"agent_id,omitempty"`

--- a/model/schema.json
+++ b/model/schema.json
@@ -97,6 +97,11 @@
           "type": "object",
           "format": "raw"
         },
+        "action_response": {
+          "description": "The custom action response payload.",
+          "type": "object",
+          "format": "raw"
+        },
         "error": {
           "description": "The action error message.",
           "type": "string"


### PR DESCRIPTION
## What does this PR do?
Add ```action_response``` to the ```.fleet-actions-results```. 

This allows to store a small payload from the beat/app action response if needed.
Currently this feature is needed for endpoint and could be useful for osquerybeat actions.

The endpoint team is hoping to get this into 7.16 if possible.

## Related issues
- Relates: https://github.com/elastic/security-team/issues/1924

## Screenshots

Confirmed mapping is created:
<img width="445" alt="Screen Shot 2021-10-20 at 4 10 34 PM" src="https://user-images.githubusercontent.com/872351/138166620-c8dcbfb7-30c2-437b-be2a-3aebfad7066f.png">

Confirmed the data is indexed and searchable with osquerybeat that now provides the number of rows returned by the query:
<img width="813" alt="Screen Shot 2021-10-20 at 4 10 58 PM" src="https://user-images.githubusercontent.com/872351/138166694-86f89e84-0493-47f1-939b-0e3ae525e48c.png">


