### PR TITLE
Populate action_input_type for the .fleet-actions-results

### DIFF
--- a/cmd/fleet/handleAck.go
+++ b/cmd/fleet/handleAck.go
@@ -190,6 +190,7 @@ func (ack *AckT) handleAckEvents(ctx context.Context, zlog zerolog.Logger, agent
 		acr := model.ActionResult{
 			ActionId:       ev.ActionId,
 			AgentId:        agent.Id,
+			InputType:      ev.InputType,
 			StartedAt:      ev.StartedAt,
 			CompletedAt:    ev.CompletedAt,
 			ActionData:     ev.ActionData,

--- a/cmd/fleet/handleAck.go
+++ b/cmd/fleet/handleAck.go
@@ -151,6 +151,20 @@ func (ack *AckT) processRequest(zlog zerolog.Logger, w http.ResponseWriter, r *h
 	return nil
 }
 
+func eventToActionResult(agentId string, ev Event) (acr model.ActionResult) {
+	return model.ActionResult{
+		ActionId:        ev.ActionId,
+		AgentId:         agentId,
+		ActionInputType: ev.ActionInputType,
+		StartedAt:       ev.StartedAt,
+		CompletedAt:     ev.CompletedAt,
+		ActionData:      ev.ActionData,
+		ActionResponse:  ev.ActionResponse,
+		Data:            ev.Data,
+		Error:           ev.Error,
+	}
+}
+
 func (ack *AckT) handleAckEvents(ctx context.Context, zlog zerolog.Logger, agent *model.Agent, events []Event) error {
 	var policyAcks []string
 	var unenroll bool
@@ -187,17 +201,8 @@ func (ack *AckT) handleAckEvents(ctx context.Context, zlog zerolog.Logger, agent
 			ack.cache.SetAction(action)
 		}
 
-		acr := model.ActionResult{
-			ActionId:       ev.ActionId,
-			AgentId:        agent.Id,
-			InputType:      ev.InputType,
-			StartedAt:      ev.StartedAt,
-			CompletedAt:    ev.CompletedAt,
-			ActionData:     ev.ActionData,
-			ActionResponse: ev.ActionResponse,
-			Data:           ev.Data,
-			Error:          ev.Error,
-		}
+		acr := eventToActionResult(agent.Id, ev)
+
 		if _, err := dl.CreateActionResult(ctx, ack.bulk, acr); err != nil {
 			return errors.Wrap(err, "create action result")
 		}

--- a/cmd/fleet/handleAck_test.go
+++ b/cmd/fleet/handleAck_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"encoding/json"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func BenchmarkMakeUpdatePolicyBody(b *testing.B) {
@@ -35,5 +37,51 @@ func TestMakeUpdatePolicyBody(t *testing.T) {
 
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestEventToActionResult(t *testing.T) {
+	agentId := "6e9b6655-8cfe-4eb6-9b2f-c10aefae7517"
+
+	tests := []struct {
+		name string
+		ev   Event
+	}{
+		{
+			name: "success",
+			ev: Event{
+				ActionId:        "1b12dcd8-bde0-4045-92dc-c4b27668d733",
+				ActionInputType: "osquery",
+				StartedAt:       "2022-02-23T18:26:08.506128Z",
+				CompletedAt:     "2022-02-23T18:26:08.507593Z",
+				ActionData:      []byte(`{"query": "select * from osquery_info"}`),
+				ActionResponse:  []byte(`{"osquery": {"count": 1}}`),
+			},
+		},
+		{
+			name: "error",
+			ev: Event{
+				ActionId:        "2b12dcd8-bde0-4045-92dc-c4b27668d733",
+				ActionInputType: "osquery",
+				StartedAt:       "2022-02-24T18:26:08.506128Z",
+				CompletedAt:     "2022-02-24T18:26:08.507593Z",
+				ActionData:      []byte(`{"query": "select * from osquery_info"}`),
+				Error:           "action undefined",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			acr := eventToActionResult(agentId, tc.ev)
+			assert.Equal(t, agentId, acr.AgentId)
+			assert.Equal(t, tc.ev.ActionId, acr.ActionId)
+			assert.Equal(t, tc.ev.ActionInputType, acr.ActionInputType)
+			assert.Equal(t, tc.ev.StartedAt, acr.StartedAt)
+			assert.Equal(t, tc.ev.CompletedAt, acr.CompletedAt)
+			assert.Equal(t, tc.ev.ActionData, acr.ActionData)
+			assert.Equal(t, tc.ev.ActionResponse, acr.ActionResponse)
+			assert.Equal(t, tc.ev.Error, acr.Error)
+		})
 	}
 }

--- a/cmd/fleet/schema.go
+++ b/cmd/fleet/schema.go
@@ -103,6 +103,7 @@ type ActionResp struct {
 
 type Event struct {
 	Type           string          `json:"type"`
+	InputType      string          `json:"input_type"`
 	SubType        string          `json:"subtype"`
 	AgentId        string          `json:"agent_id"`
 	ActionId       string          `json:"action_id"`

--- a/cmd/fleet/schema.go
+++ b/cmd/fleet/schema.go
@@ -102,22 +102,22 @@ type ActionResp struct {
 }
 
 type Event struct {
-	Type           string          `json:"type"`
-	InputType      string          `json:"input_type"`
-	SubType        string          `json:"subtype"`
-	AgentId        string          `json:"agent_id"`
-	ActionId       string          `json:"action_id"`
-	PolicyId       string          `json:"policy_id"`
-	StreamId       string          `json:"stream_id"`
-	Timestamp      string          `json:"timestamp"`
-	Message        string          `json:"message"`
-	Payload        json.RawMessage `json:"payload,omitempty"`
-	StartedAt      string          `json:"started_at"`
-	CompletedAt    string          `json:"completed_at"`
-	ActionData     json.RawMessage `json:"action_data,omitempty"`
-	ActionResponse json.RawMessage `json:"action_response,omitempty"`
-	Data           json.RawMessage `json:"data,omitempty"`
-	Error          string          `json:"error,omitempty"`
+	Type            string          `json:"type"`
+	SubType         string          `json:"subtype"`
+	AgentId         string          `json:"agent_id"`
+	ActionId        string          `json:"action_id"`
+	ActionInputType string          `json:"action_input_type"`
+	PolicyId        string          `json:"policy_id"`
+	StreamId        string          `json:"stream_id"`
+	Timestamp       string          `json:"timestamp"`
+	Message         string          `json:"message"`
+	Payload         json.RawMessage `json:"payload,omitempty"`
+	StartedAt       string          `json:"started_at"`
+	CompletedAt     string          `json:"completed_at"`
+	ActionData      json.RawMessage `json:"action_data,omitempty"`
+	ActionResponse  json.RawMessage `json:"action_response,omitempty"`
+	Data            json.RawMessage `json:"data,omitempty"`
+	Error           string          `json:"error,omitempty"`
 }
 
 type StatusResponseVersion struct {

--- a/internal/pkg/model/schema.go
+++ b/internal/pkg/model/schema.go
@@ -94,6 +94,9 @@ type ActionResult struct {
 	// The action error message.
 	Error string `json:"error,omitempty"`
 
+	// The input type of the original action.
+	InputType string `json:"input_type,omitempty"`
+
 	// Date/time the action was started
 	StartedAt string `json:"started_at,omitempty"`
 

--- a/internal/pkg/model/schema.go
+++ b/internal/pkg/model/schema.go
@@ -79,6 +79,9 @@ type ActionResult struct {
 	// The action id.
 	ActionId string `json:"action_id,omitempty"`
 
+	// The input type of the original action.
+	ActionInputType string `json:"action_input_type,omitempty"`
+
 	// The custom action response payload.
 	ActionResponse json.RawMessage `json:"action_response,omitempty"`
 
@@ -93,9 +96,6 @@ type ActionResult struct {
 
 	// The action error message.
 	Error string `json:"error,omitempty"`
-
-	// The input type of the original action.
-	InputType string `json:"input_type,omitempty"`
 
 	// Date/time the action was started
 	StartedAt string `json:"started_at,omitempty"`

--- a/model/schema.json
+++ b/model/schema.json
@@ -82,6 +82,10 @@
           "description": "The action id.",
           "type": "string"
         },
+        "input_type": {
+          "description": "The input type of the original action.",
+          "type": "string"
+        },
         "started_at": {
           "description": "Date/time the action was started",
           "type": "string",

--- a/model/schema.json
+++ b/model/schema.json
@@ -82,7 +82,7 @@
           "description": "The action id.",
           "type": "string"
         },
-        "input_type": {
+        "action_input_type": {
           "description": "The input type of the original action.",
           "type": "string"
         },


### PR DESCRIPTION
## What is the problem this PR solves?

Populates input_type for the .fleet-actions-results. This allows to use kibana transformations on .fleet-actions-results for specific integration without a need to correlate them to the original .fleet-actions (via the action_id)

## How does this PR solve the problem?

Copies ```input_type``` from the fleet action to the fleet action response document.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas

## Related PRs

- Requires https://github.com/elastic/beats/pull/30562

## Screenshot

<img width="605" alt="Screen Shot 2022-02-24 at 1 52 00 PM" src="https://user-images.githubusercontent.com/872351/155589421-a81f7ea4-2f48-4532-878b-a76a8c822935.png">

