### PR TITLE
mergify: close automated prs if they are obsoleted

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,7 +6,10 @@ queue_rules:
 pull_request_rules:
   - name: ask to resolve conflict
     conditions:
+      - -merged
+      - -closed
       - conflict
+      - -author=apmmachine
     actions:
         comment:
           message: |
@@ -18,6 +21,19 @@ pull_request_rules:
             git merge upstream/{{base}}
             git push upstream {{head}}
             ```
+  - name: close automated pull requests with bump updates if any conflict
+    conditions:
+      - -merged
+      - -closed
+      - conflict
+      - author=apmmachine
+      - label=automation
+    actions:
+      close:
+        message: |
+          This pull request has been automatically closed by Mergify.
+          There are some other up-to-date pull requests.
+
   - name: backport patches to 8.0 branch
     conditions:
       - merged


### PR DESCRIPTION
## What is the problem this PR solves?

PRs that were created by the automation then close them if they are obsoleted.

They are obsoleted if they have a conflict.

## Related issues

- Relates https://github.com/elastic/beats/pull/29455