### PR TITLE
Switch to the schema generator that was moved into elastic org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ clean: ## - Clean up build artifacts
 .PHONY: generate
 generate: ## - Generate schema models
 	@printf "${CMD_COLOR_ON} Installing module for go generate\n${CMD_COLOR_OFF}"
-	env GOBIN=${GOBIN} go install github.com/aleksmaus/generate/cmd/schema-generate@5672148f3c31d78bbd0124583bc20133f2e18f37
+	env GOBIN=${GOBIN} go install github.com/elastic/go-json-schema-generate/cmd/schema-generate@c47877ac4d0624482caa0f6201b61bd6dc6f5899
 	@printf "${CMD_COLOR_ON} Running go generate\n${CMD_COLOR_OFF}"
 	env PATH="${GOBIN}:${PATH}" go generate ./...
 


### PR DESCRIPTION
## What is the problem this PR solves?

Switches to generator that we customized for fleet server and that now has a new home @ github.com/elastic/go-json-schema-generate, previously it was at github.com/aleksmaus/generate

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

