### PR TITLE
Mergify: replace merge action for the queue action

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,8 @@
+queue_rules:
+  - name: default
+    conditions:
+      - check-success=fleet-server/pr-merge
+
 pull_request_rules:
   - name: ask to resolve conflict
     conditions:
@@ -98,18 +103,18 @@ pull_request_rules:
       - label=backport
       - author=mergify[bot]
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart+fasttrack
+        name: default
   - name: automatic merge when CI passes and the file dev-tools/integration/.env is modified.
     conditions:
       - check-success=fleet-server/pr-merge
       - label=automation
       - files~=^dev-tools/integration/.env$
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart+fasttrack
+        name: default
   - name: delete upstream branch with changes on dev-tools/integration/.env or .go-version after merging/closing it
     conditions:
       - or:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -32,7 +32,7 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to 7.x branch
+  - name: backport patches to 7.16 branch
     conditions:
       - merged
       - base=master


### PR DESCRIPTION
### What

Migrate from the `merge action` to the `queue action`.

See https://docs.mergify.io/actions/queue/#queue-rules to know more about how the `queue` command works.

### Why

We use the merge action to automerge automated PRs, so we cannot use this approach from January 2022

```
The configuration uses the deprecated strict mode of the merge action.
A brownout is planned for the whole December 6th, 2021 day.
This option will be removed on January 10th, 2022.
For more information: https://blog.mergify.io/strict-mode-deprecation/
```
