### PR TITLE
ci: daily release artifacts for staging

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -6,8 +6,8 @@ pipeline {
   environment {
     REPO = 'fleet-server'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
-    SLACK_CHANNEL = '#elastic-agent-control-plane'
-    NOTIFY_TO = 'fleet-server+build-package@elastic.co'
+    SLACK_CHANNEL = 'UJ2J1AZV2'
+    NOTIFY_TO = 'victor.martinez+build-package@elastic.co'
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     JOB_GCS_CREDENTIALS = 'beats-ci-gcs-plugin'
     DOCKER_SECRET = 'secret/observability-team/ci/docker-registry/prod'
@@ -36,6 +36,8 @@ pipeline {
         anyOf {
           triggeredBy cause: "IssueCommentCause"
           expression {
+            //TODO
+            return true
             def ret = isUserTrigger() || isUpstreamTrigger()
             if(!ret){
               currentBuild.result = 'NOT_BUILT'
@@ -65,7 +67,9 @@ pipeline {
             setEnvVar('URI_SUFFIX', "commits/${env.GIT_BASE_COMMIT}")
             // JOB_GCS_BUCKET contains the bucket and some folders, let's build the folder structure
             setEnvVar('PATH_PREFIX', "${JOB_GCS_BUCKET.contains('/') ? JOB_GCS_BUCKET.substring(JOB_GCS_BUCKET.indexOf('/') + 1) + '/' + env.URI_SUFFIX : env.URI_SUFFIX}")
-            setEnvVar('IS_BRANCH_AVAILABLE', isBranchUnifiedReleaseAvailable(env.BRANCH_NAME))
+            //TODO
+            //setEnvVar('IS_BRANCH_AVAILABLE', isBranchUnifiedReleaseAvailable(env.BRANCH_NAME))
+            setEnvVar('IS_BRANCH_AVAILABLE', isBranchUnifiedReleaseAvailable('main'))
             dir("${BASE_DIR}") {
               setEnvVar('VERSION', sh(label: 'Get version', script: 'make get-version', returnStdout: true)?.trim())
             }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -169,9 +169,8 @@ def runPackage(def args = [:]) {
 }
 
 def publishArtifacts(def args = [:]) {
-  def bucketLocation = getBucketLocation(args.type)
   // Copy those files to another location with the sha commit to test them afterward.
-  googleStorageUpload(bucket: "gs://${JOB_GCS_BUCKET}/${URI_SUFFIX}",
+  googleStorageUpload(bucket: getBucketLocation(args.type),
     credentialsId: "${JOB_GCS_CREDENTIALS}",
     pathPrefix: "${BASE_DIR}/build/distributions/",
     pattern: "${BASE_DIR}/build/distributions/**/*",
@@ -186,8 +185,7 @@ def getBucketLocation(type) {
 def runReleaseManager(def args = [:]) {
   deleteDir()
   unstash 'source'
-  def bucketLocation = getBucketLocation(args.type)
-  googleStorageDownload(bucketUri: "${bucketLocation}/*",
+  googleStorageDownload(bucketUri: "${getBucketLocation(args.type)}/*",
                         credentialsId: "${JOB_GCS_CREDENTIALS}",
                         localDirectory: "${BASE_DIR}/build/distributions",
                         pathPrefix: env.PATH_PREFIX)

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -206,7 +206,6 @@ def runReleaseManager(def args = [:]) {
                    type: args.type,
                    artifactsFolder: 'build/distributions',
                    outputFile: args.outputFile)
-    }
   }
 }
 

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -64,7 +64,9 @@ pipeline {
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             // set environment variables globally since they are used afterwards but GIT_BASE_COMMIT won't
             // be available until gitCheckout is executed.
-            setEnvVar('URI_SUFFIX', "commits/${env.GIT_BASE_COMMIT}")
+            //TODO
+            //setEnvVar('URI_SUFFIX', "commits/${env.GIT_BASE_COMMIT}")
+            setEnvVar('URI_SUFFIX', "commits/4a0ecbe90f9d1b3214aa1bd7d852ab6aaa0acc1c")
             // JOB_GCS_BUCKET contains the bucket and some folders, let's build the folder structure
             setEnvVar('PATH_PREFIX', "${JOB_GCS_BUCKET.contains('/') ? JOB_GCS_BUCKET.substring(JOB_GCS_BUCKET.indexOf('/') + 1) + '/' + env.URI_SUFFIX : env.URI_SUFFIX}")
             //TODO
@@ -77,6 +79,8 @@ pipeline {
         }
         stage('Package') {
           options { skipDefaultCheckout() }
+          // TODO
+          when { expression { return false } }
           matrix {
             agent {
               label "${PLATFORM}"

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -72,8 +72,6 @@ pipeline {
         }
         stage('Package') {
           options { skipDefaultCheckout() }
-          //TODO
-          when { expression { return false } }
           matrix {
             agent {
               label "${PLATFORM}"

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -72,6 +72,8 @@ pipeline {
         }
         stage('Package') {
           options { skipDefaultCheckout() }
+          //TODO
+          when { expression { return false } }
           matrix {
             agent {
               label "${PLATFORM}"
@@ -179,7 +181,8 @@ def getBucketLocation(type) {
 
 def getBucketRelativeLocation(type) {
   def folder = type.equals('snapshot') ? 'commit' : type
-  return "${folder}/${env.GIT_BASE_COMMIT}"
+  //TODO return "${folder}/${env.GIT_BASE_COMMIT}"
+  return "${folder}/8950ae0d9edfa086e43f50a756a6caa87e88b09a"
 }
 
 def getBucketPathPrefix(type) {
@@ -205,11 +208,15 @@ def runReleaseManager(def args = [:]) {
       sh(label: 'create dependencies file', script: "make ${makeGoal}")
     }
     dockerLogin(secret: env.DOCKER_SECRET, registry: env.DOCKER_REGISTRY)
+    // TODO
+    withEnv(["BRANCH_NAME=main"]) {
     releaseManager(project: 'fleet-server',
                    version: env.VERSION,
                    type: args.type,
                    artifactsFolder: 'build/distributions',
                    outputFile: args.outputFile)
+    //TODO
+    }
   }
 }
 

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -175,7 +175,7 @@ def getBucketLocation(type) {
 
 def getBucketRelativeLocation(type) {
   def folder = type.equals('snapshot') ? 'commits' : type
-  TODO return "${folder}/${env.GIT_BASE_COMMIT}"
+  return "${folder}/${env.GIT_BASE_COMMIT}"
 }
 
 def getBucketPathPrefix(type) {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -72,8 +72,6 @@ pipeline {
         }
         stage('Package') {
           options { skipDefaultCheckout() }
-          // TODO
-          when { expression { return false } }
           matrix {
             agent {
               label "${PLATFORM}"

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -192,7 +192,7 @@ def runReleaseManager(def args = [:]) {
   dir("${BASE_DIR}") {
     def makeGoal = args.type.equals('staging') ? 'release-manager-dependencies-release' : 'release-manager-dependencies-snapshot'
     withMageEnv() {
-      sh(label: 'create dependencies file', script: "make ${goal}")
+      sh(label: 'create dependencies file', script: "make ${makeGoal}")
     }
     dockerLogin(secret: env.DOCKER_SECRET, registry: env.DOCKER_REGISTRY)
     releaseManager(project: 'fleet-server',


### PR DESCRIPTION
### What

This is the very last part for the DRA related to the `staging` workflow

### Implementation details

- Run in parallel the `staging` and `snapshot` package generation.
- Enable `staging` for the release branches.
- Enable `snapshot` for the release and main branches.

### Test

See [job](https://beats-ci.elastic.co/job/Ingest-manager/job/fleet-server-package-mbp/job/PR-1280/)


This [build](https://beats-ci.elastic.co/blue/organizations/jenkins/Ingest-manager%2Ffleet-server-package-mbp/detail/PR-1280/9/pipeline/452)

created:

- [staging](https://artifacts-staging.elastic.co/fleet-server/8.3.0-894cf6bf/summary-8.3.0.html)
- [snapshot](https://artifacts-snapshot.elastic.co/fleet-server/8.3.0-0c0699c2/summary-8.3.0-SNAPSHOT.html)

<img width="1067" alt="image" src="https://user-images.githubusercontent.com/2871786/161240532-a1c938e1-9feb-4c82-9b1a-cfb2d3624463.png">
