### PR TITLE
chore: update year 2022 (#1067)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Elastic Beats
-Copyright 2014-2021 Elasticsearch BV
+Copyright 2014-2022 Elasticsearch BV
 
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).


### PR DESCRIPTION
(cherry picked from commit 469ae42699984df7f1823c32c79aae854f4eafea)

We also need #1067 in 7.16 due to 7.16.3