### PR TITLE
ci: packaging pipeline for the snapshots

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -41,7 +41,7 @@ pipeline {
               currentBuild.result = 'NOT_BUILT'
               currentBuild.description = "The build has been skipped"
               currentBuild.displayName = "#${BUILD_NUMBER}-(Skipped)"
-              echo("the build has been skipped due the trigger is a branch scan and the allow ones are manual, GitHub comment, and upstream job")
+              echo("the build has been skipped due the trigger is a branch scan and the allowed ones are manual, GitHub comment, and upstream job")
             }
             return ret
           }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -116,7 +116,7 @@ pipeline {
                     googleStorageUpload(bucket: "gs://${JOB_GCS_BUCKET}/${URI_SUFFIX}",
                       credentialsId: "${JOB_GCS_CREDENTIALS}",
                       pathPrefix: "${BASE_DIR}/build/",
-                      pattern: "${BASE_DIR}/build/dependencies.csv",
+                      pattern: "${BASE_DIR}/build/reports/dependencies.csv",
                       sharedPublicly: true,
                       showInline: true)
                   }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -146,7 +146,7 @@ pipeline {
   }
   post {
     cleanup {
-      notifyBuildResult()
+      notifyBuildResult(prComment: false)
     }
     failure {
       echo 'disabled'

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -64,13 +64,19 @@ pipeline {
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             // set environment variables globally since they are used afterwards but GIT_BASE_COMMIT won't
             // be available until gitCheckout is executed.
-            setEnvVar('URI_SUFFIX', "commits/${env.GIT_BASE_COMMIT}")
+            // TODO: testing purposes
+            //setEnvVar('URI_SUFFIX', "commits/${env.GIT_BASE_COMMIT}")
+            setEnvVar('URI_SUFFIX', "commits/035118fc6bc83aa36098aa89f02d960b7d092a2e")
             // JOB_GCS_BUCKET contains the bucket and some folders, let's build the folder structure
             setEnvVar('PATH_PREFIX', "${JOB_GCS_BUCKET.contains('/') ? JOB_GCS_BUCKET.substring(JOB_GCS_BUCKET.indexOf('/') + 1) + '/' + env.URI_SUFFIX : env.URI_SUFFIX}")
           }
         }
         stage('Package') {
           options { skipDefaultCheckout() }
+          when {
+            beforeAgent true
+            expression { return false }
+          }
           matrix {
             agent {
               label "${PLATFORM}"

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -87,6 +87,7 @@ pipeline {
                 environment {
                   PLATFORMS = "${isArm() ? 'linux/arm64' : ''}"
                   PACKAGES = "${isArm() ? 'docker' : ''}"
+                  SNAPSHOT = 'true'
                 }
                 steps {
                   deleteDir()

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -78,7 +78,7 @@ pipeline {
             axes {
               axis {
                 name 'PLATFORM'
-                values 'ubuntu-20 && immutable', 'arm'
+                values 'ubuntu-20 && immutable && gobld/image:family/elastic-beats-ci-ubuntu-2004-lts-nocache', 'arm'
               }
             }
             stages {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -49,84 +49,90 @@ pipeline {
         PATH = "${env.PATH}:${env.WORKSPACE}/bin"
         HOME = "${env.WORKSPACE}"
       }
-      stage('Checkout') {
-        environment {
-          PATH = "${env.PATH}:${env.WORKSPACE}/bin"
-          HOME = "${env.WORKSPACE}"
-        }
-        options { skipDefaultCheckout() }
-        steps {
-          pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
-          deleteDir()
-          gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: false,
-                      shallow: false, reference: "/var/lib/jenkins/.git-references/${REPO}.git")
-          stash allowEmpty: true, name: 'source', useDefaultExcludes: false
-        }
-      }
-      stage('Package') {
-        // JOB_GCS_BUCKET contains the bucket and some folders, let's build the folder structure
-        environment {
-          URI_SUFFIX = "commits/${env.GIT_BASE_COMMIT}"
-          PATH_PREFIX = "${JOB_GCS_BUCKET.contains('/') ? JOB_GCS_BUCKET.substring(JOB_GCS_BUCKET.indexOf('/') + 1) + '/' + env.URI_SUFFIX : env.URI_SUFFIX}"
-          BUCKET_URI = """${isPR() ? "gs://${JOB_GCS_BUCKET}/pull-requests/pr-${env.CHANGE_ID}" : "gs://${JOB_GCS_BUCKET}/snapshots"}"""
-        }
-        options { skipDefaultCheckout() }
-        matrix {
-          agent {
-            label "${PLATFORM}"
+      stages {
+        stage('Checkout') {
+          environment {
+            PATH = "${env.PATH}:${env.WORKSPACE}/bin"
+            HOME = "${env.WORKSPACE}"
           }
-          axes {
-            axis {
-              name 'PLATFORM'
-              values 'linux && immutable', 'arm'
+          options { skipDefaultCheckout() }
+          steps {
+            pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
+            deleteDir()
+            gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: false,
+                        shallow: false, reference: "/var/lib/jenkins/.git-references/${REPO}.git")
+            stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+            // set environment variables globally since they are used afterwards but GIT_BASE_COMMIT won't
+            // be available until gitCheckout is executed.
+            setEnvVar('URI_SUFFIX', "commits/${env.GIT_BASE_COMMIT}")
+            // JOB_GCS_BUCKET contains the bucket and some folders, let's build the folder structure
+            setEnvVar('PATH_PREFIX', "${JOB_GCS_BUCKET.contains('/') ? JOB_GCS_BUCKET.substring(JOB_GCS_BUCKET.indexOf('/') + 1) + '/' + env.URI_SUFFIX : env.URI_SUFFIX}")
+          }
+        }
+        stage('Package') {
+          options { skipDefaultCheckout() }
+          matrix {
+            agent {
+              label "${PLATFORM}"
             }
-          }
-          stages {
-            stage('Package') {
-              environment {
-                PLATFORMS = "${isArm() ? 'linux/arm64' : ''}"
-                PACKAGES = "${isArm() ? 'docker' : ''}"
+            axes {
+              axis {
+                name 'PLATFORM'
+                values 'linux && immutable', 'arm'
               }
-              steps {
-                deleteDir()
-                unstash 'source'
-                dir("${BASE_DIR}"){
-                  withMageEnv() {
-                    sh(label: 'Make release-manager-snapshot', script: 'make release-manager-snapshot')
+            }
+            stages {
+              stage('Package') {
+                environment {
+                  PLATFORMS = "${isArm() ? 'linux/arm64' : ''}"
+                  PACKAGES = "${isArm() ? 'docker' : ''}"
+                }
+                steps {
+                  deleteDir()
+                  unstash 'source'
+                  dir("${BASE_DIR}"){
+                    withMageEnv() {
+											sh(label: 'make build/dependencies.csv', script: 'make build/dependencies.csv')
+                      sh(label: 'make release-manager-snapshot', script: 'make release-manager-snapshot')
+                    }
+                  }
+                }
+              }
+              stage('Publish') {
+                steps {
+                  // Copy those files to another location with the sha commit to test them afterward.
+                  googleStorageUpload(bucket: "gs://${JOB_GCS_BUCKET}/${URI_SUFFIX}",
+                    credentialsId: "${JOB_GCS_CREDENTIALS}",
+                    pathPrefix: "${BASE_DIR}/build/distributions/",
+                    pattern: "${BASE_DIR}/build/distributions/**/*",
+                    sharedPublicly: true,
+                    showInline: true)
+                  // Copy the dependencies files if no ARM
+                  whenFalse(isArm()) {
+                    googleStorageUpload(bucket: "gs://${JOB_GCS_BUCKET}/${URI_SUFFIX}",
+                      credentialsId: "${JOB_GCS_CREDENTIALS}",
+                      pathPrefix: "${BASE_DIR}/build/",
+                      pattern: "${BASE_DIR}/build/dependencies.csv",
+                      sharedPublicly: true,
+                      showInline: true)
                   }
                 }
               }
             }
-            stage('Publish') {
-              steps {
-                // Copy those files to another location with the sha commit to test them afterward.
-                googleStorageUpload(bucket: "gs://${JOB_GCS_BUCKET}/${URI_SUFFIX}",
-                  credentialsId: "${JOB_GCS_CREDENTIALS}",
-                  pathPrefix: "${BASE_DIR}/build/binaries/",
-                  pattern: "${BASE_DIR}/build/binaries/**/*",
-                  sharedPublicly: true,
-                  showInline: true)
-                googleStorageUpload(bucket: "gs://${JOB_GCS_BUCKET}/${URI_SUFFIX}",
-                  credentialsId: "${JOB_GCS_CREDENTIALS}",
-                  pathPrefix: "${BASE_DIR}/build/",
-                  pattern: "${BASE_DIR}/build/dependencies.csv",
-                  sharedPublicly: true,
-                  showInline: true)
-              }
-            }
           }
         }
-      }
-      stage('DRA') {
-        steps {
-          googleStorageDownload(bucketUri: "gs://${JOB_GCS_BUCKET}/${URI_SUFFIX}/*",
-                                credentialsId: "${JOB_GCS_CREDENTIALS}",
-                                localDirectory: "${BASE_DIR}/build/binaries",
-                                pathPrefix: env.PATH_PREFIX)
-          dir("${BASE_DIR}") {
-            script {
-              getVaultSecret.readSecretWrapper {
-                sh(label: 'release-manager.sh', script: '.ci/scripts/release-manager.sh')
+        stage('DRA') {
+          steps {
+            googleStorageDownload(bucketUri: "gs://${JOB_GCS_BUCKET}/${URI_SUFFIX}/*",
+                                  credentialsId: "${JOB_GCS_CREDENTIALS}",
+                                  localDirectory: "${BASE_DIR}/build/distributions",
+                                  pathPrefix: env.PATH_PREFIX)
+            dir("${BASE_DIR}") {
+              dockerLogin(secret: env.DOCKER_SECRET, registry: env.DOCKER_REGISTRY)
+              script {
+                getVaultSecret.readSecretWrapper {
+                  sh(label: 'release-manager.sh', script: '.ci/scripts/release-manager.sh')
+                }
               }
             }
           }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -68,7 +68,9 @@ pipeline {
             setEnvVar('URI_SUFFIX', "commits/${env.GIT_BASE_COMMIT}")
             // JOB_GCS_BUCKET contains the bucket and some folders, let's build the folder structure
             setEnvVar('PATH_PREFIX', "${JOB_GCS_BUCKET.contains('/') ? JOB_GCS_BUCKET.substring(JOB_GCS_BUCKET.indexOf('/') + 1) + '/' + env.URI_SUFFIX : env.URI_SUFFIX}")
-            setEnvVar('IS_BRANCH_AVAILABLE', isBranchUnifiedReleaseAvailable(env.BRANCH_NAME))
+            //TODO : uncomment
+            //setEnvVar('IS_BRANCH_AVAILABLE', isBranchUnifiedReleaseAvailable(env.BRANCH_NAME))
+            setEnvVar('IS_BRANCH_AVAILABLE', isBranchUnifiedReleaseAvailable('main'))
           }
         }
         stage('Package') {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -52,10 +52,6 @@ pipeline {
       }
       stages {
         stage('Checkout') {
-          environment {
-            PATH = "${env.PATH}:${env.WORKSPACE}/bin"
-            HOME = "${env.WORKSPACE}"
-          }
           options { skipDefaultCheckout() }
           steps {
             pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -80,7 +80,7 @@ pipeline {
             axes {
               axis {
                 name 'PLATFORM'
-                values 'ubuntu-20 && immutable && gobld/image:family/elastic-beats-ci-ubuntu-2004-lts-nocache', 'arm'
+                values 'ubuntu-20 && immutable', 'arm'
               }
             }
             stages {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -96,7 +96,7 @@ pipeline {
                   dir("${BASE_DIR}"){
                     withMageEnv() {
                       whenFalse(isArm()) {
-                        sh(label: 'make build/reports/dependencies.csv', script: 'make build/reports/dependencies.csv')
+                        sh(label: 'make build/distributions/dependencies.csv', script: 'make build/distributions/dependencies.csv')
                       }
                       sh(label: 'make release-manager-snapshot', script: 'make release-manager-snapshot')
                     }
@@ -112,10 +112,6 @@ pipeline {
                     pattern: "${BASE_DIR}/build/distributions/**/*",
                     sharedPublicly: true,
                     showInline: true)
-                  // Copy the dependencies files if no ARM
-                  whenFalse(isArm()) {
-                    stash(name: 'dependencies', includes: "${BASE_DIR}/build/reports/*")
-                  }
                 }
               }
             }
@@ -133,7 +129,6 @@ pipeline {
                                   credentialsId: "${JOB_GCS_CREDENTIALS}",
                                   localDirectory: "${BASE_DIR}/build/distributions",
                                   pathPrefix: env.PATH_PREFIX)
-            unstash 'dependencies'
             dir("${BASE_DIR}") {
               dockerLogin(secret: env.DOCKER_SECRET, registry: env.DOCKER_REGISTRY)
               script {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -68,6 +68,7 @@ pipeline {
             setEnvVar('URI_SUFFIX', "commits/${env.GIT_BASE_COMMIT}")
             // JOB_GCS_BUCKET contains the bucket and some folders, let's build the folder structure
             setEnvVar('PATH_PREFIX', "${JOB_GCS_BUCKET.contains('/') ? JOB_GCS_BUCKET.substring(JOB_GCS_BUCKET.indexOf('/') + 1) + '/' + env.URI_SUFFIX : env.URI_SUFFIX}")
+            setEnvVar('IS_BRANCH_AVAILABLE', isBranchUnifiedReleaseAvailable(env.BRANCH_NAME))
           }
         }
         stage('Package') {
@@ -121,6 +122,12 @@ pipeline {
           }
         }
         stage('DRA') {
+          // The Unified Release process keeps moving branches as soon as a new
+          // minor version is created, therefore old release branches won't be able
+          // to use the release manager as their definition is removed.
+          when {
+            expression { return env.IS_BRANCH_AVAILABLE == "true" }
+          }
           steps {
             googleStorageDownload(bucketUri: "gs://${JOB_GCS_BUCKET}/${URI_SUFFIX}/*",
                                   credentialsId: "${JOB_GCS_CREDENTIALS}",

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -28,7 +28,7 @@ pipeline {
   }
   stages {
     stage('Filter build') {
-      agent { label 'ubuntu-18 && immutable' }
+      agent { label 'ubuntu-20 && immutable' }
       when {
         beforeAgent true
         anyOf {
@@ -78,7 +78,7 @@ pipeline {
             axes {
               axis {
                 name 'PLATFORM'
-                values 'ubuntu-18 && immutable', 'arm'
+                values 'ubuntu-20 && immutable', 'arm'
               }
             }
             stages {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -97,9 +97,6 @@ pipeline {
                   unstash 'source'
                   dir("${BASE_DIR}"){
                     withMageEnv() {
-                      whenFalse(isArm()) {
-                        sh(label: 'make build/distributions/reports/dependencies.csv', script: 'make build/distributions/reports/dependencies.csv')
-                      }
                       sh(label: 'make release-manager-snapshot', script: 'make release-manager-snapshot')
                     }
                   }
@@ -132,6 +129,9 @@ pipeline {
                                   localDirectory: "${BASE_DIR}/build/distributions",
                                   pathPrefix: env.PATH_PREFIX)
             dir("${BASE_DIR}") {
+              withMageEnv() {
+                sh(label: 'create dependencies file', script: 'make release-manager-dependencies')
+              }
               dockerLogin(secret: env.DOCKER_SECRET, registry: env.DOCKER_REGISTRY)
               script {
                 getVaultSecret.readSecretWrapper {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -68,9 +68,7 @@ pipeline {
             setEnvVar('URI_SUFFIX', "commits/${env.GIT_BASE_COMMIT}")
             // JOB_GCS_BUCKET contains the bucket and some folders, let's build the folder structure
             setEnvVar('PATH_PREFIX', "${JOB_GCS_BUCKET.contains('/') ? JOB_GCS_BUCKET.substring(JOB_GCS_BUCKET.indexOf('/') + 1) + '/' + env.URI_SUFFIX : env.URI_SUFFIX}")
-            //TODO : uncomment
-            //setEnvVar('IS_BRANCH_AVAILABLE', isBranchUnifiedReleaseAvailable(env.BRANCH_NAME))
-            setEnvVar('IS_BRANCH_AVAILABLE', isBranchUnifiedReleaseAvailable('main'))
+            setEnvVar('IS_BRANCH_AVAILABLE', isBranchUnifiedReleaseAvailable(env.BRANCH_NAME))
           }
         }
         stage('Package') {
@@ -149,8 +147,7 @@ pipeline {
       notifyBuildResult(prComment: false)
     }
     failure {
-      echo 'disabled'
-    // notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}@${env.BRANCH_NAME}] DRA failed", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)")
+      notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}@${env.BRANCH_NAME}] DRA failed", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)")
     }
   }
 }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -66,19 +66,13 @@ pipeline {
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             // set environment variables globally since they are used afterwards but GIT_BASE_COMMIT won't
             // be available until gitCheckout is executed.
-            // TODO: testing purposes
-            //setEnvVar('URI_SUFFIX', "commits/${env.GIT_BASE_COMMIT}")
-            setEnvVar('URI_SUFFIX', "commits/035118fc6bc83aa36098aa89f02d960b7d092a2e")
+            setEnvVar('URI_SUFFIX', "commits/${env.GIT_BASE_COMMIT}")
             // JOB_GCS_BUCKET contains the bucket and some folders, let's build the folder structure
             setEnvVar('PATH_PREFIX', "${JOB_GCS_BUCKET.contains('/') ? JOB_GCS_BUCKET.substring(JOB_GCS_BUCKET.indexOf('/') + 1) + '/' + env.URI_SUFFIX : env.URI_SUFFIX}")
           }
         }
         stage('Package') {
           options { skipDefaultCheckout() }
-          when {
-            beforeAgent true
-            expression { return false }
-          }
           matrix {
             agent {
               label "${PLATFORM}"

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -1,0 +1,155 @@
+#!/usr/bin/env groovy
+@Library('apm@current') _
+
+pipeline {
+  agent none
+  environment {
+    REPO = 'fleet-server'
+    BASE_DIR = "src/github.com/elastic/${env.REPO}"
+    SLACK_CHANNEL = '#fleet-server'
+    NOTIFY_TO = 'package+fleet-server@elastic.co'
+    JOB_GCS_BUCKET = credentials('gcs-bucket')
+    JOB_GCS_CREDENTIALS = 'beats-ci-gcs-plugin'
+    SNAPSHOT = "true"
+  }
+  options {
+    timeout(time: 2, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '100', artifactNumToKeepStr: '30', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
+    quietPeriod(10)
+  }
+  triggers {
+    // disable upstream trigger on a PR basis
+    upstream("Ingest-manager/fleet-server/${ env.JOB_BASE_NAME.startsWith('PR-') ? 'none' : env.JOB_BASE_NAME }")
+  }
+  stages {
+    stage('Filter build') {
+      agent { label 'ubuntu-18 && immutable' }
+      when {
+        beforeAgent true
+        anyOf {
+          triggeredBy cause: "IssueCommentCause"
+          expression {
+            def ret = isUserTrigger() || isUpstreamTrigger()
+            if(!ret){
+              currentBuild.result = 'NOT_BUILT'
+              currentBuild.description = "The build has been skipped"
+              currentBuild.displayName = "#${BUILD_NUMBER}-(Skipped)"
+              echo("the build has been skipped due the trigger is a branch scan and the allow ones are manual, GitHub comment, and upstream job")
+            }
+            return ret
+          }
+        }
+      }
+      environment {
+        PATH = "${env.PATH}:${env.WORKSPACE}/bin"
+        HOME = "${env.WORKSPACE}"
+      }
+      stage('Checkout') {
+        environment {
+          PATH = "${env.PATH}:${env.WORKSPACE}/bin"
+          HOME = "${env.WORKSPACE}"
+        }
+        options { skipDefaultCheckout() }
+        steps {
+          pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
+          deleteDir()
+          gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: false,
+                      shallow: false, reference: "/var/lib/jenkins/.git-references/${REPO}.git")
+          stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+        }
+      }
+      stage('Package') {
+        // JOB_GCS_BUCKET contains the bucket and some folders, let's build the folder structure
+        environment {
+          URI_SUFFIX = "commits/${env.GIT_BASE_COMMIT}"
+          PATH_PREFIX = "${JOB_GCS_BUCKET.contains('/') ? JOB_GCS_BUCKET.substring(JOB_GCS_BUCKET.indexOf('/') + 1) + '/' + env.URI_SUFFIX : env.URI_SUFFIX}"
+          BUCKET_URI = """${isPR() ? "gs://${JOB_GCS_BUCKET}/pull-requests/pr-${env.CHANGE_ID}" : "gs://${JOB_GCS_BUCKET}/snapshots"}"""
+        }
+        options { skipDefaultCheckout() }
+        matrix {
+          agent {
+            label "${PLATFORM}"
+          }
+          axes {
+            axis {
+              name 'PLATFORM'
+              values 'linux && immutable', 'arm'
+            }
+          }
+          stages {
+            stage('Package') {
+              environment {
+                PLATFORMS = "${isArm() ? 'linux/arm64' : ''}"
+                PACKAGES = "${isArm() ? 'docker' : ''}"
+              }
+              steps {
+                deleteDir()
+                unstash 'source'
+                dir("${BASE_DIR}"){
+                  withMageEnv() {
+                    sh(label: 'Make release-manager-snapshot', script: 'make release-manager-snapshot')
+                  }
+                }
+              }
+            }
+            stage('Publish') {
+              steps {
+                // Copy those files to another location with the sha commit to test them afterward.
+                googleStorageUpload(bucket: "gs://${JOB_GCS_BUCKET}/${URI_SUFFIX}",
+                  credentialsId: "${JOB_GCS_CREDENTIALS}",
+                  pathPrefix: "${BASE_DIR}/build/binaries/",
+                  pattern: "${BASE_DIR}/build/binaries/**/*",
+                  sharedPublicly: true,
+                  showInline: true)
+                googleStorageUpload(bucket: "gs://${JOB_GCS_BUCKET}/${URI_SUFFIX}",
+                  credentialsId: "${JOB_GCS_CREDENTIALS}",
+                  pathPrefix: "${BASE_DIR}/build/",
+                  pattern: "${BASE_DIR}/build/dependencies.csv",
+                  sharedPublicly: true,
+                  showInline: true)
+              }
+            }
+          }
+        }
+      }
+      stage('DRA') {
+        steps {
+          googleStorageDownload(bucketUri: "gs://${JOB_GCS_BUCKET}/${URI_SUFFIX}/*",
+                                credentialsId: "${JOB_GCS_CREDENTIALS}",
+                                localDirectory: "${BASE_DIR}/build/binaries",
+                                pathPrefix: env.PATH_PREFIX)
+          dir("${BASE_DIR}") {
+            script {
+              getVaultSecret.readSecretWrapper {
+                sh(label: 'release-manager.sh', script: '.ci/scripts/release-manager.sh')
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult()
+    }
+    failure {
+      echo 'disabled'
+    // notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] DRA failed", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)")
+    }
+  }
+}
+
+def notifyStatus(def args = [:]) {
+  releaseNotification(slackChannel: "${env.SLACK_CHANNEL}",
+                      slackColor: args.slackStatus,
+                      slackCredentialsId: 'jenkins-slack-integration-token',
+                      to: "${env.NOTIFY_TO}",
+                      subject: args.subject,
+                      body: args.body)
+}

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -78,7 +78,7 @@ pipeline {
             axes {
               axis {
                 name 'PLATFORM'
-                values 'linux && immutable', 'arm'
+                values 'ubuntu-18 && immutable', 'arm'
               }
             }
             stages {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -11,6 +11,8 @@ pipeline {
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     JOB_GCS_CREDENTIALS = 'beats-ci-gcs-plugin'
     SNAPSHOT = "true"
+    DOCKER_SECRET = 'secret/observability-team/ci/docker-registry/prod'
+    DOCKER_REGISTRY = 'docker.elastic.co'
   }
   options {
     timeout(time: 2, unit: 'HOURS')

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -132,6 +132,9 @@ pipeline {
                                   localDirectory: "${BASE_DIR}/build/distributions",
                                   pathPrefix: env.PATH_PREFIX)
             dir("${BASE_DIR}") {
+              dir("build/distributions") {
+                sh(label: 'copy dependencies', script: 'cp -rf reports ../')
+              }
               dockerLogin(secret: env.DOCKER_SECRET, registry: env.DOCKER_REGISTRY)
               script {
                 getVaultSecret.readSecretWrapper {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -113,12 +113,7 @@ pipeline {
                     showInline: true)
                   // Copy the dependencies files if no ARM
                   whenFalse(isArm()) {
-                    googleStorageUpload(bucket: "gs://${JOB_GCS_BUCKET}/${URI_SUFFIX}",
-                      credentialsId: "${JOB_GCS_CREDENTIALS}",
-                      pathPrefix: "${BASE_DIR}/build/",
-                      pattern: "${BASE_DIR}/build/reports/dependencies*.csv",
-                      sharedPublicly: true,
-                      showInline: true)
+                    stash(name: 'dependencies', includes: "${BASE_DIR}/build/reports/dependencies*.csv")
                   }
                 }
               }
@@ -131,10 +126,8 @@ pipeline {
                                   credentialsId: "${JOB_GCS_CREDENTIALS}",
                                   localDirectory: "${BASE_DIR}/build/distributions",
                                   pathPrefix: env.PATH_PREFIX)
+            unstash 'dependencies'
             dir("${BASE_DIR}") {
-              dir("build/distributions") {
-                sh(label: 'copy dependencies', script: 'cp -rf reports ../')
-              }
               dockerLogin(secret: env.DOCKER_SECRET, registry: env.DOCKER_REGISTRY)
               script {
                 getVaultSecret.readSecretWrapper {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -7,7 +7,7 @@ pipeline {
     REPO = 'fleet-server'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
     SLACK_CHANNEL = '#fleet-server'
-    NOTIFY_TO = 'package+fleet-server@elastic.co'
+    NOTIFY_TO = 'fleet-server+build-package@elastic.co'
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     JOB_GCS_CREDENTIALS = 'beats-ci-gcs-plugin'
     DOCKER_SECRET = 'secret/observability-team/ci/docker-registry/prod'

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -146,7 +146,7 @@ pipeline {
     }
     failure {
       echo 'disabled'
-    // notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] DRA failed", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)")
+    // notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}@${env.BRANCH_NAME}] DRA failed", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)")
     }
   }
 }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -10,7 +10,6 @@ pipeline {
     NOTIFY_TO = 'package+fleet-server@elastic.co'
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     JOB_GCS_CREDENTIALS = 'beats-ci-gcs-plugin'
-    SNAPSHOT = "true"
     DOCKER_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
   }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -113,7 +113,7 @@ pipeline {
                     showInline: true)
                   // Copy the dependencies files if no ARM
                   whenFalse(isArm()) {
-                    stash(name: 'dependencies', includes: "${BASE_DIR}/build/reports/dependencies*.csv")
+                    stash(name: 'dependencies', includes: "${BASE_DIR}/build/reports/*")
                   }
                 }
               }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -116,7 +116,7 @@ pipeline {
                     googleStorageUpload(bucket: "gs://${JOB_GCS_BUCKET}/${URI_SUFFIX}",
                       credentialsId: "${JOB_GCS_CREDENTIALS}",
                       pathPrefix: "${BASE_DIR}/build/",
-                      pattern: "${BASE_DIR}/build/reports/dependencies.csv",
+                      pattern: "${BASE_DIR}/build/reports/dependencies*.csv",
                       sharedPublicly: true,
                       showInline: true)
                   }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -130,7 +130,7 @@ pipeline {
                                   pathPrefix: env.PATH_PREFIX)
             dir("${BASE_DIR}") {
               withMageEnv() {
-                sh(label: 'create dependencies file', script: 'make release-manager-dependencies')
+                sh(label: 'create dependencies file', script: 'make release-manager-dependencies-snapshot')
               }
               dockerLogin(secret: env.DOCKER_SECRET, registry: env.DOCKER_REGISTRY)
               script {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -95,7 +95,7 @@ pipeline {
                   dir("${BASE_DIR}"){
                     withMageEnv() {
                       whenFalse(isArm()) {
-                        sh(label: 'make build/dependencies.csv', script: 'make build/dependencies.csv')
+                        sh(label: 'make build/reports/dependencies.csv', script: 'make build/reports/dependencies.csv')
                       }
                       sh(label: 'make release-manager-snapshot', script: 'make release-manager-snapshot')
                     }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -92,7 +92,9 @@ pipeline {
                   unstash 'source'
                   dir("${BASE_DIR}"){
                     withMageEnv() {
-											sh(label: 'make build/dependencies.csv', script: 'make build/dependencies.csv')
+                      whenFalse(isArm()) {
+                        sh(label: 'make build/dependencies.csv', script: 'make build/dependencies.csv')
+                      }
                       sh(label: 'make release-manager-snapshot', script: 'make release-manager-snapshot')
                     }
                   }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -98,7 +98,7 @@ pipeline {
                   dir("${BASE_DIR}"){
                     withMageEnv() {
                       whenFalse(isArm()) {
-                        sh(label: 'make build/distributions/dependencies.csv', script: 'make build/distributions/dependencies.csv')
+                        sh(label: 'make build/distributions/reports/dependencies.csv', script: 'make build/distributions/reports/dependencies.csv')
                       }
                       sh(label: 'make release-manager-snapshot', script: 'make release-manager-snapshot')
                     }

--- a/.ci/scripts/release-manager.sh
+++ b/.ci/scripts/release-manager.sh
@@ -33,7 +33,7 @@ docker run --rm \
   "$IMAGE" \
     cli collect \
       --project fleet-server \
-      --branch "main" \
+      --branch "$BRANCH_NAME" \
       --commit "$(git rev-parse HEAD)" \
       --workflow "snapshot" \
       --artifact-set main \

--- a/.ci/scripts/release-manager.sh
+++ b/.ci/scripts/release-manager.sh
@@ -27,7 +27,7 @@ docker run --rm \
   "$IMAGE" \
     cli collect \
       --project fleet-server \
-      --branch "$BRANCH_NAME" \
+      --branch "main" \
       --commit "$(git rev-parse HEAD)" \
       --workflow "snapshot" \
       --artifact-set main

--- a/.ci/scripts/release-manager.sh
+++ b/.ci/scripts/release-manager.sh
@@ -15,6 +15,9 @@ source /usr/local/bin/bash_standard_lib.sh
 chmod -R a+r build/*
 chmod -R a+w build
 
+# get the current version (without the snapshot)
+VERSION=$(make get-version)
+
 # ensure the latest image has been pulled
 IMAGE=docker.elastic.co/infra/release-manager:latest
 (retry 3 docker pull --quiet "${IMAGE}") || echo "Error pulling ${IMAGE} Docker image, we continue"
@@ -33,4 +36,5 @@ docker run --rm \
       --branch "main" \
       --commit "$(git rev-parse HEAD)" \
       --workflow "snapshot" \
-      --artifact-set main
+      --artifact-set main \
+      --version "${VERSION}"

--- a/.ci/scripts/release-manager.sh
+++ b/.ci/scripts/release-manager.sh
@@ -12,8 +12,8 @@ set -uexo pipefail
 source /usr/local/bin/bash_standard_lib.sh
 
 # set required permissions on artifacts and directory
-chmod -R a+r build/*
-chmod -R a+w build
+chmod -R a+r build/distributions/*
+chmod -R a+w build/distributions
 
 # get the current version (without the snapshot)
 VERSION=$(make get-version)

--- a/.ci/scripts/release-manager.sh
+++ b/.ci/scripts/release-manager.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# This script is executed by the release snapshot stage.
+# It requires the below environment variables:
+# - BRANCH_NAME
+# - VAULT_ADDR
+# - VAULT_ROLE_ID
+# - VAULT_SECRET_ID
+#
+set -uexo pipefail
+
+# set required permissions on artifacts and directory
+chmod -R a+r build/distributions/*
+chmod -R a+w build/distributions
+
+# ensure the latest image has been pulled
+IMAGE=docker.elastic.co/infra/release-manager:latest
+docker pull --quiet $IMAGE
+
+# Generate checksum files and upload to GCS
+docker run --rm \
+  --name release-manager \
+  -e VAULT_ADDR \
+  -e VAULT_ROLE_ID \
+  -e VAULT_SECRET_ID \
+  --mount type=bind,readonly=false,src="$PWD",target=/artifacts \
+  "$IMAGE" \
+    cli collect \
+      --project fleet-server \
+      --branch "$BRANCH_NAME" \
+      --commit "$(git rev-parse HEAD)" \
+      --workflow "snapshot" \
+      --artifact-set main

--- a/.ci/scripts/release-manager.sh
+++ b/.ci/scripts/release-manager.sh
@@ -10,8 +10,8 @@
 set -uexo pipefail
 
 # set required permissions on artifacts and directory
-chmod -R a+r build/binaries/*
-chmod -R a+w build/binaries
+chmod -R a+r build/distributions/*
+chmod -R a+w build/distributions
 
 # ensure the latest image has been pulled
 IMAGE=docker.elastic.co/infra/release-manager:latest

--- a/.ci/scripts/release-manager.sh
+++ b/.ci/scripts/release-manager.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# This script is executed by the release snapshot stage.
+# This script is executed by the daily release artifact stage.
 # It requires the below environment variables:
 # - BRANCH_NAME
 # - VAULT_ADDR
@@ -9,13 +9,16 @@
 #
 set -uexo pipefail
 
+source /usr/local/bin/bash_standard_lib.sh
+
 # set required permissions on artifacts and directory
 chmod -R a+r build/distributions/*
 chmod -R a+w build/distributions
 
 # ensure the latest image has been pulled
 IMAGE=docker.elastic.co/infra/release-manager:latest
-docker pull --quiet $IMAGE
+(retry 3 docker pull --quiet "${IMAGE}") || echo "Error pulling ${IMAGE} Docker image, we continue"
+docker images --filter=reference=$IMAGE
 
 # Generate checksum files and upload to GCS
 docker run --rm \

--- a/.ci/scripts/release-manager.sh
+++ b/.ci/scripts/release-manager.sh
@@ -12,8 +12,8 @@ set -uexo pipefail
 source /usr/local/bin/bash_standard_lib.sh
 
 # set required permissions on artifacts and directory
-chmod -R a+r build/distributions/*
-chmod -R a+w build/distributions
+chmod -R a+r build/*
+chmod -R a+w build
 
 # ensure the latest image has been pulled
 IMAGE=docker.elastic.co/infra/release-manager:latest

--- a/.ci/scripts/release-manager.sh
+++ b/.ci/scripts/release-manager.sh
@@ -10,8 +10,8 @@
 set -uexo pipefail
 
 # set required permissions on artifacts and directory
-chmod -R a+r build/distributions/*
-chmod -R a+w build/distributions
+chmod -R a+r build/binaries/*
+chmod -R a+w build/binaries
 
 # ensure the latest image has been pulled
 IMAGE=docker.elastic.co/infra/release-manager:latest

--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,11 @@ release-manager-snapshot: ## - Builds a snapshot release. The Go version defined
 release-manager-release: ## - Builds a snapshot release. The Go version defined in .go-version will be installed and used for the build.
 	./dev-tools/run_with_go_ver $(MAKE) release
 
+## get-version : Get the Fleet server version
+.PHONY: get-version
+get-version:
+	@echo $(DEFAULT_VERSION)
+
 ##################################################
 # Integration testing targets
 ##################################################

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,14 @@ release-manager-dependencies: ## - Prepares the dependencies file.
 	./dev-tools/run_with_go_ver dev-tools/dependencies-report --csv build/distributions/reports/dependencies-$(VERSION).csv
 	@cd build/distributions/reports && shasum -a 512 dependencies-$(VERSION).csv > dependencies-$(VERSION).csv.sha512
 
+.PHONY: release-manager-dependencies-snapshot
+release-manager-dependencies-snapshot: ## - Prepares the dependencies file for a snapshot.
+	@$(MAKE) SNAPSHOT=true release-manager-dependencies
+
+.PHONY: release-manager-dependencies-release
+release-manager-dependencies-release: ## - Prepares the dependencies file for a release.
+	@$(MAKE) release-manager-dependencies
+
 .PHONY: release-manager-snapshot
 release-manager-snapshot: ## - Builds a snapshot release. The Go version defined in .go-version will be installed and used for the build.
 	@$(MAKE) SNAPSHOT=true release-manager-release

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ docker-release: build-releaser ## - Builds a release for all platforms in a dock
 .PHONY: release
 release: $(PLATFORM_TARGETS) ## - Builds a release. Specify exact platform with PLATFORMS env.
 
-build/dependencies.csv:
+build/dependencies.csv: build/distributions
 	./dev-tools/run_with_go_ver dev-tools/dependencies-report --csv $@
 
 .PHONY: release-manager-snapshot

--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,9 @@ docker-release: build-releaser ## - Builds a release for all platforms in a dock
 .PHONY: release
 release: $(PLATFORM_TARGETS) ## - Builds a release. Specify exact platform with PLATFORMS env.
 
+build/dependencies.csv:
+	./dev-tools/run_with_go_ver dev-tools/dependencies-report --csv $@
+
 .PHONY: release-manager-snapshot
 release-manager-snapshot: ## - Builds a snapshot release. The Go version defined in .go-version will be installed and used for the build.
 	@$(MAKE) SNAPSHOT=true release-manager-release

--- a/Makefile
+++ b/Makefile
@@ -166,8 +166,9 @@ docker-release: build-releaser ## - Builds a release for all platforms in a dock
 .PHONY: release
 release: $(PLATFORM_TARGETS) ## - Builds a release. Specify exact platform with PLATFORMS env.
 
-build/dependencies.csv: build/distributions
-	./dev-tools/run_with_go_ver dev-tools/dependencies-report --csv $@
+build/reports/dependencies.csv: ## - Prepares the dependencies file.
+	@mkdir -p build/reports
+	./dev-tools/run_with_go_ver dev-tools/dependencies-report --csv build/reports/dependencies-$(DEFAULT_VERSION).csv
 
 .PHONY: release-manager-snapshot
 release-manager-snapshot: ## - Builds a snapshot release. The Go version defined in .go-version will be installed and used for the build.

--- a/Makefile
+++ b/Makefile
@@ -166,10 +166,10 @@ docker-release: build-releaser ## - Builds a release for all platforms in a dock
 .PHONY: release
 release: $(PLATFORM_TARGETS) ## - Builds a release. Specify exact platform with PLATFORMS env.
 
-build/distributions/dependencies.csv: ## - Prepares the dependencies file.
-	@mkdir -p build/distributions
-	./dev-tools/run_with_go_ver dev-tools/dependencies-report --csv build/distributions/dependencies-$(VERSION).csv
-	@cd build/distributions && shasum -a 512 dependencies-$(VERSION).csv > dependencies-$(VERSION).csv.sha512
+build/distributions/reports/dependencies.csv: ## - Prepares the dependencies file.
+	@mkdir -p build/distributions/reports
+	./dev-tools/run_with_go_ver dev-tools/dependencies-report --csv build/distributions/reports/dependencies-$(VERSION).csv
+	@cd build/distributions/reports && shasum -a 512 dependencies-$(VERSION).csv > dependencies-$(VERSION).csv.sha512
 
 .PHONY: release-manager-snapshot
 release-manager-snapshot: ## - Builds a snapshot release. The Go version defined in .go-version will be installed and used for the build.

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ release: $(PLATFORM_TARGETS) ## - Builds a release. Specify exact platform with 
 
 build/reports/dependencies.csv: ## - Prepares the dependencies file.
 	@mkdir -p build/reports
-	./dev-tools/run_with_go_ver dev-tools/dependencies-report --csv build/reports/dependencies-$(DEFAULT_VERSION).csv
+	./dev-tools/run_with_go_ver dev-tools/dependencies-report --csv build/reports/dependencies-$(VERSION).csv
 
 .PHONY: release-manager-snapshot
 release-manager-snapshot: ## - Builds a snapshot release. The Go version defined in .go-version will be installed and used for the build.

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ docker-release: build-releaser ## - Builds a release for all platforms in a dock
 .PHONY: release
 release: $(PLATFORM_TARGETS) ## - Builds a release. Specify exact platform with PLATFORMS env.
 
-build/distributions/reports/dependencies.csv: ## - Prepares the dependencies file.
+release-manager-dependencies: ## - Prepares the dependencies file.
 	@mkdir -p build/distributions/reports
 	./dev-tools/run_with_go_ver dev-tools/dependencies-report --csv build/distributions/reports/dependencies-$(VERSION).csv
 	@cd build/distributions/reports && shasum -a 512 dependencies-$(VERSION).csv > dependencies-$(VERSION).csv.sha512

--- a/Makefile
+++ b/Makefile
@@ -166,10 +166,10 @@ docker-release: build-releaser ## - Builds a release for all platforms in a dock
 .PHONY: release
 release: $(PLATFORM_TARGETS) ## - Builds a release. Specify exact platform with PLATFORMS env.
 
-build/reports/dependencies.csv: ## - Prepares the dependencies file.
-	@mkdir -p build/reports
-	./dev-tools/run_with_go_ver dev-tools/dependencies-report --csv build/reports/dependencies-$(VERSION).csv
-	@cd build/reports && shasum -a 512 dependencies-$(VERSION).csv > dependencies-$(VERSION).csv.sha512
+build/distributions/dependencies.csv: ## - Prepares the dependencies file.
+	@mkdir -p build/distributions
+	./dev-tools/run_with_go_ver dev-tools/dependencies-report --csv build/distributions/dependencies-$(VERSION).csv
+	@cd build/distributions && shasum -a 512 dependencies-$(VERSION).csv > dependencies-$(VERSION).csv.sha512
 
 .PHONY: release-manager-snapshot
 release-manager-snapshot: ## - Builds a snapshot release. The Go version defined in .go-version will be installed and used for the build.

--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,7 @@ release: $(PLATFORM_TARGETS) ## - Builds a release. Specify exact platform with 
 build/reports/dependencies.csv: ## - Prepares the dependencies file.
 	@mkdir -p build/reports
 	./dev-tools/run_with_go_ver dev-tools/dependencies-report --csv build/reports/dependencies-$(VERSION).csv
+	@cd build/reports && shasum -a 512 dependencies-$(VERSION).csv > dependencies-$(VERSION).csv.sha512
 
 .PHONY: release-manager-snapshot
 release-manager-snapshot: ## - Builds a snapshot release. The Go version defined in .go-version will be installed and used for the build.


### PR DESCRIPTION
## What is the problem this PR solves?

Enable the Daily Release Artifacts for the Fleet Server project (Snapshots only)

If something bad happens then it sends an email/slack to:
- `#fleet-server`
- `fleet-server+package@...`

## How does this PR solve the problem?

A specific pipeline in charge of publishing the snapshots on a merge-commit only

## Related issues

Requires https://github.com/elastic/fleet-server/pull/1233
Requires https://github.com/elastic/apm-pipeline-library/pull/1618


## Test

https://artifacts-snapshot.elastic.co/fleet-server/8.2.0-6e3e8531/summary-8.2.0-SNAPSHOT.html has been generated (see [build](https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Ffleet-server-package-mbp/detail/PR-1234/46/pipeline/262))

<img width="894" alt="image" src="https://user-images.githubusercontent.com/2871786/159902795-857f41f3-47fb-4c14-86ec-d509aa4c82a9.png">


## Follow ups

Support BCs (to be done later on)