### PR TITLE
Remove `HTTP Done` from the log on every request.

### DIFF
--- a/internal/pkg/logger/http.go
+++ b/internal/pkg/logger/http.go
@@ -184,7 +184,7 @@ func httpDebug(r *http.Request, e *zerolog.Event) {
 	}
 }
 
-// HttpHandler returns an httprouter' Handle that wrap request with an ECS logger and
+// HttpHandler returns an httprouter.Handle that wraps the request with an ECS logger and
 // captures metrics for the current request.
 func HttpHandler(next httprouter.Handle) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {

--- a/internal/pkg/logger/http.go
+++ b/internal/pkg/logger/http.go
@@ -15,10 +15,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
 	"github.com/julienschmidt/httprouter"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
 )
 
 const (
@@ -183,9 +184,9 @@ func httpDebug(r *http.Request, e *zerolog.Event) {
 	}
 }
 
-// ECS HTTP log wrapper
+// HttpHandler returns an httprouter' Handle that wrap request with an ECS logger and
+// captures metrics for the current request.
 func HttpHandler(next httprouter.Handle) httprouter.Handle {
-
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		e := log.Info()
 
@@ -212,13 +213,15 @@ func HttpHandler(next httprouter.Handle) httprouter.Handle {
 
 		httpMeta(r, e)
 
-		// Data on response
-		e.Uint64(EcsHttpRequestBodyBytes, rdCounter.Count())
-		e.Uint64(EcsHttpResponseBodyBytes, wrCounter.Count())
-		e.Int(EcsHttpResponseCode, wrCounter.statusCode)
-		e.Int64(EcsEventDuration, time.Since(start).Nanoseconds())
+		// Only logs non 2xx errors unless we are debugging.
+		if log.Debug().Enabled() || (wrCounter.statusCode < 200 && wrCounter.statusCode >= 300) {
+			e.Uint64(EcsHttpRequestBodyBytes, rdCounter.Count())
+			e.Uint64(EcsHttpResponseBodyBytes, wrCounter.Count())
+			e.Int(EcsHttpResponseCode, wrCounter.statusCode)
+			e.Int64(EcsEventDuration, time.Since(start).Nanoseconds())
 
-		e.Msg("HTTP done")
+			e.Msgf("%d HTTP Request", wrCounter.statusCode)
+		}
 	}
 }
 


### PR DESCRIPTION
Instead of writing `HTTP Done` on every request successful or not we
will only log when request codes are non 2xx.

Closes #1083

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

Reduce the cognitive load of dealing with a "HTTP Done log" statement, they were recorded on every request.

## How does this PR solve the problem?

// Explain HOW you solved the problem in your code. It is possible that during PR reviews this changes and then this section should be updated.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->