### PR TITLE
Align golangci-lint with elastic-agent/beats

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,9 +12,20 @@ permissions:
   pull-requests: read
 jobs:
   golangci:
+    strategy:
+      matrix:
+        include:
+          - GOOS: windows
+          - GOOS: linux
+          - GOOS: darwin
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - name: Echo details
+        env:
+           GOOS: ${{ matrix.GOOS }}
+        run: echo Go GOOS=$GOOS
+
       - uses: actions/checkout@v2
 
       # Uses Go version from the repository.
@@ -27,13 +38,21 @@ jobs:
           go-version: "${{ steps.goversion.outputs.version }}"
 
       - name: golangci-lint
+        env:
+          GOOS: ${{ matrix.GOOS }}
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.44.2
 
           # Give the job more time to execute.
-          args: --timeout=5m
+          # Regarding `--whole-files`, the linter is supposed to support linting of changed a patch only but,
+          # for some reason, it's very unreliable this way - sometimes it does not report any or some
+          # issues without linting the whole files, so we have to use `--whole-files`
+          # which can lead to some frustration from developers who would like to
+          # fix a single line in an existing codebase and the linter would force them
+          # into fixing all linting issues in the whole file instead.
+          args: --timeout=30m --whole-files
 
           # Optional: if set to true then the action will use pre-installed Go.
           skip-go-installation: true


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

This run linter per operating system if we ever had specific OS code
defined with different golang build tags.

This also use the `--whole-files` arguments since from our testing
using only the patch strategy was making the linting unreliable.

See https://github.com/elastic/elastic-agent-libs/pull/30 for tests.

// Please do not just reference an issue. Explain WHAT the problem this PR solves here.

## How does this PR solve the problem?

// Explain HOW you solved the problem in your code. It is possible that during PR reviews this changes and then this section should be updated.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->