### PR TITLE
Change ack response, to allow returning errors for individual events. This allows better handling for partial acks.

### DIFF
--- a/cmd/fleet/handleAck_test.go
+++ b/cmd/fleet/handleAck_test.go
@@ -2,13 +2,27 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !integration
+// +build !integration
+
 package fleet
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
 	"testing"
 
-	"encoding/json"
+	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
+	"github.com/elastic/fleet-server/v7/internal/pkg/cache"
+	"github.com/elastic/fleet-server/v7/internal/pkg/config"
+	"github.com/elastic/fleet-server/v7/internal/pkg/es"
+	"github.com/elastic/fleet-server/v7/internal/pkg/model"
+	ftesting "github.com/elastic/fleet-server/v7/internal/pkg/testing"
+	"github.com/gofrs/uuid"
 
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -82,6 +96,316 @@ func TestEventToActionResult(t *testing.T) {
 			assert.Equal(t, tc.ev.ActionData, acr.ActionData)
 			assert.Equal(t, tc.ev.ActionResponse, acr.ActionResponse)
 			assert.Equal(t, tc.ev.Error, acr.Error)
+		})
+	}
+}
+
+// Mock bulker
+type mockBulk struct {
+	ftesting.MockBulk
+	searchErr error
+	createErr error
+	updateErr error
+	actions   []model.Action
+}
+
+type searchRequestFilter struct {
+	Term struct {
+		ActionID string `json:"action_id"`
+	} `json:"term"`
+}
+
+type searchRequest struct {
+	Query struct {
+		Bool struct {
+			Filter []searchRequestFilter `json:"filter"`
+		} `json:"bool"`
+	} `json:"query"`
+}
+
+func (m mockBulk) Search(ctx context.Context, index string, body []byte, opts ...bulk.Opt) (*es.ResultT, error) {
+	if m.searchErr != nil {
+		return nil, m.searchErr
+	}
+
+	if m.actions != nil {
+		var req searchRequest
+		err := json.Unmarshal(body, &req)
+		if err != nil {
+			return nil, err
+		}
+
+		var (
+			action model.Action
+			ok     bool
+		)
+		for _, a := range m.actions {
+			if a.ActionId == req.Query.Bool.Filter[0].Term.ActionID {
+				action = a
+				ok = true
+			}
+		}
+		if ok {
+			return &es.ResultT{
+				HitsT: es.HitsT{
+					Hits: []es.HitT{
+						{
+							Source: []byte(`{"action_id":"` + action.ActionId + `","type":"` + action.Type + `"}`),
+						},
+					},
+				},
+			}, nil
+		}
+	}
+
+	return &es.ResultT{
+		HitsT: es.HitsT{
+			Hits: []es.HitT{},
+		},
+	}, nil
+}
+
+func (m mockBulk) Create(ctx context.Context, index, id string, body []byte, opts ...bulk.Opt) (string, error) {
+	if m.createErr != nil {
+		return "", m.createErr
+	}
+	i, err := uuid.NewV4()
+	if err != nil {
+		return "", err
+	}
+	return i.String(), nil
+}
+
+func (m mockBulk) Update(ctx context.Context, index, id string, body []byte, opts ...bulk.Opt) error {
+	return m.updateErr
+}
+
+func TestHandleAckEvents(t *testing.T) {
+	// minimal sufficient config for the test
+	cfg := &config.Server{
+		Limits: config.ServerLimits{},
+	}
+
+	// Default mock bulker
+	bulker := &mockBulk{}
+
+	agent := &model.Agent{
+		ESDocument: model.ESDocument{Id: "ab12dcd8-bde0-4045-92dc-c4b27668d735"},
+		Agent:      &model.AgentMetadata{Version: "8.0.0"},
+	}
+
+	ctx := context.Background()
+
+	newAckResponse := func(errors bool, items []AckResponseItem) AckResponse {
+		return AckResponse{
+			Action: "acks",
+			Errors: errors,
+			Items:  items,
+		}
+	}
+	newAckResponseItem := func(status int) AckResponseItem {
+		return AckResponseItem{
+			Status:  status,
+			Message: http.StatusText(status),
+		}
+	}
+
+	tests := []struct {
+		name   string
+		events []Event
+		res    AckResponse
+		bulker bulk.Bulk
+	}{
+		{
+			name: "nil",
+			res:  newAckResponse(false, []AckResponseItem{}),
+		},
+		{
+			name:   "empty",
+			events: []Event{},
+			res:    newAckResponse(false, []AckResponseItem{}),
+		},
+		{
+			name: "action agentID mismatch",
+			events: []Event{
+				{
+					ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
+					AgentId:  "ab12dcd8-bde0-4045-92dc-c4b27668d737",
+				},
+			},
+			res: newAckResponse(true, []AckResponseItem{newAckResponseItem(http.StatusBadRequest)}),
+		},
+		{
+			name: "action empty agent id",
+			events: []Event{
+				{
+					ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
+				},
+			},
+			res: newAckResponse(true, []AckResponseItem{newAckResponseItem(http.StatusNotFound)}),
+		},
+		{
+			name: "action find error",
+			events: []Event{
+				{
+					ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
+				},
+			},
+			res:    newAckResponse(true, []AckResponseItem{newAckResponseItem(http.StatusInternalServerError)}),
+			bulker: mockBulk{searchErr: errors.New("network error")},
+		},
+		{
+			name: "policy action",
+			events: []Event{
+				{
+					ActionId: "policy:2b12dcd8-bde0-4045-92dc-c4b27668d733",
+				},
+			},
+			res: newAckResponse(false, []AckResponseItem{{
+				Status:  http.StatusOK,
+				Message: http.StatusText(http.StatusOK),
+			}}),
+		},
+		{
+			name: "action found",
+			events: []Event{
+				{
+					ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
+				},
+			},
+			res: newAckResponse(false, []AckResponseItem{{
+				Status:  http.StatusOK,
+				Message: http.StatusText(http.StatusOK),
+			}}),
+			bulker: mockBulk{actions: []model.Action{
+				{ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733"},
+			}},
+		},
+		{
+			name: "action found, create result general error",
+			events: []Event{
+				{
+					ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
+				},
+			},
+			res: newAckResponse(true, []AckResponseItem{newAckResponseItem(http.StatusInternalServerError)}),
+			bulker: mockBulk{
+				actions: []model.Action{
+					{ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733"},
+				},
+				createErr: errors.New("network error"),
+			},
+		},
+		{
+			name: "action found, create result elasticsearch error",
+			events: []Event{
+				{
+					ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
+				},
+			},
+			res: newAckResponse(true, []AckResponseItem{newAckResponseItem(http.StatusServiceUnavailable)}),
+			bulker: mockBulk{
+				actions: []model.Action{
+					{ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733"},
+				},
+				createErr: &es.ErrElastic{Status: http.StatusServiceUnavailable, Reason: http.StatusText(http.StatusServiceUnavailable)},
+			},
+		},
+		{
+			name: "upgrade action found, update agent error",
+			events: []Event{
+				{
+					ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
+					Type:     "UPGRADE",
+				},
+			},
+			res: newAckResponse(true, []AckResponseItem{{
+				Status:  http.StatusServiceUnavailable,
+				Message: http.StatusText(http.StatusServiceUnavailable),
+			}}),
+			bulker: mockBulk{
+				actions: []model.Action{
+					{ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733", Type: "UPGRADE"},
+				},
+				updateErr: &es.ErrElastic{Status: http.StatusServiceUnavailable, Reason: http.StatusText(http.StatusServiceUnavailable)},
+			},
+		},
+		{
+			name: "mixed actions found",
+			events: []Event{
+				{
+					ActionId: "policy:2b12dcd8-bde0-4045-92dc-c4b27668d733:1:1",
+					Type:     "POLICY_CHANGE",
+				},
+				{
+					ActionId: "1b12dcd8-bde0-4045-92dc-c4b27668d731",
+					Type:     "UNENROLL",
+				},
+				{
+					ActionId: "1b12dcd8-bde0-4045-92dc-c4b27668d733",
+				},
+				{
+					ActionId: "ab12dcd8-bde0-4045-92dc-c4b27668d73a",
+					Type:     "UPGRADE",
+				},
+				{
+					ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
+				},
+				{
+					ActionId: "policy:2b12dcd8-bde0-4045-92dc-c4b27668d733:1:2",
+					Type:     "POLICY_CHANGE",
+				},
+			},
+			res: newAckResponse(true, []AckResponseItem{
+				{
+					Status:  http.StatusOK,
+					Message: http.StatusText(http.StatusOK),
+				},
+				{
+					Status:  http.StatusOK,
+					Message: http.StatusText(http.StatusOK),
+				},
+				{
+					Status:  http.StatusNotFound,
+					Message: http.StatusText(http.StatusNotFound),
+				},
+				{
+					Status:  http.StatusOK,
+					Message: http.StatusText(http.StatusOK),
+				},
+				{
+					Status:  http.StatusOK,
+					Message: http.StatusText(http.StatusOK),
+				},
+				{
+					Status:  http.StatusOK,
+					Message: http.StatusText(http.StatusOK),
+				},
+			}),
+			bulker: mockBulk{actions: []model.Action{
+				{ActionId: "policy:2b12dcd8-bde0-4045-92dc-c4b27668d733:1:1"},
+				{ActionId: "1b12dcd8-bde0-4045-92dc-c4b27668d731", Type: "UNENROLL"},
+				{ActionId: "ab12dcd8-bde0-4045-92dc-c4b27668d73a", Type: "UPGRADE"},
+				{ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733"},
+			}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cache, err := cache.New(cache.Config{NumCounters: 100, MaxCost: 100000})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			b := tc.bulker
+			if b == nil {
+				b = bulker
+			}
+			ack := NewAckT(cfg, b, cache)
+
+			res := ack.handleAckEvents(ctx, log.Logger, agent, tc.events)
+			assert.Equal(t, tc.res, res)
 		})
 	}
 }

--- a/cmd/fleet/handleChecking_test.go
+++ b/cmd/fleet/handleChecking_test.go
@@ -2,6 +2,9 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !integration
+// +build !integration
+
 package fleet
 
 import (

--- a/cmd/fleet/handleStatus_test.go
+++ b/cmd/fleet/handleStatus_test.go
@@ -2,6 +2,9 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !integration
+// +build !integration
+
 package fleet
 
 import (


### PR DESCRIPTION
## What is the problem this PR solves?

Presently when any of the items in the ack request fail the whole request fails and there is no way for the agent to detect which acks succeeded, which are  permanently failed (400) and which one can be retried (404, 503).

This potential issue was exposed as a part of SDH investigation: https://github.com/elastic/sdh-beats/issues/1770
In this particular case the issue was likely with the action document not being indexed on a secondary replica shard. 
Instead of being able to return "404"/"not found" error for specific action ack and retry it later, the whole request is currently fails with http status code of 400 and the agent retries to resend all acks the next time (potentially including those that succeeded previously already).

There are few issues with the acking processing on the agent side that need to be addressed after this change:
1. There is no logic to recognize the individual events failure and retry them.
2. The actions acks are not persisted, so if the agent is restarted the pending actions ack can get lost and will never retry.
3. One bad action ack that failed to process can "clog" the acking of any other actions, because the in-memory acks queue is not cleaned until the agent is rebooted.


## How does this PR solve the problem?

This PR extend the ack response with an array of individual item ack results, the format is consistent with the elasticsearch bulk response, where the ```errors``` boolean flag is set if any of the ack items failed.

```
type AckResponse struct {
	Action string            `json:"action"`
	Errors bool              `json:"errors,omitempty"` // indicates that some of the events in the ack request failed
	Items  []AckResponseItem `json:"items,omitempty"`
}
```

```
type AckResponseItem struct {
	Status  int    `json:"status"`
	Message string `json:"message,omitempty"`
}
```

Each individual ack item contains the code and the message, which is effectively http status codes and the http status code messages (we probably can omit the message fields. opinions?) 
Having the http code is convenient and consistent for the cases when we get the error code from elasticsearch operation so we can just propagate it back as is.


## Checklist


- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Relates https://github.com/elastic/sdh-beats/issues/1770
