### PR TITLE
Migrate agent.id field from 7.14 to 7.15+

### DIFF
--- a/cmd/fleet/auth.go
+++ b/cmd/fleet/auth.go
@@ -137,10 +137,10 @@ func authAgent(r *http.Request, id *string, bulker bulk.Bulk, c cache.Cache) (*m
 	}
 
 	// validate that the id in the header is equal to the agent id record
-	if id != nil && *id != agent.Agent.Id {
+	if id != nil && *id != agent.Id {
 		zlog.Warn().
 			Err(ErrAgentIdentity).
-			Str("agent.Agent.Id", agent.Agent.Id).
+			Str("agent.Id", agent.Id).
 			Msg("agent id mismatch against http header")
 		return nil, ErrAgentIdentity
 	}

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -767,6 +767,11 @@ func (f *FleetServer) runSubsystems(ctx context.Context, cfg *config.Config, g *
 		return fmt.Errorf("failed version compatibility check with elasticsearch: %w", err)
 	}
 
+	// Run migrations; current safe to do in background.  That may change in the future.
+	g.Go(loggedRunFunc(ctx, "Migrations", func(ctx context.Context) error {
+		return dl.Migrate(ctx, bulker)
+	}))
+
 	// Monitoring es client, longer timeout, no retries
 	monCli, err := es.NewClient(ctx, cfg, true, es.WithUserAgent(kUAFleetServer, f.bi))
 	if err != nil {

--- a/internal/pkg/checkin/bulk.go
+++ b/internal/pkg/checkin/bulk.go
@@ -197,7 +197,9 @@ func (bc *Bulk) flush(ctx context.Context) error {
 			// If the agent version is not empty it needs to be updated
 			// Assuming the agent can by upgraded keeping the same id, but incrementing the version
 			if pendingData.extra.ver != "" {
-				fields[dl.FieldAgentVersion] = pendingData.extra.ver
+				fields[dl.FieldAgent] = map[string]interface{}{
+					dl.FieldAgentVersion: pendingData.extra.ver,
+				}
 			}
 
 			// Update local metadata if provided

--- a/internal/pkg/dl/constants.go
+++ b/internal/pkg/dl/constants.go
@@ -40,7 +40,8 @@ const (
 	FieldDefaultApiKeyId             = "default_api_key_id"
 	FieldPolicyOutputPermissionsHash = "policy_output_permissions_hash"
 	FieldUnenrolledReason            = "unenrolled_reason"
-	FieldAgentVersion                = "agent.version"
+	FieldAgentVersion                = "version"
+	FieldAgent                       = "agent"
 
 	FieldActive           = "active"
 	FieldUpdatedAt        = "updated_at"

--- a/internal/pkg/dl/migration.go
+++ b/internal/pkg/dl/migration.go
@@ -1,0 +1,130 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package dl
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
+	"github.com/elastic/fleet-server/v7/internal/pkg/dsl"
+
+	"github.com/elastic/go-elasticsearch/v7/esapi"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+func Migrate(ctx context.Context, bulker bulk.Bulk) error {
+	return migrateAgentMetadata(ctx, bulker)
+}
+
+// FleetServer 7.15 added a new *AgentMetadata field to the Agent record.
+// This field was populated in new enrollments in 7.15 and later; however, the
+// change was not backported to support 7.14.  The security team is reliant on the
+// existence of this field in 7.16, so the following migration was added to
+// support upgrade from 7.14.
+//
+// It is currently safe to run this in the background; albeit with some
+// concern on conflicts.  The conflict risk exists regardless as N Fleet Servers
+// can be run in parallel at the same time.
+//
+// As the update only occurs once, the 99.9% case is a noop.
+func migrateAgentMetadata(ctx context.Context, bulker bulk.Bulk) error {
+
+	root := dsl.NewRoot()
+	root.Query().Bool().MustNot().Exists("agent.id")
+
+	painless := "ctx._source.agent = [:]; ctx._source.agent.id = ctx._id;"
+	root.Param("script", painless)
+
+	body, err := root.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+LOOP:
+	for {
+		nConflicts, err := updateAgentMetadata(ctx, bulker, body)
+		if err != nil {
+			return err
+		}
+		if nConflicts == 0 {
+			break LOOP
+		}
+
+		time.Sleep(time.Second)
+	}
+
+	return nil
+}
+
+func updateAgentMetadata(ctx context.Context, bulker bulk.Bulk, body []byte) (int, error) {
+	start := time.Now()
+
+	client := bulker.Client()
+
+	reader := bytes.NewReader(body)
+
+	opts := []func(*esapi.UpdateByQueryRequest){
+		client.UpdateByQuery.WithBody(reader),
+		client.UpdateByQuery.WithContext(ctx),
+		client.UpdateByQuery.WithRefresh(true),
+		client.UpdateByQuery.WithConflicts("proceed"),
+	}
+
+	res, err := client.UpdateByQuery([]string{FleetAgents}, opts...)
+
+	if err != nil {
+		return 0, err
+	}
+
+	if res.IsError() {
+		return 0, fmt.Errorf("Migrate UpdateByQuery %s", res.String())
+	}
+
+	resp := struct {
+		Took             int  `json:"took"`
+		TimedOut         bool `json:"timed_out"`
+		Total            int  `json:"total"`
+		Updated          int  `json:"updated"`
+		Deleted          int  `json:"deleted"`
+		Batches          int  `json:"batches"`
+		VersionConflicts int  `json:"version_conflicts"`
+		Noops            int  `json:"noops"`
+		Retries          struct {
+			Bulk   int `json:"bulk"`
+			Search int `json:"search"`
+		} `json:"retries"`
+		Failures []json.RawMessage `json:"failures"`
+	}{}
+
+	decoder := json.NewDecoder(res.Body)
+	if err := decoder.Decode(&resp); err != nil {
+		return 0, errors.Wrap(err, "decode UpdateByQuery response")
+	}
+
+	log.Info().
+		Int("took", resp.Took).
+		Bool("timed_out", resp.TimedOut).
+		Int("total", resp.Total).
+		Int("updated", resp.Updated).
+		Int("deleted", resp.Deleted).
+		Int("batches", resp.Batches).
+		Int("version_conflicts", resp.VersionConflicts).
+		Int("noops", resp.Noops).
+		Int("retries.bulk", resp.Retries.Bulk).
+		Int("retries.search", resp.Retries.Search).
+		Dur("rtt", time.Since(start)).
+		Msg("migrate agent records response")
+
+	for _, fail := range resp.Failures {
+		log.Error().RawJSON("failure", fail).Msg("migration failure")
+	}
+
+	return resp.VersionConflicts, err
+}

--- a/internal/pkg/dl/migration.go
+++ b/internal/pkg/dl/migration.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
@@ -84,6 +85,11 @@ func updateAgentMetadata(ctx context.Context, bulker bulk.Bulk, body []byte) (in
 	}
 
 	if res.IsError() {
+		if res.StatusCode == http.StatusNotFound {
+			// Ignore index not created yet; nothing to upgrade
+			return 0, nil
+		}
+
 		return 0, fmt.Errorf("Migrate UpdateByQuery %s", res.String())
 	}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

Fix missing agent record migration added in 7.15.

## How does this PR solve the problem?

At boot, query for agent records that do not contain agent.id field and fix them up.  Should be a fast noop when no changes necessary.

In addition, fixes issue where agent.version was being written at root instead of as a child of the agent object.

## How to test this PR locally

Upgrade from 7.14, or enroll with 7.15 or later, and delete the "agent" object from the agent record in .fleet-agents.  This has been tested at scale, supports retry version conflict.  Once migration has occurred, typical response time from Elastic is less then 10ms (not including TLS roundtrip).


## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ x] I have commented my code, particularly in hard-to-understand areas


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

- Closes https://github.com/elastic/fleet-server/issues/819