### PR TITLE
Add github action for automating QA labels

### DIFF
--- a/.github/workflows/qa-labels.yml
+++ b/.github/workflows/qa-labels.yml
@@ -1,0 +1,82 @@
+name: Add QA labels to Elastic Agent issues
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  fetch_issues_to_label:
+    runs-on: ubuntu-latest
+    # Only run on PRs that were merged for the Elastic Agent teams
+    if: |
+      github.event.pull_request.merged_at &&
+      (
+        contains(github.event.pull_request.labels.*.name, 'Team:Elastic-Agent') ||
+        contains(github.event.pull_request.labels.*.name, 'Team:Elastic-Agent-Data-Plane') ||
+        contains(github.event.pull_request.labels.*.name, 'Team:Elastic-Agent-Control-Plane')
+      )
+    outputs:
+      matrix: ${{ steps.issues_to_label.outputs.value }}
+      label_ids: ${{ steps.label_ids.outputs.value }}
+    steps:
+      - uses: octokit/graphql-action@v2.x
+        id: closing_issues
+        with:
+          query: |
+            query closingIssueNumbersQuery($prnumber: Int!) {
+              repository(owner: "elastic", name: "beats") {
+                pullRequest(number: $prnumber) {
+                  closingIssuesReferences(first: 10) {
+                    nodes {
+                      id
+                      labels(first: 20) {
+                        nodes {
+                          id
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          prnumber: ${{ github.event.number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: sergeysova/jq-action@v2
+        id: issues_to_label
+        with:
+          # Map to the issues' node id
+          cmd: echo $CLOSING_ISSUES | jq -c '.repository.pullRequest.closingIssuesReferences.nodes | map(.id)'
+          multiline: true
+        env:
+          CLOSING_ISSUES: ${{ steps.closing_issues.outputs.data }}
+      - uses: sergeysova/jq-action@v2
+        id: label_ids
+        with:
+          # Get list of version labels on pull request and map to label's node id, append 'QA:Ready For Testing' id ("LA_kwDOEpQvns7jl5M2")
+          cmd: echo $PR_LABELS | jq -c 'map(select(.name | test("v[0-9]+\\.[0-9]+\\.[0-9]+")) | .node_id) + ["LA_kwDOEpQvns7jl5M2"]'
+          multiline: true
+        env:
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels) }}
+
+  label_issues:
+    needs: fetch_issues_to_label
+    runs-on: ubuntu-latest
+    # For each issue closed by the PR run this job
+    strategy:
+      matrix:
+        issueNodeId: ${{ fromJSON(needs.fetch_issues_to_label.outputs.matrix) }}
+    name: Label issue ${{ matrix.issueNodeId }}
+    steps:
+      - uses: octokit/graphql-action@v2.x
+        id: add_labels_to_closed_issue
+        with:
+          query: |
+            mutation add_label($issueid:String!, $labelids:[String!]!) {
+              addLabelsToLabelable(input: {labelableId: $issueid, labelIds: $labelids}) {
+                clientMutationId
+              }
+            }
+          issueid: ${{ matrix.issueNodeId }}
+          labelids: ${{ needs.fetch_issues_to_label.outputs.label_ids }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This mirrors the automation we've added to the beats repo in https://github.com/elastic/beats/pull/30303:

Whenever a PR is merged with the Team:Elastic-Agent, Team:Elastic-Agent-Data-Plane, or Team:Elastic-Agent-Control-Plane labels and the PR closes an issue(s):
Copy the vX.X.X labels to the closed issue(s)
Add the QA:Ready for Testing label to the closed issue(s)