### PR TITLE
Improve expired actions cleanup, use _delete_by_query instead

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -776,7 +776,7 @@ func (f *FleetServer) runSubsystems(ctx context.Context, cfg *config.Config, g *
 
 	// Run schduler for periodic GC/cleanup
 	gcCfg := cfg.Inputs[0].Server.GC
-	sched, err := scheduler.New(gc.Schedules(bulker, gcCfg.ScheduleInterval, gcCfg.CleanupAfterExpiredInteval))
+	sched, err := scheduler.New(gc.Schedules(bulker, gcCfg.ScheduleInterval, gcCfg.CleanupAfterExpiredInterval))
 	if err != nil {
 		return fmt.Errorf("failed to create elasticsearch GC: %w", err)
 	}

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -776,7 +776,7 @@ func (f *FleetServer) runSubsystems(ctx context.Context, cfg *config.Config, g *
 
 	// Run schduler for periodic GC/cleanup
 	gcCfg := cfg.Inputs[0].Server.GC
-	sched, err := scheduler.New(gc.Schedules(bulker, gcCfg.ScheduleInterval, gcCfg.CleanupBeforeInteval))
+	sched, err := scheduler.New(gc.Schedules(bulker, gcCfg.ScheduleInterval, gcCfg.CleanupAfterExpiredInteval))
 	if err != nil {
 		return fmt.Errorf("failed to create elasticsearch GC: %w", err)
 	}

--- a/internal/pkg/config/gc.go
+++ b/internal/pkg/config/gc.go
@@ -14,11 +14,11 @@ const (
 // GC is the configuration for the Fleet Server data garbage collection.
 // Currently manages the expired actions cleanup
 type GC struct {
-	ScheduleInterval           time.Duration `config:"schedule_interval"`
-	CleanupAfterExpiredInteval string        `config:"cleanup_after_expired_interval"`
+	ScheduleInterval            time.Duration `config:"schedule_interval"`
+	CleanupAfterExpiredInterval string        `config:"cleanup_after_expired_interval"`
 }
 
 func (g *GC) InitDefaults() {
 	g.ScheduleInterval = defaultScheduleInterval
-	g.CleanupAfterExpiredInteval = defaultCleanupIntervalAfterExpired
+	g.CleanupAfterExpiredInterval = defaultCleanupIntervalAfterExpired
 }

--- a/internal/pkg/config/gc.go
+++ b/internal/pkg/config/gc.go
@@ -7,18 +7,18 @@ package config
 import "time"
 
 const (
-	defaultScheduleInterval      = time.Hour
-	defaultCleanupBeforeInterval = 30 * 24 * time.Hour // cleanup expired actions with expiration time older than 30 days from now
+	defaultScheduleInterval            = time.Hour
+	defaultCleanupIntervalAfterExpired = "30d" // cleanup expired actions with expiration time older than 30 days from now
 )
 
 // GC is the configuration for the Fleet Server data garbage collection.
 // Currently manages the expired actions cleanup
 type GC struct {
-	ScheduleInterval     time.Duration `config:"schedule_interval"`
-	CleanupBeforeInteval time.Duration `config:"cleanup_before_interval"`
+	ScheduleInterval           time.Duration `config:"schedule_interval"`
+	CleanupAfterExpiredInteval string        `config:"cleanup_after_expired_interval"`
 }
 
 func (g *GC) InitDefaults() {
 	g.ScheduleInterval = defaultScheduleInterval
-	g.CleanupBeforeInteval = defaultCleanupBeforeInterval
+	g.CleanupAfterExpiredInteval = defaultCleanupIntervalAfterExpired
 }

--- a/internal/pkg/es/result.go
+++ b/internal/pkg/es/result.go
@@ -6,6 +6,7 @@ package es
 
 import (
 	"encoding/json"
+
 	"github.com/elastic/fleet-server/v7/internal/pkg/model"
 )
 
@@ -124,6 +125,15 @@ type Response struct {
 	} `json:"_shards"`
 	Hits         HitsT                  `json:"hits"`
 	Aggregations map[string]Aggregation `json:"aggregations,omitempty"`
+
+	Error ErrorT `json:"error,omitempty"`
+}
+
+type DeleteByQueryResponse struct {
+	Status   int    `json:"status"`
+	Took     uint64 `json:"took"`
+	TimedOut bool   `json:"timed_out"`
+	Deleted  int64  `json:"deleted"`
 
 	Error ErrorT `json:"error,omitempty"`
 }

--- a/internal/pkg/gc/actions.go
+++ b/internal/pkg/gc/actions.go
@@ -6,144 +6,79 @@ package gc
 
 import (
 	"context"
-	"math/rand"
-	"net/http"
-	"time"
+	"strconv"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
-	"github.com/elastic/fleet-server/v7/internal/pkg/es"
 	"github.com/elastic/fleet-server/v7/internal/pkg/scheduler"
-	"github.com/elastic/fleet-server/v7/internal/pkg/wait"
-)
-
-const (
-	defaultMaxWaitInCleanupLoop         = 10 * time.Second // the wait in the cleanup loop between iteration is random
-	defaultActionsSelectSize            = 1000
-	defaultActionsCleanupBeforeInterval = 24 * 30 * time.Hour
 )
 
 type ActionsCleanupConfig struct {
-	maxWaitInCleanupLoop  time.Duration
-	actionsSelectSize     int
-	cleanupBeforeInterval time.Duration
+	cleanupIntervalAfterExpired string
 }
 
 type ActionsCleanupOpt func(c *ActionsCleanupConfig)
 
-func WithMaxWaitInCleanupLoop(maxWaitInCleanupLoop time.Duration) ActionsCleanupOpt {
+// isIntervalStringValid validated interval string according to the elasticsearch documentation
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#date-math
+func isIntervalStringValid(interval string) bool {
+	if len(interval) < 2 {
+		return false
+	}
+	if strings.HasPrefix(interval, "-") {
+		return false
+	}
+
+	num := interval[0 : len(interval)-1]
+	suffix := interval[len(num):]
+
+	switch suffix {
+	case "y", "M", "w", "d", "h", "H", "m", "s":
+		if _, err := strconv.Atoi(num); err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+func WithCleanupIntervalAfterExpired(cleanupIntervalAfterExpired string) ActionsCleanupOpt {
 	return func(c *ActionsCleanupConfig) {
-		c.maxWaitInCleanupLoop = maxWaitInCleanupLoop
+		// Use the interval if valid, otherwise keep the default
+		if isIntervalStringValid(cleanupIntervalAfterExpired) {
+			c.cleanupIntervalAfterExpired = cleanupIntervalAfterExpired
+		}
 	}
 }
 
-func WithActionSelectSize(actionsSelectSize int) ActionsCleanupOpt {
-	return func(c *ActionsCleanupConfig) {
-		c.actionsSelectSize = actionsSelectSize
-	}
-}
-
-func WithActionCleanupBeforeInterval(cleanupBeforeInterval time.Duration) ActionsCleanupOpt {
-	return func(c *ActionsCleanupConfig) {
-		c.cleanupBeforeInterval = cleanupBeforeInterval
-	}
-}
-
-func getActionsGCFunc(bulker bulk.Bulk, cleanupBeforeInterval time.Duration) scheduler.WorkFunc {
+func getActionsGCFunc(bulker bulk.Bulk, cleanupIntervalAfterExpired string) scheduler.WorkFunc {
 	return func(ctx context.Context) error {
 		return cleanupActions(ctx, dl.FleetActions, bulker,
-			WithActionCleanupBeforeInterval(cleanupBeforeInterval))
+			WithCleanupIntervalAfterExpired(cleanupIntervalAfterExpired))
 	}
 }
 
 func cleanupActions(ctx context.Context, index string, bulker bulk.Bulk, opts ...ActionsCleanupOpt) error {
-	log := log.With().Str("ctx", "fleet actions cleanup").Logger()
-
 	c := ActionsCleanupConfig{
-		cleanupBeforeInterval: defaultActionsCleanupBeforeInterval,
-		actionsSelectSize:     defaultActionsSelectSize,
-		maxWaitInCleanupLoop:  defaultMaxWaitInCleanupLoop,
+		cleanupIntervalAfterExpired: defaultCleanupIntervalAfterExpired,
 	}
 
 	for _, opt := range opts {
 		opt(&c)
 	}
 
-	// Cleanup expired actions where expired timetamp is older than current time minus cleanupBeforeInterval
-	// Example: cleanup up actions that expired more than two weeks ago
-	expiredBefore := time.Now().Add(-c.cleanupBeforeInterval)
+	log := log.With().Str("ctx", "fleet actions cleanup").Str("interval", "now-"+c.cleanupIntervalAfterExpired).Logger()
 
-	// Random generator for calculating random pause duration in the cleanup loop
-	r := rand.New(rand.NewSource(time.Now().Unix()))
+	log.Debug().Msg("delete expired actions")
 
-	var (
-		hits []es.HitT
-		err  error
-	)
-
-	for {
-		log.Debug().Str("expired_before", expiredBefore.UTC().Format(time.RFC3339)).Msgf("find actions that expired before given date/time")
-		hits, err = dl.FindExpiredActionsHitsForIndex(ctx, index, bulker, expiredBefore, c.actionsSelectSize)
-		if err != nil {
-			return err
-		}
-
-		if len(hits) == 0 {
-			log.Debug().Msg("no more expired actions found, done cleaning")
-			return nil
-		}
-
-		log.Debug().Int("count", len(hits)).Msg("delete expired actions")
-		if len(hits) > 0 {
-			ops := make([]bulk.MultiOp, len(hits))
-			for i := 0; i < len(hits); i++ {
-				ops[i] = bulk.MultiOp{Index: index, Id: hits[i].Id}
-			}
-
-			res, err := bulker.MDelete(ctx, ops)
-			if err != nil {
-				// The error is logged
-				log.Debug().Err(err).Msg("failed to delete actions")
-				if eserr, ok := err.(*es.ErrElastic); ok {
-					if eserr.Status == http.StatusNotFound {
-						err = nil
-					}
-				}
-				if err != nil {
-					return err
-				}
-			}
-			for i, r := range res {
-				if r.Error != nil {
-					err = es.TranslateError(r.Status, r.Error)
-					if err != nil {
-						log.Debug().Err(err).Str("action_id", hits[i].Id).Msg("failed to delete action")
-						if r.Status != http.StatusNotFound {
-							return err
-						}
-					}
-				}
-			}
-		}
-
-		// If number of records selected is less than max, can exit the cleanup loop
-		if len(hits) < c.actionsSelectSize {
-			return nil
-		}
-
-		// The full number of hits was returned
-		// Can potentially have more records
-		// Pause before doing another iteration
-		if c.maxWaitInCleanupLoop > 0 {
-			pauseDuration := time.Duration(r.Int63n(int64(c.maxWaitInCleanupLoop)))
-			log.Debug().Dur("pause_duration", pauseDuration).Msg("more actions could be avaiable, pause before the next cleanup cycle")
-			// Wait with context some random short interval to avoid tight loops
-			err = wait.WithContext(ctx, pauseDuration)
-			if err != nil {
-				return err
-			}
-		}
+	deleted, err := dl.DeleteExpiredForIndex(ctx, index, bulker, c.cleanupIntervalAfterExpired)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to delete actions")
+		return err
 	}
+	log.Debug().Int64("count", deleted).Msg("deleted expired actions")
+	return nil
 }

--- a/internal/pkg/gc/actions_integration_test.go
+++ b/internal/pkg/gc/actions_integration_test.go
@@ -50,8 +50,8 @@ func TestCleanupActions(t *testing.T) {
 
 func testCleanupActionsWithSelectSize(t *testing.T, skipIndexInitialization bool, selectSize int) {
 	const (
-		thirtyDays        = 24 * 30 * time.Hour
-		thirtyDaysAndHour = thirtyDays + time.Hour
+		thirtyDays        = "720h"
+		thirtyDaysAndHour = "721h"
 	)
 	var (
 		index                             string
@@ -72,7 +72,7 @@ func testCleanupActionsWithSelectSize(t *testing.T, skipIndexInitialization bool
 			ftesting.CreateActionsWithMaxAgentsCount(7),
 			ftesting.CreateActionsWithMinActionsCount(7),
 			ftesting.CreateActionsWithMaxActionsCount(15),
-			ftesting.CreateActionsWithTimestampOffset(-thirtyDaysAndHour),
+			ftesting.CreateActionsWithTimestampOffset(-((24*30)+1)*time.Hour),
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -99,9 +99,7 @@ func testCleanupActionsWithSelectSize(t *testing.T, skipIndexInitialization bool
 	}
 
 	err = cleanupActions(ctx, index, bulker,
-		WithActionCleanupBeforeInterval(thirtyDays),
-		WithActionSelectSize(selectSize), // smaller size test few loop passes
-		WithMaxWaitInCleanupLoop(0))
+		WithCleanupIntervalAfterExpired(thirtyDays))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +107,7 @@ func testCleanupActionsWithSelectSize(t *testing.T, skipIndexInitialization bool
 	time.Sleep(time.Second)
 
 	// Check that all expired actions where deleted
-	hits, err := dl.FindExpiredActionsHitsForIndex(ctx, index, bulker, time.Now().Add(-thirtyDays), 100)
+	hits, err := dl.FindExpiredActionsHitsForIndex(ctx, index, bulker, time.Now().Add(-24*30*time.Hour), 100)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pkg/gc/actions_test.go
+++ b/internal/pkg/gc/actions_test.go
@@ -1,0 +1,47 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !integration
+// +build !integration
+
+package gc
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestIsIntervalStringValid(t *testing.T) {
+	tests := []struct {
+		interval string
+		expected bool
+	}{
+		{"", false},
+		{"-3d", false},
+		{"- 3 d", false},
+		{" -5d", false},
+		{"2-3d", false},
+		{"now-5d", false},
+		{"-d", false},
+		{"1y", true},
+		{"2M", true},
+		{"4w", true},
+		{"3d", true},
+		{"7h", true},
+		{"5H", true},
+		{"6m", true},
+		{"8s", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.interval, func(t *testing.T) {
+			valid := isIntervalStringValid(tc.interval)
+			diff := cmp.Diff(tc.expected, valid)
+			if diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/internal/pkg/gc/schedules.go
+++ b/internal/pkg/gc/schedules.go
@@ -12,24 +12,24 @@ import (
 )
 
 const (
-	defaultScheduleInterval      = time.Hour
-	defaultCleanupBeforeInterval = 30 * 24 * time.Hour // cleanup with expiration older than 30 days from now
+	defaultScheduleInterval            = time.Hour
+	defaultCleanupIntervalAfterExpired = "30d" // cleanup with expiration older than 30 days from now
 )
 
 // Schedules returns the GC schedules
-func Schedules(bulker bulk.Bulk, scheduleInterval, cleanupBeforeInterval time.Duration) []scheduler.Schedule {
+func Schedules(bulker bulk.Bulk, scheduleInterval time.Duration, cleanupIntervalAfterExpired string) []scheduler.Schedule {
 	if scheduleInterval == 0 {
 		scheduleInterval = defaultScheduleInterval
 	}
-	if cleanupBeforeInterval == 0 {
-		cleanupBeforeInterval = defaultCleanupBeforeInterval
+	if cleanupIntervalAfterExpired == "" {
+		cleanupIntervalAfterExpired = defaultCleanupIntervalAfterExpired
 	}
 
 	return []scheduler.Schedule{
 		{
 			Name:     "fleet actions cleanup",
 			Interval: scheduleInterval,
-			WorkFn:   getActionsGCFunc(bulker, cleanupBeforeInterval),
+			WorkFn:   getActionsGCFunc(bulker, cleanupIntervalAfterExpired),
 		},
 	}
 }


### PR DESCRIPTION
## What is the problem this PR solves?

Improve expired actions cleanup, use _delete_by_query instead.
The original implementation was selecting action ids and deleted them by document id, although batched, it was suboptimal.

## How does this PR solve the problem?

Replaces current cleanup implementation with ```_delete_by_query``` 


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

