### PR TITLE
Fix application name in API key

### DIFF
--- a/cmd/fleet/schema.go
+++ b/cmd/fleet/schema.go
@@ -23,7 +23,7 @@ const kFleetAccessRolesJSON = `
 	"fleet-apikey-access": {
 		"cluster": [],
 		"applications": [{
-			"application": ".fleet",
+			"application": "fleet",
 			"privileges": ["no-privileges"],
 			"resources": ["*"]
 		}]

--- a/internal/pkg/apikey/apikey_integration_test.go
+++ b/internal/pkg/apikey/apikey_integration_test.go
@@ -22,7 +22,7 @@ const testFleetRoles = `
 	"fleet-apikey-access": {
 		"cluster": [],
 		"applications": [{
-			"application": ".fleet",
+			"application": "fleet",
 			"privileges": ["no-privileges"],
 			"resources": ["*"]
 		}]


### PR DESCRIPTION
This PR fixes issue spotted in: https://github.com/elastic/elastic-package/pull/650

```
{"log.level":"info","ecs.version":"1.6.0","service.name":"fleet-server","http.request.id":"01FSMA8YRG2G2DDJESQ6ZCVW42","mod":"enroll","fleet.enroll.apikey.id":"wm2kaH4BMg40PYJ8YCOR","error.message":"fail CreateAPIKey: [400 Bad Request] {\"error\":{\"root_cause\":[{\"type\":\"action_request_validation_exception\",\"reason\":\"Validation Failed: 1: An application name prefix must match the pattern ^[a-z][A-Za-z0-9]*$ (found '.fleet');\"}],\"type\":\"action_request_validation_exception\",\"reason\":\"Validation Failed: 1: An application name prefix must match the pattern ^[a-z][A-Za-z0-9]*$ (found '.fleet');\"},\"status\":400}","http.response.status_code":400,"event.duration":306104815,"@timestamp":"2022-01-17T15:25:17.251Z","message":"fail enroll"}
{"log.level":"error","ecs.version":"1.6.0","service.name":"fleet-server","http.request.id":"01FSMA8YRG2G2DDJESQ6ZCVW42","mod":"enroll","fleet.enroll.apikey.id":"wm2kaH4BMg40PYJ8YCOR","error.message":"fail CreateAPIKey: [400 Bad Request] {\"error\":{\"root_cause\":[{\"type\":\"action_request_validation_exception\",\"reason\":\"Validation Failed: 1: An application name prefix must match the pattern ^[a-z][A-Za-z0-9]*$ (found '.fleet');\"}],\"type\":\"action_request_validation_exception\",\"reason\":\"Validation Failed: 1: An application name prefix must match the pattern ^[a-z][A-Za-z0-9]*$ (found '.fleet');\"},\"status\":400}","@timestamp":"2022-01-17T15:25:17.251Z","message":"perform rollback on enrollment failure"}
```