### PR TITLE
ci: store build/distributions

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -111,7 +111,7 @@ pipeline {
           dir("${BASE_DIR}"){
             withGoEnv(){
               sh(label: 'Create release artifacts', script: 'make docker-release')
-              uploadPackagesToGoogleBucket(pattern: 'build/binaries/')
+              uploadPackagesToGoogleBucket(pattern: 'build/distributions/')
             }
           }
         }


### PR DESCRIPTION
### What

Use the flat directory as that's the folder structure used in some other projects


### Why

To help the e2e-testing to work with the defined folder structure


### Issues

https://github.com/elastic/fleet-server/pull/1147 was the initial PR that enabled this.

### Test


```
gsutil list -l gs://beats-ci-artifacts/fleet-server/commits/455a032873113a8d35309c131ca3d2afaae850b1


Updates are available for some Cloud SDK components.  To install them,
please run:
  $ gcloud components update

   7343542  2022-03-17T13:23:05Z  gs://beats-ci-artifacts/fleet-server/commits/455a032873113a8d35309c131ca3d2afaae850b1/fleet-server-8.2.0-darwin-arm64.tar.gz
       169  2022-03-17T13:23:04Z  gs://beats-ci-artifacts/fleet-server/commits/455a032873113a8d35309c131ca3d2afaae850b1/fleet-server-8.2.0-darwin-arm64.tar.gz.sha512
   7846357  2022-03-17T13:23:05Z  gs://beats-ci-artifacts/fleet-server/commits/455a032873113a8d35309c131ca3d2afaae850b1/fleet-server-8.2.0-darwin-x86_64.tar.gz
       170  2022-03-17T13:23:04Z  gs://beats-ci-artifacts/fleet-server/commits/455a032873113a8d35309c131ca3d2afaae850b1/fleet-server-8.2.0-darwin-x86_64.tar.gz.sha512
   8227534  2022-03-17T13:23:04Z  gs://beats-ci-artifacts/fleet-server/commits/455a032873113a8d35309c131ca3d2afaae850b1/fleet-server-8.2.0-linux-arm64.tar.gz
       168  2022-03-17T13:23:04Z  gs://beats-ci-artifacts/fleet-server/commits/455a032873113a8d35309c131ca3d2afaae850b1/fleet-server-8.2.0-linux-arm64.tar.gz.sha512
   6922220  2022-03-17T13:23:04Z  gs://beats-ci-artifacts/fleet-server/commits/455a032873113a8d35309c131ca3d2afaae850b1/fleet-server-8.2.0-linux-x86.tar.gz
       166  2022-03-17T13:23:04Z  gs://beats-ci-artifacts/fleet-server/commits/455a032873113a8d35309c131ca3d2afaae850b1/fleet-server-8.2.0-linux-x86.tar.gz.sha512
   8975916  2022-03-17T13:23:04Z  gs://beats-ci-artifacts/fleet-server/commits/455a032873113a8d35309c131ca3d2afaae850b1/fleet-server-8.2.0-linux-x86_64.tar.gz
       169  2022-03-17T13:23:04Z  gs://beats-ci-artifacts/fleet-server/commits/455a032873113a8d35309c131ca3d2afaae850b1/fleet-server-8.2.0-linux-x86_64.tar.gz.sha512
   7182978  2022-03-17T13:23:05Z  gs://beats-ci-artifacts/fleet-server/commits/455a032873113a8d35309c131ca3d2afaae850b1/fleet-server-8.2.0-windows-x86.zip
       165  2022-03-17T13:23:04Z  gs://beats-ci-artifacts/fleet-server/commits/455a032873113a8d35309c131ca3d2afaae850b1/fleet-server-8.2.0-windows-x86.zip.sha512
   7661679  2022-03-17T13:23:04Z  gs://beats-ci-artifacts/fleet-server/commits/455a032873113a8d35309c131ca3d2afaae850b1/fleet-server-8.2.0-windows-x86_64.zip
       168  2022-03-17T13:23:04Z  gs://beats-ci-artifacts/fleet-server/commits/455a032873113a8d35309c131ca3d2afaae850b1/fleet-server-8.2.0-windows-x86_64.zip.sha512
TOTAL: 14 objects, 54161401 bytes (51.65 MiB)
```

Therefore no more subfolders:

```
 gsutil list -l gs://beats-ci-artifacts/fleet-server/snapshots                                       
                                 gs://beats-ci-artifacts/fleet-server/snapshots/binaries/
                                 gs://beats-ci-artifacts/fleet-server/snapshots/fleet-server-8.2.0-darwin-arm64/
                                 gs://beats-ci-artifacts/fleet-server/snapshots/fleet-server-8.2.0-darwin-x86_64/
                                 gs://beats-ci-artifacts/fleet-server/snapshots/fleet-server-8.2.0-linux-arm64/
                                 gs://beats-ci-artifacts/fleet-server/snapshots/fleet-server-8.2.0-linux-x86/
                                 gs://beats-ci-artifacts/fleet-server/snapshots/fleet-server-8.2.0-linux-x86_64/
                                 gs://beats-ci-artifacts/fleet-server/snapshots/fleet-server-8.2.0-windows-x86/
                                 gs://beats-ci-artifacts/fleet-server/snapshots/fleet-server-8.2.0-windows-x86_64/
```