### PR TITLE
Always add `api_key` to Elasticsearch output

### DIFF
--- a/cmd/fleet/handleCheckin.go
+++ b/cmd/fleet/handleCheckin.go
@@ -417,7 +417,6 @@ func convertActions(agentId string, actions []model.Action) ([]ActionResp, strin
 //  - Rewrite the policy for delivery to the agent injecting the key material.
 //
 func processPolicy(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, agentId string, pp *policy.ParsedPolicy) (*ActionResp, error) {
-
 	zlog = zlog.With().
 		Str("ctx", "processPolicy").
 		Int64("policyRevision", pp.Policy.RevisionIdx).
@@ -445,8 +444,8 @@ func processPolicy(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, a
 	}
 
 	// Iterate through the policy outputs and prepare them
-	for name, policyOutput := range pp.Outputs {
-		err = policyOutput.Prepare(ctx, zlog, bulker, &agent, outputs, name == pp.Default.Name)
+	for _, policyOutput := range pp.Outputs {
+		err = policyOutput.Prepare(ctx, zlog, bulker, &agent, outputs)
 
 		if err != nil {
 			return nil, err

--- a/internal/pkg/policy/policy_output.go
+++ b/internal/pkg/policy/policy_output.go
@@ -121,8 +121,8 @@ func (p *PolicyOutput) Prepare(ctx context.Context, zlog zerolog.Logger, bulker 
 		// to Elasticsearch.
 		//
 		// TODO(ph) Investigate allocation with the new LS output, we had optimization
-		// in place to reduce number of agent policy allocation when distribution the updated
-		// keys to multiples agents.
+		// in place to reduce number of agent policy allocation when sending the updated
+		// agent policy to multiple agents.
 		if ok := setMapObj(outputMap, agent.DefaultApiKey, p.Name, "api_key"); !ok {
 			return ErrFailInjectAPIKey
 		}

--- a/internal/pkg/policy/policy_output.go
+++ b/internal/pkg/policy/policy_output.go
@@ -12,13 +12,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rs/zerolog"
+
 	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
 	"github.com/elastic/fleet-server/v7/internal/pkg/logger"
 	"github.com/elastic/fleet-server/v7/internal/pkg/model"
 	"github.com/elastic/fleet-server/v7/internal/pkg/smap"
-	"github.com/rs/zerolog"
 )
 
 const (
@@ -60,7 +61,6 @@ func (p *PolicyOutput) Prepare(ctx context.Context, zlog zerolog.Logger, bulker 
 		case agent.DefaultApiKey == "":
 			zlog.Debug().Msg("must generate api key as default API key is not present")
 		case p.Role.Sha2 != agent.PolicyOutputPermissionsHash:
-			fmt.Println("!= hash?")
 			zlog.Debug().Msg("must generate api key as policy output permissions changed")
 		default:
 			needNewKey = false

--- a/internal/pkg/policy/policy_output.go
+++ b/internal/pkg/policy/policy_output.go
@@ -120,9 +120,10 @@ func (p *PolicyOutput) Prepare(ctx context.Context, zlog zerolog.Logger, bulker 
 		// add it the agent will not receive the `api_key` and will not be able to connect
 		// to Elasticsearch.
 		//
-		// TODO(ph) Investigate allocation with the new LS output, we had optimization
+		// We need to investigate allocation with the new LS output, we had optimization
 		// in place to reduce number of agent policy allocation when sending the updated
 		// agent policy to multiple agents.
+		// See: https://github.com/elastic/fleet-server/issues/1301
 		if ok := setMapObj(outputMap, agent.DefaultApiKey, p.Name, "api_key"); !ok {
 			return ErrFailInjectAPIKey
 		}

--- a/internal/pkg/policy/policy_output.go
+++ b/internal/pkg/policy/policy_output.go
@@ -38,7 +38,7 @@ type PolicyOutput struct {
 	Role *RoleT
 }
 
-func (p *PolicyOutput) Prepare(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, agent *model.Agent, outputMap smap.Map, isDefault bool) error {
+func (p *PolicyOutput) Prepare(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, agent *model.Agent, outputMap smap.Map) error {
 	switch p.Type {
 	case OutputTypeElasticsearch:
 		zlog.Debug().Msg("preparing elasticsearch output")
@@ -116,7 +116,7 @@ func (p *PolicyOutput) Prepare(ctx context.Context, zlog zerolog.Logger, bulker 
 		}
 
 		// Always insert the `api_key` as part of the output block, this is required
-		// because only fleet server know the api key for the specific agent, if we don't
+		// because only fleet server knows the api key for the specific agent, if we don't
 		// add it the agent will not receive the `api_key` and will not be able to connect
 		// to Elasticsearch.
 		//

--- a/internal/pkg/policy/policy_output_test.go
+++ b/internal/pkg/policy/policy_output_test.go
@@ -6,15 +6,15 @@ package policy
 
 import (
 	"context"
-	"fmt"
 	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/model"
 	"github.com/elastic/fleet-server/v7/internal/pkg/smap"
 	ftesting "github.com/elastic/fleet-server/v7/internal/pkg/testing"
-	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/require"
 )
 
 var TestPayload []byte
@@ -112,7 +112,6 @@ func TestPolicyOutputESPrepare(t *testing.T) {
 
 		key, ok := policyMap.GetMap("test output")["api_key"].(string)
 
-		fmt.Println(policyMap)
 		require.True(t, ok, "unable to case api key")
 		require.Equal(t, testAgent.DefaultApiKey, key)
 		require.Equal(t, len(bulker.ArgumentData.Update), 0, "update should not be called")

--- a/internal/pkg/policy/policy_output_test.go
+++ b/internal/pkg/policy/policy_output_test.go
@@ -33,7 +33,7 @@ func TestPolicyLogstashOutputPrepare(t *testing.T) {
 		},
 	}
 
-	err := po.Prepare(context.Background(), zerolog.Logger{}, bulker, &model.Agent{}, smap.Map{}, false)
+	err := po.Prepare(context.Background(), zerolog.Logger{}, bulker, &model.Agent{}, smap.Map{})
 	require.Nil(t, err, "expected prepare to pass")
 }
 func TestPolicyLogstashOutputPrepareNoRole(t *testing.T) {
@@ -47,7 +47,7 @@ func TestPolicyLogstashOutputPrepareNoRole(t *testing.T) {
 		Role: nil,
 	}
 
-	err := po.Prepare(context.Background(), zerolog.Logger{}, bulker, &model.Agent{}, smap.Map{}, false)
+	err := po.Prepare(context.Background(), zerolog.Logger{}, bulker, &model.Agent{}, smap.Map{})
 	// No permissions are required by logstash currently
 	require.Nil(t, err, "expected prepare to pass")
 }
@@ -66,7 +66,7 @@ func TestPolicyDefaultLogstashOutputPrepare(t *testing.T) {
 		},
 	}
 
-	err := po.Prepare(context.Background(), zerolog.Logger{}, bulker, &model.Agent{}, smap.Map{}, true)
+	err := po.Prepare(context.Background(), zerolog.Logger{}, bulker, &model.Agent{}, smap.Map{})
 	require.Nil(t, err, "expected prepare to pass")
 }
 
@@ -81,7 +81,7 @@ func TestPolicyESOutputPrepareNoRole(t *testing.T) {
 		Role: nil,
 	}
 
-	err := po.Prepare(context.Background(), zerolog.Logger{}, bulker, &model.Agent{}, smap.Map{}, false)
+	err := po.Prepare(context.Background(), zerolog.Logger{}, bulker, &model.Agent{}, smap.Map{})
 	require.NotNil(t, err, "expected prepare to error")
 }
 
@@ -107,7 +107,7 @@ func TestPolicyOutputESPrepare(t *testing.T) {
 			PolicyOutputPermissionsHash: hashPerm,
 		}
 
-		err := po.Prepare(context.Background(), zerolog.Logger{}, bulker, testAgent, policyMap, false)
+		err := po.Prepare(context.Background(), zerolog.Logger{}, bulker, testAgent, policyMap)
 		require.NoError(t, err, "expected prepare to pass")
 
 		key, ok := policyMap.GetMap("test output")["api_key"].(string)
@@ -141,7 +141,7 @@ func TestPolicyOutputESPrepare(t *testing.T) {
 			PolicyOutputPermissionsHash: "old-HASH",
 		}
 
-		err := po.Prepare(context.Background(), zerolog.Logger{}, bulker, testAgent, policyMap, false)
+		err := po.Prepare(context.Background(), zerolog.Logger{}, bulker, testAgent, policyMap)
 		require.NoError(t, err, "expected prepare to pass")
 
 		key, ok := policyMap.GetMap("test output")["api_key"].(string)
@@ -172,7 +172,7 @@ func TestPolicyOutputESPrepare(t *testing.T) {
 
 		testAgent := &model.Agent{}
 
-		err := po.Prepare(context.Background(), zerolog.Logger{}, bulker, testAgent, policyMap, false)
+		err := po.Prepare(context.Background(), zerolog.Logger{}, bulker, testAgent, policyMap)
 		require.NoError(t, err, "expected prepare to pass")
 
 		key, ok := policyMap.GetMap("test output")["api_key"].(string)


### PR DESCRIPTION
## What is the problem this PR solves?


This fixes a few issues:

- When the hash on the permission and the hash on the agent were the
same the key was not added to the output. This was causing the agent to
not be able to connect to Elasticsearch. If you change an integration
policy field, as the `host` field,  and the data stream are the same the permission hash will
stay the same.

- Fix a possible issue when the new key was not saved on the Agent model, the
the key was only saved when we were targetting a default agent policy.
Currently, we only support a single ES output so this should always be saved.

- Reorganize the test to ensure that all the scenarios from the `case switch` are tested

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->
 
- Wait for the Agent's status to be Healthy
- Change a integration field value.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

Closes: https://github.com/elastic/elastic-agent/issues/285