### PR TITLE
Add @elastic/elastic-agent-control-plane to the CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
 # CI Specific
 /.ci/ @elastic/observablt-robots
 /Jenkinsfile @elastic/observablt-robots
+
+# Team responsable for Fleet Server
+/ @elastic/elastic-agent-control-plane


### PR DESCRIPTION
Add @elastic/elastic-agent-control-plane to the CODEOWNERS to get
notified on new pull request.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

Allow the Elastic Agent control plane team to get notified on new pull request.

