### PR TITLE
Use darwin-aarch64 artifact when building darwin

### DIFF
--- a/.ci/scripts/test-release.sh
+++ b/.ci/scripts/test-release.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 FLEET_SERVER_VERSION=${1:?"Fleet Server version is needed"}
 
-PLATFORM_FILES=(darwin-arm64.tar.gz darwin-x86_64.tar.gz linux-arm64.tar.gz linux-x86_64.tar.gz linux-x86.tar.gz windows-x86_64.zip windows-x86.zip)
+PLATFORM_FILES=(darwin-aarch64.tar.gz darwin-x86_64.tar.gz linux-arm64.tar.gz linux-x86_64.tar.gz linux-x86.tar.gz windows-x86_64.zip windows-x86.zip)
 
 #make release
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -5,3 +5,4 @@
 ==== New Features
 
 - Fleet server now supports Logstash type outputs for managed agents. {pull}1188[1188]
+- Use the darwin-aarch64 as the suffix for Darwin Arm64 release {pull}1267[1267]

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,10 @@ ifeq ($(OS),windows)
 	@mv build/binaries/fleet-server-$(VERSION)-$(OS)-$(ARCH)/fleet-server build/binaries/fleet-server-$(VERSION)-$(OS)-$(ARCH)/fleet-server.exe
 	@cd build/binaries && zip -q -r ../distributions/fleet-server-$(VERSION)-$(OS)-$(ARCH).zip fleet-server-$(VERSION)-$(OS)-$(ARCH)
 	@cd build/distributions && shasum -a 512 fleet-server-$(VERSION)-$(OS)-$(ARCH).zip > fleet-server-$(VERSION)-$(OS)-$(ARCH).zip.sha512
+else ifeq ($(OS)-$(ARCH),darwin-arm64)
+	@mv build/binaries/fleet-server-$(VERSION)-$(OS)-$(ARCH) build/binaries/fleet-server-$(VERSION)-$(OS)-aarch64
+	@tar -C build/binaries -zcf build/distributions/fleet-server-$(VERSION)-$(OS)-aarch64.tar.gz fleet-server-$(VERSION)-$(OS)-aarch64
+	@cd build/distributions && shasum -a 512 fleet-server-$(VERSION)-$(OS)-aarch64.tar.gz > fleet-server-$(VERSION)-$(OS)-aarch64.tar.gz.sha512
 else
 	@tar -C build/binaries -zcf build/distributions/fleet-server-$(VERSION)-$(OS)-$(ARCH).tar.gz fleet-server-$(VERSION)-$(OS)-$(ARCH)
 	@cd build/distributions && shasum -a 512 fleet-server-$(VERSION)-$(OS)-$(ARCH).tar.gz > fleet-server-$(VERSION)-$(OS)-$(ARCH).tar.gz.sha512


### PR DESCRIPTION
This use the `darwin-aarch64` suffix instead of `darwin-arm64`, this
align the naming with the other products of the stack.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

// Please do not just reference an issue. Explain WHAT the problem this PR solves here.

## How does this PR solve the problem?

// Explain HOW you solved the problem in your code. It is possible that during PR reviews this changes and then this section should be updated.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

```
 ❯ make  release-manager-snapshot                                                                                                                                       [15:36:20]
./dev-tools/run_with_go_ver /Library/Developer/CommandLineTools/usr/bin/make release
v0.3.2
GOOS=darwin GOARCH=amd64 go build -ldflags="-w -s -X main.Version=8.2.0-SNAPSHOT -X main.Commit=b8a6346 -X main.BuildTime=2022-03-28T19:36:21Z" -buildmode=pie -o build/binaries/fleet-server-8.2.0-SNAPSHOT-darwin-x86_64/fleet-server .
GOOS=darwin GOARCH=arm64 go build -ldflags="-w -s -X main.Version=8.2.0-SNAPSHOT -X main.Commit=b8a6346 -X main.BuildTime=2022-03-28T19:36:27Z" -buildmode=pie -o build/binaries/fleet-server-8.2.0-SNAPSHOT-darwin-arm64/fleet-server .
GOOS=linux GOARCH=386 go build -ldflags="-w -s -X main.Version=8.2.0-SNAPSHOT -X main.Commit=b8a6346 -X main.BuildTime=2022-03-28T19:36:32Z"  -o build/binaries/fleet-server-8.2.0-SNAPSHOT-linux-x86/fleet-server .
GOOS=linux GOARCH=amd64 go build -ldflags="-w -s -X main.Version=8.2.0-SNAPSHOT -X main.Commit=b8a6346 -X main.BuildTime=2022-03-28T19:36:35Z" -buildmode=pie -o build/binaries/fleet-server-8.2.0-SNAPSHOT-linux-x86_64/fleet-server .
GOOS=linux GOARCH=arm64 go build -ldflags="-w -s -X main.Version=8.2.0-SNAPSHOT -X main.Commit=b8a6346 -X main.BuildTime=2022-03-28T19:36:39Z" -buildmode=pie -o build/binaries/fleet-server-8.2.0-SNAPSHOT-linux-arm64/fleet-server .
GOOS=windows GOARCH=386 go build -ldflags="-w -s -X main.Version=8.2.0-SNAPSHOT -X main.Commit=b8a6346 -X main.BuildTime=2022-03-28T19:36:44Z" -buildmode=pie -o build/binaries/fleet-server-8.2.0-SNAPSHOT-windows-x86/fleet-server .
GOOS=windows GOARCH=amd64 go build -ldflags="-w -s -X main.Version=8.2.0-SNAPSHOT -X main.Commit=b8a6346 -X main.BuildTime=2022-03-28T19:36:47Z" -buildmode=pie -o build/binaries/fleet-server-8.2.0-SNAPSHOT-windows-x86_64/fleet-server .
```
```
-rw-r--r--  1 ph  staff  7321637 28 Mar 15:37 fleet-server-8.2.0-SNAPSHOT-darwin-aarch64.tar.gz
-rw-r--r--  1 ph  staff      180 28 Mar 15:37 fleet-server-8.2.0-SNAPSHOT-darwin-aarch64.tar.gz.sha512
-rw-r--r--  1 ph  staff  8042729 28 Mar 15:37 fleet-server-8.2.0-SNAPSHOT-darwin-x86_64.tar.gz
-rw-r--r--  1 ph  staff      179 28 Mar 15:37 fleet-server-8.2.0-SNAPSHOT-darwin-x86_64.tar.gz.sha512
-rw-r--r--  1 ph  staff  8204658 28 Mar 15:37 fleet-server-8.2.0-SNAPSHOT-linux-arm64.tar.gz
-rw-r--r--  1 ph  staff      177 28 Mar 15:37 fleet-server-8.2.0-SNAPSHOT-linux-arm64.tar.gz.sha512
-rw-r--r--  1 ph  staff  6900846 28 Mar 15:37 fleet-server-8.2.0-SNAPSHOT-linux-x86.tar.gz
-rw-r--r--  1 ph  staff      175 28 Mar 15:37 fleet-server-8.2.0-SNAPSHOT-linux-x86.tar.gz.sha512
-rw-r--r--  1 ph  staff  8951828 28 Mar 15:37 fleet-server-8.2.0-SNAPSHOT-linux-x86_64.tar.gz
-rw-r--r--  1 ph  staff      178 28 Mar 15:37 fleet-server-8.2.0-SNAPSHOT-linux-x86_64.tar.gz.sha512
-rw-r--r--  1 ph  staff  7186820 28 Mar 15:37 fleet-server-8.2.0-SNAPSHOT-windows-x86.zip
-rw-r--r--  1 ph  staff      174 28 Mar 15:37 fleet-server-8.2.0-SNAPSHOT-windows-x86.zip.sha512
-rw-r--r--  1 ph  staff  7666849 28 Mar 15:38 fleet-server-8.2.0-SNAPSHOT-windows-x86_64.zip
-rw-r--r--  1 ph  staff      177 28 Mar 15:38 fleet-server-8.2.0-SNAPSHOT-windows-x86_64.zip.sha512
```

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->