### PR TITLE
Improve the cleanup code on enrollment handling error

### DIFF
--- a/cmd/fleet/handleEnroll.go
+++ b/cmd/fleet/handleEnroll.go
@@ -20,6 +20,7 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/limit"
 	"github.com/elastic/fleet-server/v7/internal/pkg/logger"
 	"github.com/elastic/fleet-server/v7/internal/pkg/model"
+	"github.com/elastic/fleet-server/v7/internal/pkg/rollback"
 	"github.com/elastic/fleet-server/v7/internal/pkg/sqn"
 
 	"github.com/gofrs/uuid"
@@ -84,7 +85,25 @@ func (rt Router) handleEnroll(w http.ResponseWriter, r *http.Request, ps httprou
 		Str("mod", kEnrollMod).
 		Logger()
 
-	resp, err := rt.et.handleEnroll(&zlog, w, r)
+	// Error in the scope for deferred rolback function check
+	var err error
+
+	// Initialize rollback/cleanup for enrollment
+	// This deletes all the artifacts that were created during enrollment
+	rb := rollback.New(zlog)
+	defer func() {
+		if err != nil {
+			zlog.Error().Err(err).Msg("perform rollback on enrollment failure")
+			// Using the router context for the rollback
+			err = rb.Rollback(rt.ctx)
+			if err != nil {
+				zlog.Error().Err(err).Msg("rollback error on enrollment failure")
+			}
+		}
+	}()
+
+	var resp *EnrollResponse
+	resp, err = rt.et.handleEnroll(rb, &zlog, w, r)
 
 	if err != nil {
 		cntEnroll.IncError(err)
@@ -96,8 +115,8 @@ func (rt Router) handleEnroll(w http.ResponseWriter, r *http.Request, ps httprou
 			Int64(EcsEventDuration, time.Since(start).Nanoseconds()).
 			Msg("fail enroll")
 
-		if err := resp.Write(w); err != nil {
-			zlog.Error().Err(err).Msg("fail writing error response")
+		if rerr := resp.Write(w); rerr != nil {
+			zlog.Error().Err(rerr).Msg("fail writing error response")
 		}
 		return
 	}
@@ -108,13 +127,10 @@ func (rt Router) handleEnroll(w http.ResponseWriter, r *http.Request, ps httprou
 			Err(err).
 			Int64(EcsEventDuration, time.Since(start).Nanoseconds()).
 			Msg("fail write response")
-
-		// Remove ghost artifacts; agent will never receive the paylod
-		rt.et.wipeGhosts(r.Context(), zlog, resp)
 	}
 }
 
-func (et *EnrollerT) handleEnroll(zlog *zerolog.Logger, w http.ResponseWriter, r *http.Request) (*EnrollResponse, error) {
+func (et *EnrollerT) handleEnroll(rb *rollback.Rollback, zlog *zerolog.Logger, w http.ResponseWriter, r *http.Request) (*EnrollResponse, error) {
 
 	limitF, err := et.limit.Acquire()
 	if err != nil {
@@ -141,10 +157,10 @@ func (et *EnrollerT) handleEnroll(zlog *zerolog.Logger, w http.ResponseWriter, r
 	dfunc := cntEnroll.IncStart()
 	defer dfunc()
 
-	return et.processRequest(*zlog, w, r, key.Id, ver)
+	return et.processRequest(rb, *zlog, w, r, key.Id, ver)
 }
 
-func (et *EnrollerT) processRequest(zlog zerolog.Logger, w http.ResponseWriter, r *http.Request, enrollmentApiKeyId, ver string) (*EnrollResponse, error) {
+func (et *EnrollerT) processRequest(rb *rollback.Rollback, zlog zerolog.Logger, w http.ResponseWriter, r *http.Request, enrollmentApiKeyId, ver string) (*EnrollResponse, error) {
 
 	// Validate that an enrollment record exists for a key with this id.
 	erec, err := et.fetchEnrollmentKeyRecord(r.Context(), enrollmentApiKeyId)
@@ -169,10 +185,10 @@ func (et *EnrollerT) processRequest(zlog zerolog.Logger, w http.ResponseWriter, 
 
 	cntEnroll.bodyIn.Add(readCounter.Count())
 
-	return et._enroll(r.Context(), zlog, req, erec.PolicyId, ver)
+	return et._enroll(r.Context(), rb, zlog, req, erec.PolicyId, ver)
 }
 
-func (et *EnrollerT) _enroll(ctx context.Context, zlog zerolog.Logger, req *EnrollRequest, policyId, ver string) (*EnrollResponse, error) {
+func (et *EnrollerT) _enroll(ctx context.Context, rb *rollback.Rollback, zlog zerolog.Logger, req *EnrollRequest, policyId, ver string) (*EnrollResponse, error) {
 
 	if req.SharedId != "" {
 		// TODO: Support pre-existing install
@@ -201,6 +217,11 @@ func (et *EnrollerT) _enroll(ctx context.Context, zlog zerolog.Logger, req *Enro
 		return nil, err
 	}
 
+	// Register invalidate API key function for enrollment error rollback
+	rb.Register("invalidate API key", func(ctx context.Context) error {
+		return invalidateApiKey(ctx, zlog, et.bulker, accessApiKey.Id)
+	})
+
 	agentData := model.Agent{
 		Active:         true,
 		PolicyId:       policyId,
@@ -217,9 +238,13 @@ func (et *EnrollerT) _enroll(ctx context.Context, zlog zerolog.Logger, req *Enro
 
 	err = createFleetAgent(ctx, et.bulker, agentId, agentData)
 	if err != nil {
-		invalidateApiKey(ctx, zlog, et.bulker, accessApiKey.Id)
 		return nil, err
 	}
+
+	// Register delete fleet agent for enrollment error rollback
+	rb.Register("delete agent", func(ctx context.Context) error {
+		return deleteAgent(ctx, zlog, et.bulker, agentId)
+	})
 
 	resp := EnrollResponse{
 		Action: "created",
@@ -243,17 +268,15 @@ func (et *EnrollerT) _enroll(ctx context.Context, zlog zerolog.Logger, req *Enro
 	return &resp, nil
 }
 
-// Remove the ghost artifacts from Elastic; the agent record and the accessApiKey.
-func (et *EnrollerT) wipeGhosts(ctx context.Context, zlog zerolog.Logger, resp *EnrollResponse) {
-	zlog = zlog.With().Str(LogAgentId, resp.Item.ID).Logger()
+func deleteAgent(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, agentID string) error {
+	zlog = zlog.With().Str(LogAgentId, agentID).Logger()
 
-	if err := et.bulker.Delete(ctx, dl.FleetAgents, resp.Item.ID); err != nil {
-		zlog.Error().Err(err).Msg("ghost agent record failed to delete")
-	} else {
-		zlog.Info().Msg("ghost agent record deleted")
+	if err := bulker.Delete(ctx, dl.FleetAgents, agentID); err != nil {
+		zlog.Error().Err(err).Msg("agent record failed to delete")
+		return err
 	}
-
-	invalidateApiKey(ctx, zlog, et.bulker, resp.Item.AccessApiKeyId)
+	zlog.Info().Msg("agent record deleted")
+	return nil
 }
 
 func invalidateApiKey(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, apikeyId string) error {

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -843,7 +843,7 @@ func (f *FleetServer) runSubsystems(ctx context.Context, cfg *config.Config, g *
 	at := NewArtifactT(&cfg.Inputs[0].Server, bulker, f.cache)
 	ack := NewAckT(&cfg.Inputs[0].Server, bulker, f.cache)
 
-	router := NewRouter(bulker, ct, et, at, ack, sm)
+	router := NewRouter(ctx, bulker, ct, et, at, ack, sm)
 
 	g.Go(loggedRunFunc(ctx, "Http server", func(ctx context.Context) error {
 		return runServer(ctx, router, &cfg.Inputs[0].Server)

--- a/cmd/fleet/router.go
+++ b/cmd/fleet/router.go
@@ -5,6 +5,7 @@
 package fleet
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
@@ -23,6 +24,7 @@ const (
 )
 
 type Router struct {
+	ctx    context.Context
 	bulker bulk.Bulk
 	ver    string
 	ct     *CheckinT
@@ -32,9 +34,10 @@ type Router struct {
 	sm     policy.SelfMonitor
 }
 
-func NewRouter(bulker bulk.Bulk, ct *CheckinT, et *EnrollerT, at *ArtifactT, ack *AckT, sm policy.SelfMonitor) *httprouter.Router {
+func NewRouter(ctx context.Context, bulker bulk.Bulk, ct *CheckinT, et *EnrollerT, at *ArtifactT, ack *AckT, sm policy.SelfMonitor) *httprouter.Router {
 
 	r := Router{
+		ctx:    ctx,
 		bulker: bulker,
 		ct:     ct,
 		et:     et,

--- a/cmd/fleet/server_test.go
+++ b/cmd/fleet/server_test.go
@@ -46,7 +46,7 @@ func TestRunServer(t *testing.T) {
 	et, err := NewEnrollerT(verCon, cfg, nil, c)
 	require.NoError(t, err)
 
-	router := NewRouter(bulker, ct, et, nil, nil, nil)
+	router := NewRouter(ctx, bulker, ct, et, nil, nil, nil)
 	errCh := make(chan error)
 
 	var wg sync.WaitGroup

--- a/internal/pkg/rollback/rollback.go
+++ b/internal/pkg/rollback/rollback.go
@@ -1,0 +1,50 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package rollback
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+)
+
+type RollbackFunc func(ctx context.Context) error
+
+type rollbackInfo struct {
+	name string
+	fn   RollbackFunc
+}
+
+type Rollback struct {
+	log zerolog.Logger
+	rbi []rollbackInfo
+}
+
+func New(log zerolog.Logger) *Rollback {
+	return &Rollback{
+		log: log,
+	}
+}
+
+func (r *Rollback) Register(name string, fn RollbackFunc) {
+	r.rbi = append(r.rbi, rollbackInfo{name, fn})
+}
+
+func (r *Rollback) Rollback(ctx context.Context) (err error) {
+	// Execute all rollback functions, log errors, return the first error
+	for _, rb := range r.rbi {
+		log := r.log.With().Str("name", rb.name).Logger()
+		log.Debug().Msg("rollback function called")
+		if rerr := rb.fn(ctx); rerr != nil {
+			log.Error().Err(rerr).Msg("rollback function failed")
+			if err == nil {
+				err = rerr
+			}
+		} else {
+			log.Debug().Msg("rollback function succeeded")
+		}
+	}
+	return
+}


### PR DESCRIPTION
## What is the problem this PR solves?

The cleanup code for enrollment errors is scattered in couple of places:
```
Router.handleEnroll->
	->EnrollerT.handleEnroll
		->EnrollerT.processRequest
			->EnrollerT._enroll
				->generateAccessApiKey + createFleetAgent(If Fail)->invalidateApiKey

	->writeResponse(If Fail) 
		-> wipeGhosts
			-> delete Agent document
			-> invalidateApiKey
```

This change consolidates the cleanup code through the rollback/cleanup wrapper. 

## How does this PR solve the problem?

Implemented a simple "rollback" wrapper that can have the "rollback/cleanup" cleanup functions added as needed. The ```Rollback``` is called on error which in turn calls the registered cleanup functions.

For example, the log when Fleet Server fails to create the agent record:
```
{"log.level":"error","service.name":"fleet-server","http.request.id":"01FMQW2DC9GXDDX3Z8S6YCTZ0M","mod":"enroll","fleet.enroll.apikey.id":"NxK5Jn0ByQ6Ip6IwWvny","error.message":"elastic fail 403:cluster_block_exception:index [.fleet-agents-7] blocked by: [FORBIDDEN/8/index write (api)];","@timestamp":"2021-11-17T21:15:31.625Z","message":"perform rollback on enrollment failure"}
{"log.level":"debug","service.name":"fleet-server","http.request.id":"01FMQW2DC9GXDDX3Z8S6YCTZ0M","mod":"enroll","name":"invalidate API key","@timestamp":"2021-11-17T21:15:31.625Z","message":"rollback function called"}
{"log.level":"info","service.name":"fleet-server","http.request.id":"01FMQW2DC9GXDDX3Z8S6YCTZ0M","mod":"enroll","fleet.enroll.apikey.id":"NxK5Jn0ByQ6Ip6IwWvny","fleet.apikey.id":"81fBL30BMo45IINiNv-r","dur":773.635427,"@timestamp":"2021-11-17T21:15:32.399Z","message":"invalidated apiKey"}
{"log.level":"debug","service.name":"fleet-server","http.request.id":"01FMQW2DC9GXDDX3Z8S6YCTZ0M","mod":"enroll","name":"invalidate API key","@timestamp":"2021-11-17T21:15:32.399Z","message":"rollback function succeeded"} 
```

So, now:
1. when the api key is created the ```api key invalidation``` function is registered with the Rollback
2. when the agent is created the ```delete agent``` function is registered with the Rollback
3. the deferred function in ```handleEnroll``` calls ```Rollback``` if there was an error during enrollment. the Rollback calls all the registered cleanup function in order to remove/invalidate the data that was created. 


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

