### PR TITLE
Update go-elasticsearch to the latest 7.15.1 version

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -483,11 +483,11 @@ SOFTWARE
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/go-elasticsearch/v7
-Version: v7.5.1-0.20210823155509-845c8efe54a7
+Version: v7.15.1
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/go-elasticsearch/v7@v7.5.1-0.20210823155509-845c8efe54a7/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/go-elasticsearch/v7@v7.15.1/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/elastic/beats/v7 v7.11.1
 	github.com/elastic/elastic-agent-client/v7 v7.0.0-20210727140539-f0905d9377f6
-	github.com/elastic/go-elasticsearch/v7 v7.5.1-0.20210823155509-845c8efe54a7
+	github.com/elastic/go-elasticsearch/v7 v7.15.1
 	github.com/elastic/go-ucfg v0.8.3
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/google/go-cmp v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,8 @@ github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270 h1:cWPqxlPtir4RoQ
 github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270/go.mod h1:Msl1pdboCbArMF/nSCDUXgQuWTeoMmE/z8607X+k7ng=
 github.com/elastic/go-concert v0.0.4 h1:pzgYCmJ/xMJsW8PSk33inAWZ065hrwSeP79TpwAbsLE=
 github.com/elastic/go-concert v0.0.4/go.mod h1:9MtFarjXroUgmm0m6HY3NSe1XiKhdktiNRRj9hWvIaM=
-github.com/elastic/go-elasticsearch/v7 v7.5.1-0.20210823155509-845c8efe54a7 h1:Nq382VeELkUSC7y8JIXBNj0YfOqmq/d8mX+crl4xdrM=
-github.com/elastic/go-elasticsearch/v7 v7.5.1-0.20210823155509-845c8efe54a7/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
+github.com/elastic/go-elasticsearch/v7 v7.15.1 h1:Wd8RLHb5D8xPBU8vGlnLXyflkso9G+rCmsXjqH8LLQQ=
+github.com/elastic/go-elasticsearch/v7 v7.15.1/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-libaudit/v2 v2.1.0 h1:yWSKoGaoWLGFPjqWrQ4gwtuM77pTk7K4CsPxXss8he4=
 github.com/elastic/go-libaudit/v2 v2.1.0/go.mod h1:MM/l/4xV7ilcl+cIblL8Zn448J7RZaDwgNLE4gNKYPg=
 github.com/elastic/go-licenser v0.3.1 h1:RmRukU/JUmts+rpexAw0Fvt2ly7VVu6mw8z4HrEzObU=


### PR DESCRIPTION
## What is the problem this PR solves?

Updated to 7.15.1 tag that includes "Allow to overwrite User-Agent http request header" 
https://github.com/elastic/go-elasticsearch/commit/eeed8d4c1c5393ff4ae61deb809edf5b1e1c9af8

Previously we had to use commit hash to pick up this change.

## How does this PR solve the problem?

Updates go-elasticsearch dependency

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation


