### PR TITLE
Change agentId field to a value that elastic will map.

### DIFF
--- a/cmd/fleet/handleAck.go
+++ b/cmd/fleet/handleAck.go
@@ -64,6 +64,7 @@ func (rt Router) handleAcks(w http.ResponseWriter, r *http.Request, ps httproute
 
 		log.WithLevel(resp.Level).
 			Err(err).
+			Str("agentId", id).
 			Str(EcsHttpRequestId, reqId).
 			Int(EcsHttpResponseCode, resp.StatusCode).
 			Int64(EcsEventDuration, time.Since(start).Nanoseconds()).

--- a/cmd/fleet/handleArtifacts.go
+++ b/cmd/fleet/handleArtifacts.go
@@ -74,7 +74,7 @@ func (rt Router) handleArtifacts(w http.ResponseWriter, r *http.Request, ps http
 	reqId := r.Header.Get(logger.HeaderRequestID)
 
 	zlog := log.With().
-		Str("id", id).
+		Str("agentId", id).
 		Str("sha2", sha2).
 		Str("remoteAddr", r.RemoteAddr).
 		Str(EcsHttpRequestId, reqId).

--- a/cmd/fleet/handleCheckin.go
+++ b/cmd/fleet/handleCheckin.go
@@ -74,11 +74,9 @@ func (rt Router) handleCheckin(w http.ResponseWriter, r *http.Request, ps httpro
 
 		reqId := r.Header.Get(logger.HeaderRequestID)
 
-		log.WithLevel(resp.Level).
+		zlog.WithLevel(resp.Level).
 			Err(err).
-			Str("id", id).
 			Int(EcsHttpResponseCode, resp.StatusCode).
-			Str(EcsHttpRequestId, reqId).
 			Int64(EcsEventDuration, time.Since(start).Nanoseconds()).
 			Msg("fail checkin")
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

While errors are being logged when a checkin fails, the "id" field is not mapped making it difficult to track individual agents in the logs.  Use a field name that will be mapped.


## How does this PR solve the problem?

Renames the field.


## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x ] I have commented my code, particularly in hard-to-understand areas


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->