### PR TITLE
chore: update year 2022

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Elastic Beats
-Copyright 2014-2021 Elasticsearch BV
+Copyright 2014-2022 Elasticsearch BV
 
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).


### PR DESCRIPTION
## What is the problem this PR solves?

Update Copyright year, otherwise the builds will fail since the linting verifies this