### PR TITLE
Periodic expired actions cleanup

### DIFF
--- a/cmd/fleet/userAgent_test.go
+++ b/cmd/fleet/userAgent_test.go
@@ -2,6 +2,9 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !integration
+// +build !integration
+
 package fleet
 
 import (

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -122,6 +122,7 @@ func TestConfig(t *testing.T) {
 							CompressionThresh: 1024,
 							Limits:            defaultServerLimits(),
 							Bulk:              defaultServerBulk(),
+							GC:                defaultServerGC(),
 						},
 						Cache: defaultCache(),
 						Monitor: Monitor{
@@ -194,6 +195,12 @@ func defaultServerLimits() ServerLimits {
 
 func defaultServerBulk() ServerBulk {
 	var d ServerBulk
+	d.InitDefaults()
+	return d
+}
+
+func defaultServerGC() GC {
+	var d GC
 	d.InitDefaults()
 	return d
 }

--- a/internal/pkg/config/gc.go
+++ b/internal/pkg/config/gc.go
@@ -1,0 +1,24 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package config
+
+import "time"
+
+const (
+	defaultScheduleInterval      = time.Hour
+	defaultCleanupBeforeInterval = 30 * 24 * time.Hour // cleanup expired actions with expiration time older than 30 days from now
+)
+
+// GC is the configuration for the Fleet Server data garbage collection.
+// Currently manages the expired actions cleanup
+type GC struct {
+	ScheduleInterval     time.Duration `config:"schedule_interval"`
+	CleanupBeforeInteval time.Duration `config:"cleanup_before_interval"`
+}
+
+func (g *GC) InitDefaults() {
+	g.ScheduleInterval = defaultScheduleInterval
+	g.CleanupBeforeInteval = defaultCleanupBeforeInterval
+}

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -65,6 +65,7 @@ type Server struct {
 	Limits            ServerLimits            `config:"limits"`
 	Runtime           Runtime                 `config:"runtime"`
 	Bulk              ServerBulk              `config:"bulk"`
+	GC                GC                      `config:"gc"`
 }
 
 // InitDefaults initializes the defaults for the configuration.
@@ -78,6 +79,7 @@ func (c *Server) InitDefaults() {
 	c.Limits.InitDefaults()
 	c.Runtime.InitDefaults()
 	c.Bulk.InitDefaults()
+	c.GC.InitDefaults()
 }
 
 // BindAddress returns the binding address for the HTTP server.

--- a/internal/pkg/dsl/size.go
+++ b/internal/pkg/dsl/size.go
@@ -8,3 +8,8 @@ func (n *Node) Size(sz uint64) {
 	childNode := n.findOrCreateChildByName(kKeywordSize)
 	childNode.leaf = sz
 }
+
+// WithSize allows to parameterize the size
+func (n *Node) WithSize(v interface{}) {
+	n.nodeMap[kKeywordSize] = &Node{leaf: v}
+}

--- a/internal/pkg/es/error.go
+++ b/internal/pkg/es/error.go
@@ -6,7 +6,8 @@ package es
 
 import (
 	"errors"
-	"fmt"
+	"strconv"
+	"strings"
 )
 
 // TODO: Why do we have both ErrElastic and ErrorT?  Very strange.
@@ -32,7 +33,22 @@ func (e *ErrElastic) Unwrap() error {
 }
 
 func (e ErrElastic) Error() string {
-	return fmt.Sprintf("elastic fail %d:%s:%s", e.Status, e.Type, e.Reason)
+	// Improved error string to account on missing empty e.Type and e.Reason
+	// Otherwise were getting: "elastic fail 404::"
+	msg := "elastic fail "
+	var b strings.Builder
+	b.Grow(len(msg) + 5 + len(e.Type) + len(e.Reason))
+	b.WriteString(msg)
+	b.WriteString(strconv.Itoa(e.Status))
+	if e.Type != "" {
+		b.WriteString(":")
+		b.WriteString(e.Type)
+	}
+	if e.Reason != "" {
+		b.WriteString(":")
+		b.WriteString(e.Reason)
+	}
+	return b.String()
 }
 
 var (

--- a/internal/pkg/gc/actions.go
+++ b/internal/pkg/gc/actions.go
@@ -1,0 +1,134 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package gc
+
+import (
+	"context"
+	"math/rand"
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
+	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
+	"github.com/elastic/fleet-server/v7/internal/pkg/es"
+	"github.com/elastic/fleet-server/v7/internal/pkg/scheduler"
+	"github.com/elastic/fleet-server/v7/internal/pkg/wait"
+)
+
+const (
+	defaultMaxWaitInCleanupLoop         = 10 * time.Second // the wait in the cleanup loop between iteration is random
+	defaultActionsSelectSize            = 1000
+	defaultActionsCleanupBeforeInterval = 24 * 30 * time.Hour
+)
+
+type ActionsCleanupConfig struct {
+	maxWaitInCleanupLoop  time.Duration
+	actionsSelectSize     int
+	cleanupBeforeInterval time.Duration
+}
+
+type ActionsCleanupOpt func(c *ActionsCleanupConfig)
+
+func WithMaxWaitInCleanupLoop(maxWaitInCleanupLoop time.Duration) ActionsCleanupOpt {
+	return func(c *ActionsCleanupConfig) {
+		c.maxWaitInCleanupLoop = maxWaitInCleanupLoop
+	}
+}
+
+func WithActionSelectSize(actionsSelectSize int) ActionsCleanupOpt {
+	return func(c *ActionsCleanupConfig) {
+		c.actionsSelectSize = actionsSelectSize
+	}
+}
+
+func WithActionCleanupBeforeInterval(cleanupBeforeInterval time.Duration) ActionsCleanupOpt {
+	return func(c *ActionsCleanupConfig) {
+		c.cleanupBeforeInterval = cleanupBeforeInterval
+	}
+}
+
+func getActionsGCFunc(bulker bulk.Bulk, cleanupBeforeInterval time.Duration) scheduler.WorkFunc {
+	return func(ctx context.Context) error {
+		return cleanupActions(ctx, dl.FleetActions, bulker,
+			WithActionCleanupBeforeInterval(cleanupBeforeInterval))
+	}
+}
+
+func cleanupActions(ctx context.Context, index string, bulker bulk.Bulk, opts ...ActionsCleanupOpt) error {
+	log := log.With().Str("ctx", "fleet actions cleanup").Logger()
+
+	c := ActionsCleanupConfig{
+		cleanupBeforeInterval: defaultActionsCleanupBeforeInterval,
+		actionsSelectSize:     defaultActionsSelectSize,
+		maxWaitInCleanupLoop:  defaultMaxWaitInCleanupLoop,
+	}
+
+	for _, opt := range opts {
+		opt(&c)
+	}
+
+	// Cleanup expired actions where expired timetamp is older than current time minus cleanupBeforeInterval
+	// Example: cleanup up actions that expired more than two weeks ago
+	expiredBefore := time.Now().Add(-c.cleanupBeforeInterval)
+
+	// Random generator for calculating random pause duration in the cleanup loop
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+
+	var (
+		hits []es.HitT
+		err  error
+	)
+
+	for {
+		log.Debug().Str("expired_before", expiredBefore.UTC().Format(time.RFC3339)).Msgf("find actions that expired before given date/time")
+		hits, err = dl.FindExpiredActionsHitsForIndex(ctx, index, bulker, expiredBefore, c.actionsSelectSize)
+		if err != nil {
+			return err
+		}
+
+		if len(hits) == 0 {
+			log.Debug().Msg("no more expired actions found, done cleaning")
+			return nil
+		}
+
+		log.Debug().Int("count", len(hits)).Msg("delete expired actions")
+		for _, hit := range hits {
+			err = bulker.Delete(ctx, index, hit.Id)
+			if err != nil {
+				// The error is logged
+				log.Debug().Err(err).Str("action_id", hit.Id).Msg("failed to delete action")
+				if eserr, ok := err.(*es.ErrElastic); ok {
+					// The document could be missing, deleted by the other fleet server instance GC, which is ok
+					if eserr.Status == http.StatusNotFound {
+						err = nil
+					}
+				}
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		// If number of records selected is less than max, can exit the cleanup loop
+		if len(hits) < c.actionsSelectSize {
+			return nil
+		}
+
+		// The full number of hits was returned
+		// Can potentially have more records
+		// Pause before doing another iteration
+		if c.maxWaitInCleanupLoop > 0 {
+			pauseDuration := time.Duration(r.Int63n(int64(c.maxWaitInCleanupLoop)))
+			log.Debug().Dur("pause_duration", pauseDuration).Msg("more actions could be avaiable, pause before the next cleanup cycle")
+			// Wait with context some random short interval to avoid tight loops
+			err = wait.WithContext(ctx, pauseDuration)
+			if err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/internal/pkg/gc/actions_integration_test.go
+++ b/internal/pkg/gc/actions_integration_test.go
@@ -1,0 +1,114 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package gc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
+	"github.com/elastic/fleet-server/v7/internal/pkg/es"
+	ftesting "github.com/elastic/fleet-server/v7/internal/pkg/testing"
+)
+
+func TestCleanupActions(t *testing.T) {
+	tests := []struct {
+		name       string
+		selectSize int
+	}{
+		{
+			name:       "one loop pass",
+			selectSize: 1000,
+		},
+		{
+			name:       "multiple loop passes",
+			selectSize: 5,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			testCleanupActionsWithSelectSize(t, tc.selectSize)
+		})
+	}
+}
+
+func testCleanupActionsWithSelectSize(t *testing.T, selectSize int) {
+	const (
+		thirtyDays        = 24 * 30 * time.Hour
+		thirtyDaysAndHour = thirtyDays + time.Hour
+	)
+
+	ctx := context.Background()
+	index, bulker := ftesting.SetupIndexWithBulk(ctx, t, es.MappingAction)
+
+	_ = index
+
+	expiredActions, err := ftesting.CreateRandomActions(
+		ftesting.CreateActionsWithMinAgentsCount(3),
+		ftesting.CreateActionsWithMaxAgentsCount(7),
+		ftesting.CreateActionsWithMinActionsCount(7),
+		ftesting.CreateActionsWithMaxActionsCount(15),
+		ftesting.CreateActionsWithTimestampOffset(-thirtyDaysAndHour),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nonExpiredActions, err := ftesting.CreateRandomActions(
+		ftesting.CreateActionsWithMinAgentsCount(3),
+		ftesting.CreateActionsWithMaxAgentsCount(7),
+		ftesting.CreateActionsWithMinActionsCount(7),
+		ftesting.CreateActionsWithMaxActionsCount(15),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ftesting.StoreActions(ctx, bulker, index, append(expiredActions, nonExpiredActions...))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cleanupActions(ctx, index, bulker,
+		WithActionCleanupBeforeInterval(thirtyDays),
+		WithActionSelectSize(selectSize), // smaller size test few loop passes
+		WithMaxWaitInCleanupLoop(0))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Second)
+
+	// Check that all expired actions where deleted
+	hits, err := dl.FindExpiredActionsHitsForIndex(ctx, index, bulker, time.Now().Add(-thirtyDays), 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) > 0 {
+		t.Errorf("unexpected number of hits, got %d, want 0", len(hits))
+	}
+
+	// Check that non-expired actions are still there
+	hits, err = dl.FindExpiredActionsHitsForIndex(ctx, index, bulker, time.Now().Add(time.Hour), 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != len(nonExpiredActions) {
+		t.Errorf("unexpected number of hits, got %d, want %d", len(hits), len(nonExpiredActions))
+	}
+}

--- a/internal/pkg/gc/actions_integration_test.go
+++ b/internal/pkg/gc/actions_integration_test.go
@@ -2,6 +2,9 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build integration
+// +build integration
+
 package gc
 
 import (

--- a/internal/pkg/gc/schedules.go
+++ b/internal/pkg/gc/schedules.go
@@ -1,0 +1,35 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package gc
+
+import (
+	"time"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
+	"github.com/elastic/fleet-server/v7/internal/pkg/scheduler"
+)
+
+const (
+	defaultScheduleInterval      = time.Hour
+	defaultCleanupBeforeInterval = 30 * 24 * time.Hour // cleanup with expiration older than 30 days from now
+)
+
+// Schedules returns the GC schedules
+func Schedules(bulker bulk.Bulk, scheduleInterval, cleanupBeforeInterval time.Duration) []scheduler.Schedule {
+	if scheduleInterval == 0 {
+		scheduleInterval = defaultScheduleInterval
+	}
+	if cleanupBeforeInterval == 0 {
+		cleanupBeforeInterval = defaultCleanupBeforeInterval
+	}
+
+	return []scheduler.Schedule{
+		{
+			Name:     "fleet actions cleanup",
+			Interval: scheduleInterval,
+			WorkFn:   getActionsGCFunc(bulker, cleanupBeforeInterval),
+		},
+	}
+}

--- a/internal/pkg/scheduler/scheduler.go
+++ b/internal/pkg/scheduler/scheduler.go
@@ -1,0 +1,123 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"math/rand"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	defaultSplayPercent  = 10
+	defaultFirstRunDelay = 10 * time.Second
+)
+
+type WorkFunc func(ctx context.Context) error
+
+type Schedule struct {
+	Name     string
+	Interval time.Duration
+	WorkFn   WorkFunc
+}
+
+type OptFunc func(*Scheduler) error
+
+type Scheduler struct {
+	log zerolog.Logger
+
+	splayPercent  int
+	firstRunDelay time.Duration // Interval to run the scheduled function for the first time since the scheduler started, splayed as well.
+
+	rand      *rand.Rand
+	schedules []Schedule
+}
+
+func WithSplayPercent(splayPercent uint) OptFunc {
+	return func(s *Scheduler) error {
+		if splayPercent >= 100 {
+			return errors.New("invalid splay value, expected < 100")
+		}
+		s.splayPercent = int(splayPercent)
+		return nil
+	}
+}
+
+func WithFirstRunDelay(delay time.Duration) OptFunc {
+	return func(s *Scheduler) error {
+		s.firstRunDelay = delay
+		return nil
+	}
+}
+
+func New(schedules []Schedule, opts ...OptFunc) (*Scheduler, error) {
+	s := &Scheduler{
+		log:           log.With().Str("ctx", "elasticsearch CG scheduler").Logger(),
+		splayPercent:  defaultSplayPercent,
+		firstRunDelay: defaultFirstRunDelay,
+		rand:          rand.New(rand.NewSource(time.Now().UnixNano())),
+		schedules:     schedules,
+	}
+
+	for _, opt := range opts {
+		err := opt(s)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return s, nil
+}
+
+func (s *Scheduler) Run(ctx context.Context) error {
+	g, ctx := errgroup.WithContext(ctx)
+
+	for _, schedule := range s.schedules {
+		g.Go(s.getRunScheduleFunc(ctx, schedule))
+	}
+	return g.Wait()
+}
+
+func (s *Scheduler) getRunScheduleFunc(ctx context.Context, schedule Schedule) func() error {
+	return func() error {
+		log := log.With().Str("schedule", schedule.Name).Logger()
+
+		t := time.NewTimer(s.intervalWithSplay(s.firstRunDelay)) // Initial schedule to run right away with splayed randomly delay
+		defer t.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				log.Debug().Msg("exiting on context cancel")
+				return nil
+			case <-t.C:
+				runSchedule(ctx, log, schedule)
+				t.Reset(s.intervalWithSplay(schedule.Interval))
+			}
+		}
+	}
+}
+
+func (s *Scheduler) intervalWithSplay(interval time.Duration) time.Duration {
+	percent := 100 - s.splayPercent + s.rand.Intn(2*s.splayPercent+1)
+	return time.Duration(int64(interval) / int64(100.0) * int64(percent))
+}
+
+func runSchedule(ctx context.Context, log zerolog.Logger, schedule Schedule) {
+	log.Debug().Dur("interval", schedule.Interval).Msg("started")
+
+	err := schedule.WorkFn(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("failed running schedule function")
+	}
+
+	log.Debug().Msg("finished")
+}

--- a/internal/pkg/scheduler/scheduler_test.go
+++ b/internal/pkg/scheduler/scheduler_test.go
@@ -1,0 +1,82 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !integration
+// +build !integration
+
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/wait"
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/sync/errgroup"
+)
+
+var (
+	errTest = errors.New("errgroup exit")
+)
+
+type scheduleTester struct {
+	called int
+}
+
+func (s *scheduleTester) Run(ctx context.Context) error {
+	s.called++
+	return nil
+}
+
+func TestScheduler(t *testing.T) {
+
+	const (
+		scheduleInterval       = 200 * time.Millisecond
+		scheduleCancelInterval = 500 * time.Millisecond
+		expectedNumberOfCalls  = int(scheduleCancelInterval/scheduleInterval) + 1 // Expected number of calls, plus initial one
+	)
+
+	st := scheduleTester{}
+
+	schedules := []Schedule{
+		{
+			Name:     "test schedule",
+			Interval: scheduleInterval,
+			WorkFn:   st.Run,
+		},
+	}
+
+	sched, err := New(schedules, WithFirstRunDelay(0))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g, ctx := errgroup.WithContext(context.Background())
+
+	// Run scheduler
+	g.Go(func() error {
+		return sched.Run(ctx)
+	})
+
+	g.Go(func() error {
+		wait.WithContext(ctx, 500*time.Millisecond)
+		// return some error here to cause exit error group wait
+		return errTest
+	})
+
+	// Wait for result
+	err = g.Wait()
+	if !errors.Is(err, errTest) {
+		t.Errorf("unxpected err, want: %v, got: %v", errTest, err)
+	}
+
+	// Expected
+	diff := cmp.Diff(expectedNumberOfCalls, st.called)
+	if diff != "" {
+		t.Fatal(diff)
+	}
+
+}

--- a/internal/pkg/testing/actions.go
+++ b/internal/pkg/testing/actions.go
@@ -158,7 +158,7 @@ func StoreActions(ctx context.Context, bulker bulk.Bulk, index string, actions [
 		if err != nil {
 			return err
 		}
-		_, err = bulker.Create(ctx, index, action.Id, body)
+		_, err = bulker.Create(ctx, index, action.Id, body, bulk.WithRefresh())
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/testing/actions.go
+++ b/internal/pkg/testing/actions.go
@@ -22,16 +22,75 @@ import (
 	"github.com/rs/xid"
 )
 
-func CreateRandomActions(min, max int) ([]model.Action, error) {
+type CreateActionsConfig struct {
+	minAgentsCount   int
+	maxAgentsCount   int
+	minActionsCount  int
+	maxActionsCount  int
+	timestampOffset  time.Duration // offset for the action timestamp from the current time
+	expirationOffset time.Duration // expiration offset since the action creation
+}
+
+type CreateActionsOpt func(c *CreateActionsConfig)
+
+func CreateActionsWithMinAgentsCount(count int) CreateActionsOpt {
+	return func(c *CreateActionsConfig) {
+		c.minAgentsCount = count
+	}
+}
+
+func CreateActionsWithMaxAgentsCount(count int) CreateActionsOpt {
+	return func(c *CreateActionsConfig) {
+		c.maxAgentsCount = count
+	}
+}
+
+func CreateActionsWithMinActionsCount(count int) CreateActionsOpt {
+	return func(c *CreateActionsConfig) {
+		c.minActionsCount = count
+	}
+}
+
+func CreateActionsWithMaxActionsCount(count int) CreateActionsOpt {
+	return func(c *CreateActionsConfig) {
+		c.maxActionsCount = count
+	}
+}
+
+func CreateActionsWithTimestampOffset(timestampOffset time.Duration) CreateActionsOpt {
+	return func(c *CreateActionsConfig) {
+		c.timestampOffset = timestampOffset
+	}
+}
+
+func CreateActionsWithExpirationOffset(expirationOffset time.Duration) CreateActionsOpt {
+	return func(c *CreateActionsConfig) {
+		c.expirationOffset = expirationOffset
+	}
+}
+
+func CreateRandomActions(opts ...CreateActionsOpt) ([]model.Action, error) {
+	c := CreateActionsConfig{
+		minAgentsCount:   1,
+		maxAgentsCount:   1,
+		minActionsCount:  4,               // previously hardcoded, using as default
+		maxActionsCount:  9,               // previously hardcoded, using as default
+		expirationOffset: 5 * time.Minute, // default expiration of the action since the action timestamp
+	}
+
+	for _, opt := range opts {
+		opt(&c)
+	}
+
 	r := rnd.New()
 
-	sz := r.Int(min, max)
+	sz := r.Int(c.minAgentsCount, c.maxAgentsCount)
 	agentIds := make([]string, sz)
 	for i := 0; i < sz; i++ {
 		agentIds[i] = uuid.Must(uuid.NewV4()).String()
 	}
 
-	sz = r.Int(4, 9)
+	sz = r.Int(c.minActionsCount, c.maxActionsCount)
 
 	now := time.Now().UTC()
 
@@ -54,13 +113,21 @@ func CreateRandomActions(min, max int) ([]model.Action, error) {
 		if len(aid) == 0 {
 			aid = nil
 		}
+
+		timestamp := r.Time(now, 1, 3, time.Second, rnd.TimeBefore)
+		if c.timestampOffset != 0 {
+			timestamp = timestamp.Add(c.timestampOffset)
+		}
+
+		expiration := timestamp.Add(c.expirationOffset)
+
 		action := model.Action{
 			ESDocument: model.ESDocument{
 				Id: xid.New().String(),
 			},
 			ActionId:   uuid.Must(uuid.NewV4()).String(),
-			Timestamp:  r.Time(now, 2, 5, time.Second, rnd.TimeBefore).Format(time.RFC3339),
-			Expiration: r.Time(now, 12, 25, time.Minute, rnd.TimeAfter).Format(time.RFC3339),
+			Timestamp:  timestamp.Format(time.RFC3339),
+			Expiration: expiration.Format(time.RFC3339),
 			Type:       "APP_ACTION",
 			InputType:  "osquery",
 			Agents:     aid,
@@ -70,25 +137,33 @@ func CreateRandomActions(min, max int) ([]model.Action, error) {
 		actions[i] = action
 	}
 	return actions, nil
+
 }
 
 func StoreRandomActions(ctx context.Context, bulker bulk.Bulk, index string, min, max int) ([]model.Action, error) {
-	actions, err := CreateRandomActions(min, max)
+	actions, err := CreateRandomActions(
+		CreateActionsWithMinAgentsCount(min),
+		CreateActionsWithMaxAgentsCount(max),
+	)
 	if err != nil {
 		return nil, err
 	}
 
+	return actions, StoreActions(ctx, bulker, index, actions)
+}
+
+func StoreActions(ctx context.Context, bulker bulk.Bulk, index string, actions []model.Action) error {
 	for _, action := range actions {
 		body, err := json.Marshal(action)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		_, err = bulker.Create(ctx, index, action.Id, body, bulk.WithRefresh())
+		_, err = bulker.Create(ctx, index, action.Id, body)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
-	return actions, err
+	return nil
 }
 
 func SetupActions(ctx context.Context, t *testing.T, min, max int) (string, bulk.Bulk, []model.Action) {

--- a/internal/pkg/wait/wait.go
+++ b/internal/pkg/wait/wait.go
@@ -1,0 +1,21 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package wait
+
+import (
+	"context"
+	"time"
+)
+
+func WithContext(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}


### PR DESCRIPTION
## What is the problem this PR solves?

Due to current limitations of the index changes monitoring with utilizing Elasticsearch document sequence numbers for fleet actions, the .fleet-actions index can't be rolled over or have multiple shards.
Until this problem is solved on Elasticsearch side we have to continue using the same single index/shard, that allows the implementation to rely on the guaranteed incremental document sequence number. In order to reduce the number of documents stored in the index over time we need to introduce some kind of cleanup procedure for removal of the old documents.

This PR introduces scheduled cleanup for the expired fleet actions.
The current default is to remove the expired document where the expiration date/time is older than 30 day from the moment the cleanup job runs. The cleanup runs first within about 10 seconds from the start of the fleet server and then about every hour after that, the interval is splayed by 10% by default.

I believe the .fleet-policies would have to do the same, will add to this PR later.

## How does this PR solve the problem?

This PR introduces scheduled cleanup for the expired fleet actions.
The current default is to remove the expired document where the expiration date/time is older than 30 day from the moment the cleanup job runs. The cleanup runs first within about 10 seconds from the start of the fleet server and then about every hour after that, the interval is splayed by 10% by default.


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

