### PR TITLE
Support agent record migration from 7.14 agents.

### DIFF
--- a/cmd/fleet/auth.go
+++ b/cmd/fleet/auth.go
@@ -111,13 +111,6 @@ func authAgent(r *http.Request, id *string, bulker bulk.Bulk, c cache.Cache) (*m
 		return nil, err
 	}
 
-	if agent.Agent == nil {
-		zlog.Warn().
-			Err(ErrAgentCorrupted).
-			Msg("agent record does not contain required metadata section")
-		return nil, ErrAgentCorrupted
-	}
-
 	findTime := time.Now()
 
 	if findTime.Sub(authTime) > time.Second {
@@ -137,10 +130,10 @@ func authAgent(r *http.Request, id *string, bulker bulk.Bulk, c cache.Cache) (*m
 	}
 
 	// validate that the id in the header is equal to the agent id record
-	if id != nil && *id != agent.Agent.Id {
+	if id != nil && *id != agent.Id {
 		zlog.Warn().
 			Err(ErrAgentIdentity).
-			Str("agent.Agent.Id", agent.Agent.Id).
+			Str("agent.Id", agent.Id).
 			Msg("agent id mismatch against http header")
 		return nil, ErrAgentIdentity
 	}

--- a/cmd/fleet/handleAck.go
+++ b/cmd/fleet/handleAck.go
@@ -98,6 +98,10 @@ func (ack *AckT) handleAcks(zlog *zerolog.Logger, w http.ResponseWriter, r *http
 		return ctx.Str(LogAccessApiKeyId, agent.AccessApiKeyId)
 	})
 
+	if err = dl.MigrateAgent(r.Context(), *zlog, ack.bulk, agent); err != nil {
+		return err
+	}
+
 	// Metrics; serenity now.
 	dfunc := cntAcks.IncStart()
 	defer dfunc()

--- a/cmd/fleet/handleArtifacts.go
+++ b/cmd/fleet/handleArtifacts.go
@@ -131,6 +131,10 @@ func (at ArtifactT) handleArtifacts(zlog *zerolog.Logger, r *http.Request, id, s
 		return ctx.Str(LogAccessApiKeyId, agent.AccessApiKeyId)
 	})
 
+	if err = dl.MigrateAgent(r.Context(), *zlog, at.bulker, agent); err != nil {
+		return nil, err
+	}
+
 	// Metrics; serenity now.
 	dfunc := cntArtifacts.IncStart()
 	defer dfunc()

--- a/cmd/fleet/handleCheckin.go
+++ b/cmd/fleet/handleCheckin.go
@@ -153,6 +153,10 @@ func (ct *CheckinT) handleCheckin(zlog *zerolog.Logger, w http.ResponseWriter, r
 		return ctx.Str(LogAccessApiKeyId, agent.AccessApiKeyId)
 	})
 
+	if err = dl.MigrateAgent(r.Context(), *zlog, ct.bulker, agent); err != nil {
+		return err
+	}
+
 	ver, err := validateUserAgent(*zlog, r, ct.verCon)
 	if err != nil {
 		return err

--- a/internal/pkg/checkin/bulk.go
+++ b/internal/pkg/checkin/bulk.go
@@ -197,7 +197,9 @@ func (bc *Bulk) flush(ctx context.Context) error {
 			// If the agent version is not empty it needs to be updated
 			// Assuming the agent can by upgraded keeping the same id, but incrementing the version
 			if pendingData.extra.ver != "" {
-				fields[dl.FieldAgentVersion] = pendingData.extra.ver
+				fields[dl.FieldAgent] = map[string]interface{}{
+					dl.FieldAgentVersion: pendingData.extra.ver,
+				}
 			}
 
 			// Update local metadata if provided

--- a/internal/pkg/dl/constants.go
+++ b/internal/pkg/dl/constants.go
@@ -40,7 +40,8 @@ const (
 	FieldDefaultApiKeyId             = "default_api_key_id"
 	FieldPolicyOutputPermissionsHash = "policy_output_permissions_hash"
 	FieldUnenrolledReason            = "unenrolled_reason"
-	FieldAgentVersion                = "agent.version"
+	FieldAgentVersion                = "version"
+	FieldAgent                       = "agent"
 
 	FieldActive           = "active"
 	FieldUpdatedAt        = "updated_at"

--- a/internal/pkg/dl/migration.go
+++ b/internal/pkg/dl/migration.go
@@ -1,0 +1,53 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package dl
+
+import (
+	"context"
+	"time"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
+	"github.com/elastic/fleet-server/v7/internal/pkg/logger"
+	"github.com/elastic/fleet-server/v7/internal/pkg/model"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+func MigrateAgent(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, agent *model.Agent) error {
+
+	// Agents enrolled before 7.15 do not have the metadata structure in the record.
+	// This metadata record was added to simplify transformations for the security application.
+	// If the record exists, there's nothing to do here.
+	// NOTE: This logic can be removed when we no longer support upgrade from 7.14.
+	if agent.Agent != nil {
+		return nil
+	}
+
+	// Update the id record, the version will be picked up on the next check-in.
+	meta := &model.AgentMetadata{Id: agent.Id}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	doc := bulk.UpdateFields{
+		FieldAgent:     meta,
+		FieldUpdatedAt: now,
+	}
+
+	body, err := doc.Marshal()
+	if err != nil {
+		return errors.Wrap(err, "migrateAgent marshal")
+	}
+
+	if err = bulker.Update(ctx, FleetAgents, agent.Id, body, bulk.WithRefresh()); err != nil {
+		zlog.Error().Err(err).Msg("fail migrate agent metadata")
+		return errors.Wrap(err, "migrateAgent update")
+	}
+
+	agent.Agent = meta
+
+	zlog.Info().Str(logger.AgentId, agent.Id).Msg("migrate agent record metadata")
+	return nil
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

// Please do not just reference an issue. Explain WHAT the problem this PR solves here.

Agent records created during 7.14 do not have the new "agent" sub-object used for transforms.  This code performs the migration.

## How does this PR solve the problem?

// Explain HOW you solved the problem in your code. It is possible that during PR reviews this changes and then this section should be updated.

If the agent record does not exist, create it.


## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x ] I have commented my code, particularly in hard-to-understand areas

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

- Relates https://github.com/elastic/fleet-server/issues/819