### PR TITLE
fix: update mergify's base branch for 8.1 and 8.2

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -51,7 +51,7 @@ pull_request_rules:
   - name: backport patches to 8.1 branch
     conditions:
       - merged
-      - base=master
+      - base=main
       - label=backport-v8.1.0
     actions:
       backport:
@@ -65,7 +65,7 @@ pull_request_rules:
   - name: backport patches to 8.2 branch
     conditions:
       - merged
-      - base=master
+      - base=main
       - label=backport-v8.2.0
     actions:
       backport:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?
Automated backports to 8.1 and 8.2 did not work because of Mergify's config was outdated.

// Please do not just reference an issue. Explain WHAT the problem this PR solves here.

## How does this PR solve the problem?
It uses `main` as base branch for Mergify to resolve the rules for those two branches

// Explain HOW you solved the problem in your code. It is possible that during PR reviews this changes and then this section should be updated.



<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.




<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->