### PR TITLE
Remove windows and darwin linting

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - GOOS: windows
           - GOOS: linux
-          - GOOS: darwin
+          #- GOOS: windows
+          #- GOOS: darwin
     name: lint
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We have seems weirds behavior in Darwin and Windows execution of the
linting. Until all the errors are fixes this is a bit counter productive
to run it on everything. It will just multiply the errors detected.





## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
Ref: https://github.com/elastic/fleet-server/pull/1270