### PR TITLE
[7.16] (backport #995) Deprecate username/password when connecting to es

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/status"
 	"github.com/elastic/fleet-server/v7/internal/pkg/ver"
 
+	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 	"github.com/hashicorp/go-version"
@@ -559,6 +560,7 @@ func redactOutputCfg(cfg *config.Config) config.Output {
 	redacted := cfg.Output
 
 	if redacted.Elasticsearch.Password != "" {
+		cfgwarn.Deprecate("8.0.0", "Basic authentication (username:password) is deprecated. Please use api_key.")
 		redacted.Elasticsearch.Password = kRedacted
 	}
 

--- a/internal/pkg/es/client.go
+++ b/internal/pkg/es/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/build"
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
 
+	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/rs/zerolog/log"
 )
@@ -22,6 +23,9 @@ type ConfigOption func(config elasticsearch.Config)
 
 func NewClient(ctx context.Context, cfg *config.Config, longPoll bool, opts ...ConfigOption) (*elasticsearch.Client, error) {
 	escfg, err := cfg.Output.Elasticsearch.ToESConfig(longPoll)
+	if escfg.Password != "" {
+		cfgwarn.Deprecate("8.0.0", "Basic authentication (username:password) is deprecated. Please use api_key.")
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Backport #995 to 7.16