### PR TITLE
Fix: Fleet Server crashes on expired actions search

### DIFF
--- a/internal/pkg/dl/actions.go
+++ b/internal/pkg/dl/actions.go
@@ -128,7 +128,10 @@ func FindExpiredActionsHitsForIndex(ctx context.Context, index string, bulker bu
 	if err != nil {
 		return nil, err
 	}
-	return res.Hits, nil
+	if res != nil {
+		return res.Hits, nil
+	}
+	return nil, nil
 }
 
 func findActionsHits(ctx context.Context, bulker bulk.Bulk, tmpl *dsl.Tmpl, index string, params map[string]interface{}, seqNos []int64) (*es.HitsT, error) {


### PR DESCRIPTION
## What is the problem this PR solves?

Fixes the crash on expired actions search if the .fleet-actions index doesn't exists (on a clean install) on master and 8.0 branches.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x47d5a7c]

goroutine 60 [running]:
github.com/elastic/fleet-server/v7/internal/pkg/dl.FindExpiredActionsHitsForIndex({0x4dde6d8, 0xc0001d2400}, {0x4c91d88, 0xe}, {0x4dfc250, 0xc00013ed00}, {0x1f4, 0xc000032fd0, 0x567b960}, 0x3e8)
	/Users/amaus/elastic/fleet-server/internal/pkg/dl/actions.go:131 +0x27c
github.com/elastic/fleet-server/v7/internal/pkg/gc.cleanupActions({0x4dde6d8, 0xc0001d2400}, {0x4c91d88, 0xe}, {0x4dfc250, 0xc00013ed00}, {0xc000735bb0, 0x1, 0xc000394000})
	/Users/amaus/elastic/fleet-server/internal/pkg/gc/actions.go:88 +0x5ed
```

## How does this PR solve the problem?

The result could be nil if the index is not found. Added check for nil.

## How to test this PR locally

Start clean instance of the stack, fleet server should start with no crash after the fix.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

