### PR TITLE
[8.0] Support multiple endpoints

### DIFF
--- a/cmd/fleet/server.go
+++ b/cmd/fleet/server.go
@@ -39,7 +39,7 @@ func diagConn(c net.Conn, s http.ConnState) {
 }
 
 func runServer(ctx context.Context, router http.Handler, cfg *config.Server) error {
-	addr := cfg.BindAddress()
+	listeners := cfg.BindEndpoints()
 	rdto := cfg.Timeouts.Read
 	wrto := cfg.Timeouts.Write
 	idle := cfg.Timeouts.Idle
@@ -47,75 +47,94 @@ func runServer(ctx context.Context, router http.Handler, cfg *config.Server) err
 	mhbz := cfg.Limits.MaxHeaderByteSize
 	bctx := func(net.Listener) context.Context { return ctx }
 
-	log.Info().
-		Str("bind", addr).
-		Dur("rdTimeout", rdto).
-		Dur("wrTimeout", wrto).
-		Msg("server listening")
+	errChan := make(chan error)
+	cancelCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-	server := http.Server{
-		Addr:              addr,
-		ReadTimeout:       rdto,
-		WriteTimeout:      wrto,
-		IdleTimeout:       idle,
-		ReadHeaderTimeout: rdhr,
-		Handler:           router,
-		BaseContext:       bctx,
-		ConnState:         diagConn,
-		MaxHeaderBytes:    mhbz,
-		ErrorLog:          errLogger(),
-	}
+	for _, addr := range listeners {
+		log.Info().
+			Str("bind", addr).
+			Dur("rdTimeout", rdto).
+			Dur("wrTimeout", wrto).
+			Msg("server listening")
 
-	forceCh := make(chan struct{})
-	defer close(forceCh)
-
-	// handler to close server
-	go func() {
-		select {
-		case <-ctx.Done():
-			log.Debug().Msg("force server close on ctx.Done()")
-			server.Close()
-		case <-forceCh:
-			log.Debug().Msg("go routine forced closed on exit")
+		server := http.Server{
+			Addr:              addr,
+			ReadTimeout:       rdto,
+			WriteTimeout:      wrto,
+			IdleTimeout:       idle,
+			ReadHeaderTimeout: rdhr,
+			Handler:           router,
+			BaseContext:       bctx,
+			ConnState:         diagConn,
+			MaxHeaderBytes:    mhbz,
+			ErrorLog:          errLogger(),
 		}
-	}()
 
-	var listenCfg net.ListenConfig
+		forceCh := make(chan struct{})
+		defer close(forceCh)
 
-	ln, err := listenCfg.Listen(ctx, "tcp", addr)
-	if err != nil {
-		return err
-	}
+		// handler to close server
+		go func() {
+			select {
+			case <-ctx.Done():
+				log.Debug().Msg("force server close on ctx.Done()")
+				server.Close()
+			case <-forceCh:
+				log.Debug().Msg("go routine forced closed on exit")
+			}
+		}()
 
-	// Bind the deferred Close() to the stack variable to handle case where 'ln' is wrapped
-	defer func() { ln.Close() }()
+		var listenCfg net.ListenConfig
 
-	// Conn Limiter must be before the TLS handshake in the stack;
-	// The server should not eat the cost of the handshake if there
-	// is no capacity to service the connection.
-	// Also, it appears the HTTP2 implementation depends on the tls.Listener
-	// being at the top of the stack.
-	ln = wrapConnLimitter(ctx, ln, cfg)
-
-	if cfg.TLS != nil && cfg.TLS.IsEnabled() {
-		commonTlsCfg, err := tlscommon.LoadTLSServerConfig(cfg.TLS)
+		ln, err := listenCfg.Listen(ctx, "tcp", addr)
 		if err != nil {
 			return err
 		}
-		server.TLSConfig = commonTlsCfg.ToConfig()
 
-		// Must enable http/2 in the configuration explicitly.
-		// (see https://golang.org/pkg/net/http/#Server.Serve)
-		server.TLSConfig.NextProtos = []string{"h2", "http/1.1"}
+		// Bind the deferred Close() to the stack variable to handle case where 'ln' is wrapped
+		defer func() { ln.Close() }()
 
-		ln = tls.NewListener(ln, server.TLSConfig)
+		// Conn Limiter must be before the TLS handshake in the stack;
+		// The server should not eat the cost of the handshake if there
+		// is no capacity to service the connection.
+		// Also, it appears the HTTP2 implementation depends on the tls.Listener
+		// being at the top of the stack.
+		ln = wrapConnLimitter(ctx, ln, cfg)
 
-	} else {
-		log.Warn().Msg("exposed over insecure HTTP; enablement of TLS is strongly recommended")
+		if cfg.TLS != nil && cfg.TLS.IsEnabled() {
+			commonTlsCfg, err := tlscommon.LoadTLSServerConfig(cfg.TLS)
+			if err != nil {
+				return err
+			}
+			server.TLSConfig = commonTlsCfg.ToConfig()
+
+			// Must enable http/2 in the configuration explicitly.
+			// (see https://golang.org/pkg/net/http/#Server.Serve)
+			server.TLSConfig.NextProtos = []string{"h2", "http/1.1"}
+
+			ln = tls.NewListener(ln, server.TLSConfig)
+
+		} else {
+			log.Warn().Msg("Exposed over insecure HTTP; enablement of TLS is strongly recommended")
+		}
+
+		log.Debug().Msgf("Listening on %s", addr)
+
+		go func(ctx context.Context, errChan chan error, ln net.Listener) {
+			if err := server.Serve(ln); err != nil && err != http.ErrServerClosed {
+				errChan <- err
+			}
+		}(cancelCtx, errChan, ln)
+
 	}
 
-	if err := server.Serve(ln); err != nil && err != http.ErrServerClosed {
-		return err
+	select {
+	case err := <-errChan:
+		if err != context.Canceled {
+			return err
+		}
+	case <-cancelCtx.Done():
 	}
 
 	return nil

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -103,8 +103,9 @@ func TestConfig(t *testing.T) {
 					{
 						Type: "fleet-server",
 						Server: Server{
-							Host: "localhost",
-							Port: 8888,
+							Host:         "localhost",
+							Port:         8888,
+							InternalPort: 8221,
 							Timeouts: ServerTimeouts{
 								Read:             20 * time.Second,
 								ReadHeader:       5 * time.Second,

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -15,6 +15,8 @@ import (
 
 const kDefaultHost = "0.0.0.0"
 const kDefaultPort = 8220
+const kDefaultInternalHost = "localhost"
+const kDefaultInternalPort = 8221
 
 // Policy is the configuration policy to use.
 type Policy struct {
@@ -57,6 +59,7 @@ func (c *ServerBulk) InitDefaults() {
 type Server struct {
 	Host              string                  `config:"host"`
 	Port              uint16                  `config:"port"`
+	InternalPort      uint16                  `config:"internal_port"`
 	TLS               *tlscommon.ServerConfig `config:"ssl"`
 	Timeouts          ServerTimeouts          `config:"timeouts"`
 	Profiler          ServerProfiler          `config:"profiler"`
@@ -73,6 +76,7 @@ type Server struct {
 func (c *Server) InitDefaults() {
 	c.Host = kDefaultHost
 	c.Port = kDefaultPort
+	c.InternalPort = kDefaultInternalPort
 	c.Timeouts.InitDefaults()
 	c.CompressionLevel = flate.BestSpeed
 	c.CompressionThresh = 1024
@@ -83,13 +87,38 @@ func (c *Server) InitDefaults() {
 	c.GC.InitDefaults()
 }
 
+// BindEndpoints returns the binding address for the all HTTP server listeners.
+func (c *Server) BindEndpoints() []string {
+	primaryAddress := c.BindAddress()
+	endpoints := make([]string, 0, 2)
+	endpoints = append(endpoints, primaryAddress)
+
+	if internalAddress := c.BindInternalAddress(); internalAddress != "" && internalAddress != ":0" && internalAddress != primaryAddress {
+		endpoints = append(endpoints, internalAddress)
+	}
+
+	return endpoints
+}
+
 // BindAddress returns the binding address for the HTTP server.
 func (c *Server) BindAddress() string {
-	host := c.Host
+	return bindAddress(c.Host, c.Port)
+}
+
+// BindInternalAddress returns the binding address for the internal HTTP server.
+func (c *Server) BindInternalAddress() string {
+	if c.InternalPort <= 0 {
+		return bindAddress(kDefaultInternalHost, kDefaultInternalPort)
+	}
+
+	return bindAddress(kDefaultInternalHost, c.InternalPort)
+}
+
+func bindAddress(host string, port uint16) string {
 	if strings.Count(host, ":") > 1 && strings.Count(host, "]") == 0 {
 		host = "[" + host + "]"
 	}
-	return fmt.Sprintf("%s:%d", host, c.Port)
+	return fmt.Sprintf("%s:%d", host, port)
 }
 
 // Input is the input defined by Agent to run Fleet Server.


### PR DESCRIPTION
## What is the problem this PR solves?

What this PR solves is a problem when agent got unenrolled on heavier load when agent managing fleet server cannot checkin to it's own server so it will fallback to unenroll.
Closes https://github.com/elastic/fleet-server/issues/741 

## How does this PR solve the problem?
Problem is solved by adding internal endpoint which is used for communication on local network (with agent handling fleet server)
It lets FS to spin up 2 set of handlers, one on public 8220 and one on port defined in config. 

## How to test this PR locally

This needs to be tested with work on `elastic-agent` Link: https://github.com/elastic/beats/pull/28993
- Start stack
- Install agent with FS in a policy
- Check ports
```
sh-3.2# lsof -i -P | grep LISTEN | grep fleet
fleet-ser  7056            root   19u  IPv4 0xba7881a9227099a5      0t0    TCP localhost:{random_port} (LISTEN)
fleet-ser  7056            root   21u  IPv6 0xba7881a91284721d      0t0    TCP *:8220 (LISTEN)
```

- run wireshark, set filter to random port, there should be some comm
- set filter to 8220 port, there should be no comm
- enroll new agent, from another VM
- there should be some comm on both ports


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

