### PR TITLE
instrumentation: Add "tls" configuration options

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -895,6 +895,26 @@ func (f *FleetServer) initTracer(cfg config.Instrumentation) (*apm.Tracer, error
 
 	log.Info().Msg("fleet-server instrumentation is enabled")
 
+	// TODO(marclop): Ideally, we'd use apmtransport.NewHTTPTransportOptions()
+	// but it doesn't exist today. Update this code once we have something
+	// available via the APM Go agent.
+	const (
+		envVerifyServerCert = "ELASTIC_APM_VERIFY_SERVER_CERT"
+		envServerCert       = "ELASTIC_APM_SERVER_CERT"
+		envCACert           = "ELASTIC_APM_SERVER_CA_CERT_FILE"
+	)
+	if cfg.TLS.SkipVerify {
+		os.Setenv(envVerifyServerCert, "false")
+		defer os.Unsetenv(envVerifyServerCert)
+	}
+	if cfg.TLS.ServerCertificate != "" {
+		os.Setenv(envServerCert, cfg.TLS.ServerCertificate)
+		defer os.Unsetenv(envServerCert)
+	}
+	if cfg.TLS.ServerCA != "" {
+		os.Setenv(envCACert, cfg.TLS.ServerCA)
+		defer os.Unsetenv(envCACert)
+	}
 	transport, err := apmtransport.NewHTTPTransport()
 	if err != nil {
 		return nil, err

--- a/internal/pkg/config/instrumentation.go
+++ b/internal/pkg/config/instrumentation.go
@@ -6,9 +6,16 @@ package config
 
 // Instrumentation configures APM Tracing for the `fleet-server`.
 type Instrumentation struct {
-	Environment string   `config:"environment"`
-	APIKey      string   `config:"api_key"`
-	SecretToken string   `config:"secret_token"`
-	Hosts       []string `config:"hosts"`
-	Enabled     bool     `config:"enabled"`
+	TLS         InstrumentationTLS `config:"tls"`
+	Environment string             `config:"environment"`
+	APIKey      string             `config:"api_key"`
+	SecretToken string             `config:"secret_token"`
+	Hosts       []string           `config:"hosts"`
+	Enabled     bool               `config:"enabled"`
+}
+
+type InstrumentationTLS struct {
+	SkipVerify        bool   `config:"skip_verify"`
+	ServerCertificate string `config:"server_certificate"`
+	ServerCA          string `config:"server_ca"`
 }


### PR DESCRIPTION
## What is the problem this PR solves?

Adds TLS configuration options for the APM instrumentation, using env
vars to configure the APM HTTP Tracer since it currently doesn't support
setting those values in Golang. We'll follow up on this once the apm
tracer has a function to create a new tracer with configurable settings
via config struct.

## How does this PR solve the problem?

Adds a TLS config struct and sets the relevant values as env vars for the APM tracer to configure itself.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~


## Related issues

Follow up from #898 