### PR TITLE
Refactor: move files from cmd/fleet to pkg/api

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,7 +60,6 @@ linters:
     - noctx # noctx finds sending http request without context.Context
     - unconvert # Remove unnecessary type conversions
     - wastedassign # wastedassign finds wasted assignment statements.
-    - godox # tool for detection of FIXME, TODO and other comment keywords
 
 # all available settings of specific linters
 linters-settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,8 @@ linters:
     - noctx # noctx finds sending http request without context.Context
     - unconvert # Remove unnecessary type conversions
     - wastedassign # wastedassign finds wasted assignment statements.
+    #- godox # tool for detection of FIXME, TODO and other comment keywords
+
 
 # all available settings of specific linters
 linters-settings:
@@ -139,6 +141,8 @@ linters-settings:
   stylecheck:
     # Select the Go version to target. The default is '1.13'.
     go: "1.17"
+    initialisms: ["ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "QPS", "RAM", "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "GID", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS", "ECS"]
+
 
   unparam:
     # Inspect exported functions, default is false. Set to true if no external program/library imports your code.

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -481,10 +481,10 @@ LOOP:
 		ech := make(chan error, 2)
 
 		if started {
-			f.reporter.Status(proto.StateObserved_CONFIGURING, "Re-configuring", nil) //nolint:errcheck,gosec // unclear on what should we do if updating the status fails?
+			f.reporter.Status(proto.StateObserved_CONFIGURING, "Re-configuring", nil) //nolint:errcheck // unclear on what should we do if updating the status fails?
 		} else {
 			started = true
-			f.reporter.Status(proto.StateObserved_STARTING, "Starting", nil) //nolint:errcheck,gosec // unclear on what should we do if updating the status fails?
+			f.reporter.Status(proto.StateObserved_STARTING, "Starting", nil) //nolint:errcheck // unclear on what should we do if updating the status fails?
 		}
 
 		// Create or recreate cache
@@ -532,11 +532,11 @@ LOOP:
 		case newCfg = <-f.cfgCh:
 			log.Info().Msg("Server configuration update")
 		case err := <-ech:
-			f.reporter.Status(proto.StateObserved_FAILED, fmt.Sprintf("Error - %s", err), nil) //nolint:errcheck,gosec // unclear on what should we do if updating the status fails?
+			f.reporter.Status(proto.StateObserved_FAILED, fmt.Sprintf("Error - %s", err), nil) //nolint:errcheck // unclear on what should we do if updating the status fails?
 			log.Error().Err(err).Msg("Fleet Server failed")
 			return err
 		case <-ctx.Done():
-			f.reporter.Status(proto.StateObserved_STOPPING, "Stopping", nil) //nolint:errcheck,gosec // unclear on what should we do if updating the status fails?
+			f.reporter.Status(proto.StateObserved_STOPPING, "Stopping", nil) //nolint:errcheck // unclear on what should we do if updating the status fails?
 			break LOOP
 		}
 	}
@@ -912,16 +912,16 @@ func (f *FleetServer) initTracer(cfg config.Instrumentation) (*apm.Tracer, error
 		envCACert           = "ELASTIC_APM_SERVER_CA_CERT_FILE"
 	)
 	if cfg.TLS.SkipVerify {
-		os.Setenv(envVerifyServerCert, "false") //nolint:errcheck,gosec // what do we do if env var operation fail
-		defer os.Unsetenv(envVerifyServerCert)  //nolint:errcheck // what do we do if env var operation fail
+		os.Setenv(envVerifyServerCert, "false")
+		defer os.Unsetenv(envVerifyServerCert)
 	}
 	if cfg.TLS.ServerCertificate != "" {
-		os.Setenv(envServerCert, cfg.TLS.ServerCertificate) //nolint:errcheck,gosec // what do we do if env var operation fail
-		defer os.Unsetenv(envServerCert)                    //nolint:errcheck // what do we do if env var operation fail
+		os.Setenv(envServerCert, cfg.TLS.ServerCertificate)
+		defer os.Unsetenv(envServerCert)
 	}
 	if cfg.TLS.ServerCA != "" {
-		os.Setenv(envCACert, cfg.TLS.ServerCA) //nolint:errcheck,gosec // what do we do if env var operation fail
-		defer os.Unsetenv(envCACert)           //nolint:errcheck // what do we do if env var operation fail
+		os.Setenv(envCACert, cfg.TLS.ServerCA)
+		defer os.Unsetenv(envCACert)
 	}
 	transport, err := apmtransport.NewHTTPTransport()
 	if err != nil {

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -170,7 +170,7 @@ func getRunCommand(bi build.Info) func(cmd *cobra.Command, args []string) error 
 			runErr = srv.Run(installSignalHandler())
 		}
 
-		if runErr != nil && errors.Is(runErr, context.Canceled) {
+		if runErr != nil && !errors.Is(runErr, context.Canceled) {
 			log.Error().Err(runErr).Msg("Exiting")
 			l.Sync()
 			return runErr

--- a/cmd/fleet/server_integration_test.go
+++ b/cmd/fleet/server_integration_test.go
@@ -5,7 +5,7 @@
 //go:build integration
 // +build integration
 
-package api
+package fleet
 
 import (
 	"bytes"
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/elastic/fleet-server/v7/internal/pkg/api"
 	"github.com/elastic/fleet-server/v7/internal/pkg/build"
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
 	"github.com/elastic/fleet-server/v7/internal/pkg/logger"
@@ -171,7 +172,7 @@ func TestServerUnauthorized(t *testing.T) {
 			}
 
 			raw, _ := ioutil.ReadAll(res.Body)
-			var resp errResp
+			var resp api.ErrResp
 			err = json.Unmarshal(raw, &resp)
 			if err != nil {
 				t.Fatal(err)
@@ -206,7 +207,7 @@ func TestServerUnauthorized(t *testing.T) {
 			}
 
 			raw, _ := ioutil.ReadAll(res.Body)
-			var resp errResp
+			var resp api.ErrResp
 			err = json.Unmarshal(raw, &resp)
 			if err != nil {
 				t.Fatal(err)

--- a/cmd/fleet/server_integration_test.go
+++ b/cmd/fleet/server_integration_test.go
@@ -172,7 +172,7 @@ func TestServerUnauthorized(t *testing.T) {
 			}
 
 			raw, _ := ioutil.ReadAll(res.Body)
-			var resp api.ErrResp
+			var resp api.HTTPErrResp
 			err = json.Unmarshal(raw, &resp)
 			if err != nil {
 				t.Fatal(err)
@@ -207,7 +207,7 @@ func TestServerUnauthorized(t *testing.T) {
 			}
 
 			raw, _ := ioutil.ReadAll(res.Body)
-			var resp api.ErrResp
+			var resp api.HTTPErrResp
 			err = json.Unmarshal(raw, &resp)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/pkg/api/auth.go
+++ b/internal/pkg/api/auth.go
@@ -50,16 +50,16 @@ func authAPIKey(r *http.Request, bulker bulk.Bulk, c cache.Cache) (*apikey.ApiKe
 		log.Info().
 			Err(err).
 			Str(LogAPIKeyID, key.Id).
-			Str(EcsHTTPRequestID, reqID).
-			Int64(EcsEventDuration, time.Since(start).Nanoseconds()).
+			Str(ECSHTTPRequestID, reqID).
+			Int64(ECSEventDuration, time.Since(start).Nanoseconds()).
 			Msg("ApiKey fail authentication")
 		return nil, err
 	}
 
 	log.Trace().
 		Str("id", key.Id).
-		Str(EcsHTTPRequestID, reqID).
-		Int64(EcsEventDuration, time.Since(start).Nanoseconds()).
+		Str(ECSHTTPRequestID, reqID).
+		Int64(ECSEventDuration, time.Since(start).Nanoseconds()).
 		Str("userName", info.UserName).
 		Strs("roles", info.Roles).
 		Bool("enabled", info.Enabled).
@@ -72,8 +72,8 @@ func authAPIKey(r *http.Request, bulker bulk.Bulk, c cache.Cache) (*apikey.ApiKe
 		log.Info().
 			Err(err).
 			Str("id", key.Id).
-			Str(EcsHTTPRequestID, reqID).
-			Int64(EcsEventDuration, time.Since(start).Nanoseconds()).
+			Str(ECSHTTPRequestID, reqID).
+			Int64(ECSEventDuration, time.Since(start).Nanoseconds()).
 			Msg("ApiKey not enabled")
 	}
 
@@ -91,7 +91,7 @@ func authAgent(r *http.Request, id *string, bulker bulk.Bulk, c cache.Cache) (*m
 
 	w := log.With().
 		Str(LogAccessAPIKeyID, key.Id).
-		Str(EcsHTTPRequestID, r.Header.Get(logger.HeaderRequestID))
+		Str(ECSHTTPRequestID, r.Header.Get(logger.HeaderRequestID))
 
 	if id != nil {
 		w = w.Str(LogAgentID, *id)
@@ -103,7 +103,7 @@ func authAgent(r *http.Request, id *string, bulker bulk.Bulk, c cache.Cache) (*m
 
 	if authTime.Sub(start) > time.Second {
 		zlog.Debug().
-			Int64(EcsEventDuration, authTime.Sub(start).Nanoseconds()).
+			Int64(ECSEventDuration, authTime.Sub(start).Nanoseconds()).
 			Msg("authApiKey slow")
 	}
 
@@ -123,7 +123,7 @@ func authAgent(r *http.Request, id *string, bulker bulk.Bulk, c cache.Cache) (*m
 
 	if findTime.Sub(authTime) > time.Second {
 		zlog.Debug().
-			Int64(EcsEventDuration, findTime.Sub(authTime).Nanoseconds()).
+			Int64(ECSEventDuration, findTime.Sub(authTime).Nanoseconds()).
 			Msg("findAgentByApiKeyId slow")
 	}
 

--- a/internal/pkg/api/auth.go
+++ b/internal/pkg/api/auth.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package fleet
+package api
 
 import (
 	"errors"

--- a/internal/pkg/api/error.go
+++ b/internal/pkg/api/error.go
@@ -21,10 +21,10 @@ import (
 
 // Alias logger constants
 const (
-	EcsHttpRequestId         = logger.EcsHttpRequestId
+	EcsHTTPRequestID         = logger.EcsHttpRequestId
 	EcsEventDuration         = logger.EcsEventDuration
-	EcsHttpResponseCode      = logger.EcsHttpResponseCode
-	EcsHttpResponseBodyBytes = logger.EcsHttpResponseBodyBytes
+	EcsHTTPResponseCode      = logger.EcsHttpResponseCode
+	EcsHTTPResponseBodyBytes = logger.EcsHttpResponseBodyBytes
 
 	LogAPIKeyID       = logger.ApiKeyId
 	LogPolicyID       = logger.PolicyId
@@ -74,7 +74,7 @@ func NewErrorResp(err error) errResp {
 			},
 		},
 		{
-			ErrApiKeyNotEnabled,
+			ErrAPIKeyNotEnabled,
 			errResp{
 				http.StatusUnauthorized,
 				"Unauthorized",

--- a/internal/pkg/api/error.go
+++ b/internal/pkg/api/error.go
@@ -21,10 +21,10 @@ import (
 
 // Alias logger constants
 const (
-	EcsHTTPRequestID         = logger.EcsHttpRequestId
-	EcsEventDuration         = logger.EcsEventDuration
-	EcsHTTPResponseCode      = logger.EcsHttpResponseCode
-	EcsHTTPResponseBodyBytes = logger.EcsHttpResponseBodyBytes
+	ECSHTTPRequestID         = logger.EcsHttpRequestId
+	ECSEventDuration         = logger.EcsEventDuration
+	ECSHTTPResponseCode      = logger.EcsHttpResponseCode
+	ECSHTTPResponseBodyBytes = logger.EcsHttpResponseBodyBytes
 
 	LogAPIKeyID       = logger.ApiKeyId
 	LogPolicyID       = logger.PolicyId

--- a/internal/pkg/api/error.go
+++ b/internal/pkg/api/error.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package fleet
+package api
 
 import (
 	"context"

--- a/internal/pkg/api/handleAck.go
+++ b/internal/pkg/api/handleAck.go
@@ -68,7 +68,7 @@ func (rt Router) handleAcks(w http.ResponseWriter, r *http.Request, ps httproute
 
 	zlog := log.With().
 		Str(LogAgentID, id).
-		Str(EcsHTTPRequestID, reqID).
+		Str(ECSHTTPRequestID, reqID).
 		Logger()
 
 	err := rt.ack.handleAcks(&zlog, w, r, id)
@@ -79,8 +79,8 @@ func (rt Router) handleAcks(w http.ResponseWriter, r *http.Request, ps httproute
 
 		zlog.WithLevel(resp.Level).
 			Err(err).
-			Int(EcsHTTPResponseCode, resp.StatusCode).
-			Int64(EcsEventDuration, time.Since(start).Nanoseconds()).
+			Int(ECSHTTPResponseCode, resp.StatusCode).
+			Int64(ECSEventDuration, time.Since(start).Nanoseconds()).
 			Msg("fail ACK")
 
 		if err := resp.Write(w); err != nil {

--- a/internal/pkg/api/handleAck.go
+++ b/internal/pkg/api/handleAck.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package fleet
+package api
 
 import (
 	"bytes"

--- a/internal/pkg/api/handleAck.go
+++ b/internal/pkg/api/handleAck.go
@@ -75,7 +75,7 @@ func (rt Router) handleAcks(w http.ResponseWriter, r *http.Request, ps httproute
 
 	if err != nil {
 		cntAcks.IncError(err)
-		resp := NewErrorResp(err)
+		resp := NewHTTPErrResp(err)
 
 		zlog.WithLevel(resp.Level).
 			Err(err).

--- a/internal/pkg/api/handleAck_test.go
+++ b/internal/pkg/api/handleAck_test.go
@@ -5,7 +5,7 @@
 //go:build !integration
 // +build !integration
 
-package fleet
+package api
 
 import (
 	"context"

--- a/internal/pkg/api/handleAck_test.go
+++ b/internal/pkg/api/handleAck_test.go
@@ -30,22 +30,22 @@ import (
 func BenchmarkMakeUpdatePolicyBody(b *testing.B) {
 	b.ReportAllocs()
 
-	const policyId = "ed110be4-c2a0-42b8-adc0-94c2f0569207"
+	const policyID = "ed110be4-c2a0-42b8-adc0-94c2f0569207"
 	const newRev = 2
 	const coord = 1
 
 	for n := 0; n < b.N; n++ {
-		makeUpdatePolicyBody(policyId, newRev, coord)
+		makeUpdatePolicyBody(policyID, newRev, coord)
 	}
 }
 
 func TestMakeUpdatePolicyBody(t *testing.T) {
 
-	const policyId = "ed110be4-c2a0-42b8-adc0-94c2f0569207"
+	const policyID = "ed110be4-c2a0-42b8-adc0-94c2f0569207"
 	const newRev = 2
 	const coord = 1
 
-	data := makeUpdatePolicyBody(policyId, newRev, coord)
+	data := makeUpdatePolicyBody(policyID, newRev, coord)
 
 	var i interface{}
 	err := json.Unmarshal(data, &i)
@@ -56,7 +56,7 @@ func TestMakeUpdatePolicyBody(t *testing.T) {
 }
 
 func TestEventToActionResult(t *testing.T) {
-	agentId := "6e9b6655-8cfe-4eb6-9b2f-c10aefae7517"
+	agentID := "6e9b6655-8cfe-4eb6-9b2f-c10aefae7517"
 
 	tests := []struct {
 		name string
@@ -65,7 +65,7 @@ func TestEventToActionResult(t *testing.T) {
 		{
 			name: "success",
 			ev: Event{
-				ActionId:        "1b12dcd8-bde0-4045-92dc-c4b27668d733",
+				ActionID:        "1b12dcd8-bde0-4045-92dc-c4b27668d733",
 				ActionInputType: "osquery",
 				StartedAt:       "2022-02-23T18:26:08.506128Z",
 				CompletedAt:     "2022-02-23T18:26:08.507593Z",
@@ -76,7 +76,7 @@ func TestEventToActionResult(t *testing.T) {
 		{
 			name: "error",
 			ev: Event{
-				ActionId:        "2b12dcd8-bde0-4045-92dc-c4b27668d733",
+				ActionID:        "2b12dcd8-bde0-4045-92dc-c4b27668d733",
 				ActionInputType: "osquery",
 				StartedAt:       "2022-02-24T18:26:08.506128Z",
 				CompletedAt:     "2022-02-24T18:26:08.507593Z",
@@ -88,9 +88,9 @@ func TestEventToActionResult(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			acr := eventToActionResult(agentId, tc.ev)
-			assert.Equal(t, agentId, acr.AgentId)
-			assert.Equal(t, tc.ev.ActionId, acr.ActionId)
+			acr := eventToActionResult(agentID, tc.ev)
+			assert.Equal(t, agentID, acr.AgentId)
+			assert.Equal(t, tc.ev.ActionID, acr.ActionId)
 			assert.Equal(t, tc.ev.ActionInputType, acr.ActionInputType)
 			assert.Equal(t, tc.ev.StartedAt, acr.StartedAt)
 			assert.Equal(t, tc.ev.CompletedAt, acr.CompletedAt)
@@ -231,8 +231,8 @@ func TestHandleAckEvents(t *testing.T) {
 			name: "action agentID mismatch",
 			events: []Event{
 				{
-					ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
-					AgentId:  "ab12dcd8-bde0-4045-92dc-c4b27668d737",
+					ActionID: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
+					AgentID:  "ab12dcd8-bde0-4045-92dc-c4b27668d737",
 				},
 			},
 			res: newAckResponse(true, []AckResponseItem{newAckResponseItem(http.StatusBadRequest)}),
@@ -242,7 +242,7 @@ func TestHandleAckEvents(t *testing.T) {
 			name: "action empty agent id",
 			events: []Event{
 				{
-					ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
+					ActionID: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
 				},
 			},
 			res: newAckResponse(true, []AckResponseItem{newAckResponseItem(http.StatusNotFound)}),
@@ -252,7 +252,7 @@ func TestHandleAckEvents(t *testing.T) {
 			name: "action find error",
 			events: []Event{
 				{
-					ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
+					ActionID: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
 				},
 			},
 			res:    newAckResponse(true, []AckResponseItem{newAckResponseItem(http.StatusInternalServerError)}),
@@ -263,7 +263,7 @@ func TestHandleAckEvents(t *testing.T) {
 			name: "policy action",
 			events: []Event{
 				{
-					ActionId: "policy:2b12dcd8-bde0-4045-92dc-c4b27668d733",
+					ActionID: "policy:2b12dcd8-bde0-4045-92dc-c4b27668d733",
 				},
 			},
 			res: newAckResponse(false, []AckResponseItem{{
@@ -275,7 +275,7 @@ func TestHandleAckEvents(t *testing.T) {
 			name: "action found",
 			events: []Event{
 				{
-					ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
+					ActionID: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
 				},
 			},
 			res: newAckResponse(false, []AckResponseItem{{
@@ -290,7 +290,7 @@ func TestHandleAckEvents(t *testing.T) {
 			name: "action found, create result general error",
 			events: []Event{
 				{
-					ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
+					ActionID: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
 				},
 			},
 			res: newAckResponse(true, []AckResponseItem{newAckResponseItem(http.StatusInternalServerError)}),
@@ -306,7 +306,7 @@ func TestHandleAckEvents(t *testing.T) {
 			name: "action found, create result elasticsearch error",
 			events: []Event{
 				{
-					ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
+					ActionID: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
 				},
 			},
 			res: newAckResponse(true, []AckResponseItem{newAckResponseItem(http.StatusServiceUnavailable)}),
@@ -322,7 +322,7 @@ func TestHandleAckEvents(t *testing.T) {
 			name: "upgrade action found, update agent error",
 			events: []Event{
 				{
-					ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
+					ActionID: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
 					Type:     "UPGRADE",
 				},
 			},
@@ -342,25 +342,25 @@ func TestHandleAckEvents(t *testing.T) {
 			name: "mixed actions found",
 			events: []Event{
 				{
-					ActionId: "policy:2b12dcd8-bde0-4045-92dc-c4b27668d733:1:1",
+					ActionID: "policy:2b12dcd8-bde0-4045-92dc-c4b27668d733:1:1",
 					Type:     "POLICY_CHANGE",
 				},
 				{
-					ActionId: "1b12dcd8-bde0-4045-92dc-c4b27668d731",
+					ActionID: "1b12dcd8-bde0-4045-92dc-c4b27668d731",
 					Type:     "UNENROLL",
 				},
 				{
-					ActionId: "1b12dcd8-bde0-4045-92dc-c4b27668d733",
+					ActionID: "1b12dcd8-bde0-4045-92dc-c4b27668d733",
 				},
 				{
-					ActionId: "ab12dcd8-bde0-4045-92dc-c4b27668d73a",
+					ActionID: "ab12dcd8-bde0-4045-92dc-c4b27668d73a",
 					Type:     "UPGRADE",
 				},
 				{
-					ActionId: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
+					ActionID: "2b12dcd8-bde0-4045-92dc-c4b27668d733",
 				},
 				{
-					ActionId: "policy:2b12dcd8-bde0-4045-92dc-c4b27668d733:1:2",
+					ActionID: "policy:2b12dcd8-bde0-4045-92dc-c4b27668d733:1:2",
 					Type:     "POLICY_CHANGE",
 				},
 			},

--- a/internal/pkg/api/handleArtifacts.go
+++ b/internal/pkg/api/handleArtifacts.go
@@ -75,7 +75,7 @@ func (rt Router) handleArtifacts(w http.ResponseWriter, r *http.Request, ps http
 
 	zlog := log.With().
 		Str(LogAgentID, id).
-		Str(EcsHTTPRequestID, reqID).
+		Str(ECSHTTPRequestID, reqID).
 		Str("sha2", sha2).
 		Str("remoteAddr", r.RemoteAddr).
 		Logger()
@@ -87,8 +87,8 @@ func (rt Router) handleArtifacts(w http.ResponseWriter, r *http.Request, ps http
 		nWritten, err = io.Copy(w, rdr)
 		zlog.Trace().
 			Err(err).
-			Int64(EcsHTTPResponseBodyBytes, nWritten).
-			Int64(EcsEventDuration, time.Since(start).Nanoseconds()).
+			Int64(ECSHTTPResponseBodyBytes, nWritten).
+			Int64(ECSEventDuration, time.Since(start).Nanoseconds()).
 			Msg("Response sent")
 
 		cntArtifacts.bodyOut.Add(uint64(nWritten))
@@ -100,9 +100,9 @@ func (rt Router) handleArtifacts(w http.ResponseWriter, r *http.Request, ps http
 
 		zlog.WithLevel(resp.Level).
 			Err(err).
-			Int(EcsHTTPResponseCode, resp.StatusCode).
-			Int64(EcsHTTPResponseBodyBytes, nWritten).
-			Int64(EcsEventDuration, time.Since(start).Nanoseconds()).
+			Int(ECSHTTPResponseCode, resp.StatusCode).
+			Int64(ECSHTTPResponseBodyBytes, nWritten).
+			Int64(ECSEventDuration, time.Since(start).Nanoseconds()).
 			Msg("fail artifact")
 
 		if err := resp.Write(w); err != nil {
@@ -259,7 +259,7 @@ func (at ArtifactT) fetchArtifact(ctx context.Context, zlog zerolog.Logger, iden
 
 	zlog.Info().
 		Err(err).
-		Int64(EcsEventDuration, time.Since(start).Nanoseconds()).
+		Int64(ECSEventDuration, time.Since(start).Nanoseconds()).
 		Msg("fetch artifact")
 
 	return artifact, errors.Wrap(err, "fetchArtifact")

--- a/internal/pkg/api/handleArtifacts.go
+++ b/internal/pkg/api/handleArtifacts.go
@@ -96,7 +96,7 @@ func (rt Router) handleArtifacts(w http.ResponseWriter, r *http.Request, ps http
 
 	if err != nil {
 		cntArtifacts.IncError(err)
-		resp := NewErrorResp(err)
+		resp := NewHTTPErrResp(err)
 
 		zlog.WithLevel(resp.Level).
 			Err(err).

--- a/internal/pkg/api/handleArtifacts.go
+++ b/internal/pkg/api/handleArtifacts.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package fleet
+package api
 
 import (
 	"bytes"

--- a/internal/pkg/api/handleArtifacts.go
+++ b/internal/pkg/api/handleArtifacts.go
@@ -71,11 +71,11 @@ func (rt Router) handleArtifacts(w http.ResponseWriter, r *http.Request, ps http
 		sha2 = ps.ByName("sha2") // DecodedSha256 in the artifact record
 	)
 
-	reqId := r.Header.Get(logger.HeaderRequestID)
+	reqID := r.Header.Get(logger.HeaderRequestID)
 
 	zlog := log.With().
 		Str(LogAgentID, id).
-		Str(EcsHttpRequestId, reqId).
+		Str(EcsHTTPRequestID, reqID).
 		Str("sha2", sha2).
 		Str("remoteAddr", r.RemoteAddr).
 		Logger()
@@ -87,7 +87,7 @@ func (rt Router) handleArtifacts(w http.ResponseWriter, r *http.Request, ps http
 		nWritten, err = io.Copy(w, rdr)
 		zlog.Trace().
 			Err(err).
-			Int64(EcsHttpResponseBodyBytes, nWritten).
+			Int64(EcsHTTPResponseBodyBytes, nWritten).
 			Int64(EcsEventDuration, time.Since(start).Nanoseconds()).
 			Msg("Response sent")
 
@@ -100,8 +100,8 @@ func (rt Router) handleArtifacts(w http.ResponseWriter, r *http.Request, ps http
 
 		zlog.WithLevel(resp.Level).
 			Err(err).
-			Int(EcsHttpResponseCode, resp.StatusCode).
-			Int64(EcsHttpResponseBodyBytes, nWritten).
+			Int(EcsHTTPResponseCode, resp.StatusCode).
+			Int64(EcsHTTPResponseBodyBytes, nWritten).
 			Int64(EcsEventDuration, time.Since(start).Nanoseconds()).
 			Msg("fail artifact")
 
@@ -136,12 +136,6 @@ func (at ArtifactT) handleArtifacts(zlog *zerolog.Logger, r *http.Request, id, s
 	defer dfunc()
 
 	return at.processRequest(r.Context(), *zlog, agent, id, sha2)
-}
-
-type artHandler struct {
-	zlog   zerolog.Logger
-	bulker bulk.Bulk
-	c      cache.Cache
 }
 
 func (at ArtifactT) processRequest(ctx context.Context, zlog zerolog.Logger, agent *model.Agent, id, sha2 string) (io.Reader, error) {

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -40,7 +40,7 @@ import (
 var (
 	ErrAgentNotFound    = errors.New("agent not found")
 	ErrNoPolicyOutput   = errors.New("output section not found")
-	ErrFailInjectAPIKey = errors.New("fail inject api key")
+	ErrFailInjectAPIKey = errors.New("failure to inject api key")
 )
 
 const (
@@ -63,7 +63,7 @@ func (rt Router) handleCheckin(w http.ResponseWriter, r *http.Request, ps httpro
 
 	if err != nil {
 		cntCheckin.IncError(err)
-		resp := NewErrorResp(err)
+		resp := NewHTTPErrResp(err)
 
 		// Log this as warn for visibility that limit has been reached.
 		// This allows customers to tune the configuration on detection of threshold.
@@ -213,7 +213,7 @@ func (ct *CheckinT) processRequest(zlog zerolog.Logger, w http.ResponseWriter, r
 	defer func() {
 		err := ct.pm.Unsubscribe(sub)
 		if err != nil {
-			zlog.Error().Err(err).Str("policy_id", agent.PolicyId).Msg("unable to unsubscribe")
+			zlog.Error().Err(err).Str("policy_id", agent.PolicyId).Msg("unable to unsubscribe from policy")
 		}
 	}()
 

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package fleet
+package api
 
 import (
 	"bytes"

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -40,7 +40,7 @@ import (
 var (
 	ErrAgentNotFound    = errors.New("agent not found")
 	ErrNoPolicyOutput   = errors.New("output section not found")
-	ErrFailInjectApiKey = errors.New("fail inject api key")
+	ErrFailInjectAPIKey = errors.New("fail inject api key")
 )
 
 const (
@@ -52,11 +52,11 @@ func (rt Router) handleCheckin(w http.ResponseWriter, r *http.Request, ps httpro
 
 	id := ps.ByName("id")
 
-	reqId := r.Header.Get(logger.HeaderRequestID)
+	reqID := r.Header.Get(logger.HeaderRequestID)
 
 	zlog := log.With().
 		Str(LogAgentID, id).
-		Str(EcsHttpRequestId, reqId).
+		Str(EcsHTTPRequestID, reqID).
 		Logger()
 
 	err := rt.ct.handleCheckin(&zlog, w, r, id)
@@ -73,7 +73,7 @@ func (rt Router) handleCheckin(w http.ResponseWriter, r *http.Request, ps httpro
 
 		zlog.WithLevel(resp.Level).
 			Err(err).
-			Int(EcsHttpResponseCode, resp.StatusCode).
+			Int(EcsHTTPResponseCode, resp.StatusCode).
 			Int64(EcsEventDuration, time.Since(start).Nanoseconds()).
 			Msg("fail checkin")
 
@@ -210,7 +210,12 @@ func (ct *CheckinT) processRequest(zlog zerolog.Logger, w http.ResponseWriter, r
 	if err != nil {
 		return errors.Wrap(err, "subscribe policy monitor")
 	}
-	defer ct.pm.Unsubscribe(sub)
+	defer func() {
+		err := ct.pm.Unsubscribe(sub)
+		if err != nil {
+			zlog.Error().Err(err).Str("policy_id", agent.PolicyId).Msg("unable to unsubscribe")
+		}
+	}()
 
 	// Update check-in timestamp on timeout
 	tick := time.NewTicker(ct.cfg.Timeouts.CheckinTimestamp)
@@ -232,8 +237,11 @@ func (ct *CheckinT) processRequest(zlog zerolog.Logger, w http.ResponseWriter, r
 	longPoll := time.NewTicker(pollDuration)
 	defer longPoll.Stop()
 
-	// Intial update on checkin, and any user fields that might have changed
-	ct.bc.CheckIn(agent.Id, req.Status, rawMeta, seqno, ver)
+	// Initial update on checkin, and any user fields that might have changed
+	err = ct.bc.CheckIn(agent.Id, req.Status, rawMeta, seqno, ver)
+	if err != nil {
+		zlog.Error().Err(err).Str("agent_id", agent.Id).Msg("checkin failed")
+	}
 
 	// Initial fetch for pending actions
 	var (
@@ -270,7 +278,10 @@ func (ct *CheckinT) processRequest(zlog zerolog.Logger, w http.ResponseWriter, r
 				zlog.Trace().Msg("fire long poll")
 				break LOOP
 			case <-tick.C:
-				ct.bc.CheckIn(agent.Id, req.Status, nil, nil, ver)
+				err := ct.bc.CheckIn(agent.Id, req.Status, nil, nil, ver)
+				if err != nil {
+					zlog.Error().Err(err).Str("agent_id", agent.Id).Msg("checkin failed")
+				}
 			}
 		}
 	}
@@ -279,7 +290,7 @@ func (ct *CheckinT) processRequest(zlog zerolog.Logger, w http.ResponseWriter, r
 		zlog.Info().
 			Str("ackToken", ackToken).
 			Str("createdAt", action.CreatedAt).
-			Str("id", action.Id).
+			Str("id", action.ID).
 			Str("type", action.Type).
 			Str("inputType", action.InputType).
 			Int64("timeout", action.Timeout).
@@ -355,10 +366,11 @@ func acceptsEncoding(r *http.Request, encoding string) bool {
 }
 
 // Resolve AckToken from request, fallback on the agent record
-func (ct *CheckinT) resolveSeqNo(ctx context.Context, zlog zerolog.Logger, req CheckinRequest, agent *model.Agent) (seqno sqn.SeqNo, err error) {
+func (ct *CheckinT) resolveSeqNo(ctx context.Context, zlog zerolog.Logger, req CheckinRequest, agent *model.Agent) (sqn.SeqNo, error) {
+	var err error
 	// Resolve AckToken from request, fallback on the agent record
 	ackToken := req.AckToken
-	seqno = agent.ActionSeqNo
+	var seqno sqn.SeqNo = agent.ActionSeqNo
 
 	if ct.tr != nil && ackToken != "" {
 		var sn int64
@@ -368,18 +380,17 @@ func (ct *CheckinT) resolveSeqNo(ctx context.Context, zlog zerolog.Logger, req C
 				zlog.Debug().Str("token", ackToken).Msg("revision token not found")
 				err = nil
 			} else {
-				err = errors.Wrap(err, "resolveSeqNo")
-				return
+				return seqno, errors.Wrap(err, "resolveSeqNo")
 			}
 		}
 		seqno = []int64{sn}
 	}
-	return seqno, nil
+	return seqno, err
 }
 
-func (ct *CheckinT) fetchAgentPendingActions(ctx context.Context, seqno sqn.SeqNo, agentId string) ([]model.Action, error) {
+func (ct *CheckinT) fetchAgentPendingActions(ctx context.Context, seqno sqn.SeqNo, agentID string) ([]model.Action, error) {
 
-	actions, err := dl.FindAgentActions(ctx, ct.bulker, seqno, ct.gcp.GetCheckpoint(), agentId)
+	actions, err := dl.FindAgentActions(ctx, ct.bulker, seqno, ct.gcp.GetCheckpoint(), agentID)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "fetchAgentPendingActions")
@@ -388,17 +399,17 @@ func (ct *CheckinT) fetchAgentPendingActions(ctx context.Context, seqno sqn.SeqN
 	return actions, err
 }
 
-func convertActions(agentId string, actions []model.Action) ([]ActionResp, string) {
+func convertActions(agentID string, actions []model.Action) ([]ActionResp, string) {
 	var ackToken string
 	sz := len(actions)
 
 	respList := make([]ActionResp, 0, sz)
 	for _, action := range actions {
 		respList = append(respList, ActionResp{
-			AgentId:   agentId,
+			AgentID:   agentID,
 			CreatedAt: action.Timestamp,
 			Data:      action.Data,
-			Id:        action.ActionId,
+			ID:        action.ActionId,
 			Type:      action.Type,
 			InputType: action.InputType,
 			Timeout:   action.Timeout,
@@ -416,7 +427,7 @@ func convertActions(agentId string, actions []model.Action) ([]ActionResp, strin
 //  - Generate and update default ApiKey if roles have changed.
 //  - Rewrite the policy for delivery to the agent injecting the key material.
 //
-func processPolicy(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, agentId string, pp *policy.ParsedPolicy) (*ActionResp, error) {
+func processPolicy(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, agentID string, pp *policy.ParsedPolicy) (*ActionResp, error) {
 	zlog = zlog.With().
 		Str("ctx", "processPolicy").
 		Int64("policyRevision", pp.Policy.RevisionIdx).
@@ -425,7 +436,7 @@ func processPolicy(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, a
 		Logger()
 
 	// Repull and decode the agent object.  Do not trust the cache.
-	agent, err := dl.FindAgent(ctx, bulker, dl.QueryAgentByID, dl.FieldId, agentId)
+	agent, err := dl.FindAgent(ctx, bulker, dl.QueryAgentByID, dl.FieldId, agentID)
 	if err != nil {
 		zlog.Error().Err(err).Msg("fail find agent record")
 		return nil, err
@@ -473,17 +484,17 @@ func processPolicy(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, a
 
 	r := policy.RevisionFromPolicy(pp.Policy)
 	resp := ActionResp{
-		AgentId:   agent.Id,
+		AgentID:   agent.Id,
 		CreatedAt: pp.Policy.Timestamp,
 		Data:      rewrittenPolicy,
-		Id:        r.String(),
+		ID:        r.String(),
 		Type:      TypePolicyChange,
 	}
 
 	return &resp, nil
 }
 
-func findAgentByApiKeyId(ctx context.Context, bulker bulk.Bulk, id string) (*model.Agent, error) {
+func findAgentByAPIKeyID(ctx context.Context, bulker bulk.Bulk, id string) (*model.Agent, error) {
 	agent, err := dl.FindAgent(ctx, bulker, dl.QueryAgentByAssessAPIKeyID, dl.FieldAccessAPIKeyID, id)
 	if err != nil {
 		if errors.Is(err, dl.ErrNotFound) {

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -582,7 +582,7 @@ func calcPollDuration(zlog zerolog.Logger, cfg *config.Server, setupDuration tim
 
 	var jitter time.Duration
 	if cfg.Timeouts.CheckinJitter != 0 {
-		jitter = time.Duration(rand.Int63n(int64(cfg.Timeouts.CheckinJitter)))
+		jitter = time.Duration(rand.Int63n(int64(cfg.Timeouts.CheckinJitter))) //nolint:gosec // jitter time does not need to by generated from a crypto secure source
 		if jitter < pollDuration {
 			pollDuration = pollDuration - jitter
 			zlog.Trace().Dur("poll", pollDuration).Msg("Long poll with jitter")

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -56,7 +56,7 @@ func (rt Router) handleCheckin(w http.ResponseWriter, r *http.Request, ps httpro
 
 	zlog := log.With().
 		Str(LogAgentID, id).
-		Str(EcsHTTPRequestID, reqID).
+		Str(ECSHTTPRequestID, reqID).
 		Logger()
 
 	err := rt.ct.handleCheckin(&zlog, w, r, id)
@@ -73,8 +73,8 @@ func (rt Router) handleCheckin(w http.ResponseWriter, r *http.Request, ps httpro
 
 		zlog.WithLevel(resp.Level).
 			Err(err).
-			Int(EcsHTTPResponseCode, resp.StatusCode).
-			Int64(EcsEventDuration, time.Since(start).Nanoseconds()).
+			Int(ECSHTTPResponseCode, resp.StatusCode).
+			Int64(ECSEventDuration, time.Since(start).Nanoseconds()).
 			Msg("fail checkin")
 
 		if err := resp.Write(w); err != nil {

--- a/internal/pkg/api/handleChecking_test.go
+++ b/internal/pkg/api/handleChecking_test.go
@@ -30,8 +30,8 @@ func TestConvertActions(t *testing.T) {
 	resp, token := convertActions("agent-id", actions)
 	assert.Equal(t, resp, []ActionResp{
 		{
-			AgentId: "agent-id",
-			Id:      "1234",
+			AgentID: "agent-id",
+			ID:      "1234",
 			Data:    json.RawMessage(nil),
 		},
 	})

--- a/internal/pkg/api/handleChecking_test.go
+++ b/internal/pkg/api/handleChecking_test.go
@@ -5,7 +5,7 @@
 //go:build !integration
 // +build !integration
 
-package fleet
+package api
 
 import (
 	"encoding/json"

--- a/internal/pkg/api/handleEnroll.go
+++ b/internal/pkg/api/handleEnroll.go
@@ -80,7 +80,7 @@ func (rt Router) handleEnroll(w http.ResponseWriter, r *http.Request, ps httprou
 	reqID := r.Header.Get(logger.HeaderRequestID)
 
 	zlog := log.With().
-		Str(EcsHTTPRequestID, reqID).
+		Str(ECSHTTPRequestID, reqID).
 		Str("mod", kEnrollMod).
 		Logger()
 
@@ -110,8 +110,8 @@ func (rt Router) handleEnroll(w http.ResponseWriter, r *http.Request, ps httprou
 
 		zlog.WithLevel(resp.Level).
 			Err(err).
-			Int(EcsHTTPResponseCode, resp.StatusCode).
-			Int64(EcsEventDuration, time.Since(start).Nanoseconds()).
+			Int(ECSHTTPResponseCode, resp.StatusCode).
+			Int64(ECSEventDuration, time.Since(start).Nanoseconds()).
 			Msg("fail enroll")
 
 		if rerr := resp.Write(w); rerr != nil {
@@ -124,7 +124,7 @@ func (rt Router) handleEnroll(w http.ResponseWriter, r *http.Request, ps httprou
 		cntEnroll.IncError(err)
 		zlog.Error().
 			Err(err).
-			Int64(EcsEventDuration, time.Since(start).Nanoseconds()).
+			Int64(ECSEventDuration, time.Since(start).Nanoseconds()).
 			Msg("fail write response")
 	}
 }
@@ -343,8 +343,8 @@ func writeResponse(zlog zerolog.Logger, w http.ResponseWriter, resp *EnrollRespo
 		Str(LogAgentID, resp.Item.ID).
 		Str(LogPolicyID, resp.Item.PolicyID).
 		Str(LogAccessAPIKeyID, resp.Item.AccessAPIKeyID).
-		Int(EcsHTTPResponseBodyBytes, numWritten).
-		Int64(EcsEventDuration, time.Since(start).Nanoseconds()).
+		Int(ECSHTTPResponseBodyBytes, numWritten).
+		Int64(ECSEventDuration, time.Since(start).Nanoseconds()).
 		Msg("Elastic Agent successfully enrolled")
 
 	return nil

--- a/internal/pkg/api/handleEnroll.go
+++ b/internal/pkg/api/handleEnroll.go
@@ -106,7 +106,7 @@ func (rt Router) handleEnroll(w http.ResponseWriter, r *http.Request, ps httprou
 
 	if err != nil {
 		cntEnroll.IncError(err)
-		resp := NewErrorResp(err)
+		resp := NewHTTPErrResp(err)
 
 		zlog.WithLevel(resp.Level).
 			Err(err).

--- a/internal/pkg/api/handleEnroll.go
+++ b/internal/pkg/api/handleEnroll.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package fleet
+package api
 
 import (
 	"context"

--- a/internal/pkg/api/handleStatus.go
+++ b/internal/pkg/api/handleStatus.go
@@ -155,7 +155,7 @@ func (rt Router) handleStatus(w http.ResponseWriter, r *http.Request, _ httprout
 
 	var nWritten int
 	if nWritten, err = w.Write(data); err != nil {
-		if errors.Is(err, context.Canceled) {
+		if !errors.Is(err, context.Canceled) {
 			zlog.Error().Err(err).Int(EcsHTTPResponseCode, code).
 				Int64(EcsEventDuration, time.Since(start).Nanoseconds()).Msg("fail status")
 		}

--- a/internal/pkg/api/handleStatus.go
+++ b/internal/pkg/api/handleStatus.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package fleet
+package api
 
 import (
 	"context"
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
+	"github.com/elastic/fleet-server/v7/internal/pkg/build"
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/cache"
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
@@ -90,7 +91,7 @@ func (st StatusT) handleStatus(zlog *zerolog.Logger, r *http.Request, rt *Router
 
 	status = rt.sm.Status()
 	resp = StatusResponse{
-		Name:   kServiceName,
+		Name:   build.ServiceName,
 		Status: status.String(),
 	}
 

--- a/internal/pkg/api/handleStatus.go
+++ b/internal/pkg/api/handleStatus.go
@@ -124,7 +124,7 @@ func (rt Router) handleStatus(w http.ResponseWriter, r *http.Request, _ httprout
 	resp, status, err := rt.st.handleStatus(&zlog, r, &rt)
 	if err != nil {
 		cntStatus.IncError(err)
-		resp := NewErrorResp(err)
+		resp := NewHTTPErrResp(err)
 
 		zlog.WithLevel(resp.Level).
 			Err(err).

--- a/internal/pkg/api/handleStatus.go
+++ b/internal/pkg/api/handleStatus.go
@@ -117,7 +117,7 @@ func (rt Router) handleStatus(w http.ResponseWriter, r *http.Request, _ httprout
 	reqID := r.Header.Get(logger.HeaderRequestID)
 
 	zlog := log.With().
-		Str(EcsHTTPRequestID, reqID).
+		Str(ECSHTTPRequestID, reqID).
 		Str("mod", kStatusMod).
 		Logger()
 
@@ -128,8 +128,8 @@ func (rt Router) handleStatus(w http.ResponseWriter, r *http.Request, _ httprout
 
 		zlog.WithLevel(resp.Level).
 			Err(err).
-			Int(EcsHTTPResponseCode, resp.StatusCode).
-			Int64(EcsEventDuration, time.Since(start).Nanoseconds()).
+			Int(ECSHTTPResponseCode, resp.StatusCode).
+			Int64(ECSEventDuration, time.Since(start).Nanoseconds()).
 			Msg("fail status")
 
 		if rerr := resp.Write(w); rerr != nil {
@@ -141,8 +141,8 @@ func (rt Router) handleStatus(w http.ResponseWriter, r *http.Request, _ httprout
 	data, err := json.Marshal(&resp)
 	if err != nil {
 		code := http.StatusInternalServerError
-		zlog.Error().Err(err).Int(EcsHTTPResponseCode, code).
-			Int64(EcsEventDuration, time.Since(start).Nanoseconds()).Msg("fail status")
+		zlog.Error().Err(err).Int(ECSHTTPResponseCode, code).
+			Int64(ECSEventDuration, time.Since(start).Nanoseconds()).Msg("fail status")
 		http.Error(w, "", code)
 		return
 	}
@@ -156,14 +156,14 @@ func (rt Router) handleStatus(w http.ResponseWriter, r *http.Request, _ httprout
 	var nWritten int
 	if nWritten, err = w.Write(data); err != nil {
 		if !errors.Is(err, context.Canceled) {
-			zlog.Error().Err(err).Int(EcsHTTPResponseCode, code).
-				Int64(EcsEventDuration, time.Since(start).Nanoseconds()).Msg("fail status")
+			zlog.Error().Err(err).Int(ECSHTTPResponseCode, code).
+				Int64(ECSEventDuration, time.Since(start).Nanoseconds()).Msg("fail status")
 		}
 	}
 
 	cntStatus.bodyOut.Add(uint64(nWritten))
 	zlog.Debug().
-		Int(EcsHTTPResponseBodyBytes, nWritten).
-		Int64(EcsEventDuration, time.Since(start).Nanoseconds()).
+		Int(ECSHTTPResponseBodyBytes, nWritten).
+		Int64(ECSEventDuration, time.Since(start).Nanoseconds()).
 		Msg("ok status")
 }

--- a/internal/pkg/api/handleStatus_test.go
+++ b/internal/pkg/api/handleStatus_test.go
@@ -5,7 +5,7 @@
 //go:build !integration
 // +build !integration
 
-package fleet
+package api
 
 import (
 	"context"

--- a/internal/pkg/api/handleStatus_test.go
+++ b/internal/pkg/api/handleStatus_test.go
@@ -69,7 +69,7 @@ func TestHandleStatus(t *testing.T) {
 		},
 	}
 
-	// Test table, with inner loop on all avaiable statuses
+	// Test table, with inner loop on all available statuses
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			for k, v := range proto.StateObserved_Status_name {
@@ -87,10 +87,10 @@ func TestHandleStatus(t *testing.T) {
 					}
 
 					hr := httprouter.New()
-					hr.Handle(http.MethodGet, ROUTE_STATUS, r.handleStatus)
+					hr.Handle(http.MethodGet, RouteStatus, r.handleStatus)
 
 					w := httptest.NewRecorder()
-					req, _ := http.NewRequest(http.MethodGet, ROUTE_STATUS, nil)
+					req, _ := http.NewRequestWithContext(ctx, http.MethodGet, RouteStatus, nil)
 					hr.ServeHTTP(w, req)
 
 					expectedCode := http.StatusServiceUnavailable

--- a/internal/pkg/api/metrics.go
+++ b/internal/pkg/api/metrics.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package fleet
+package api
 
 import (
 	"context"
@@ -11,6 +11,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/cmd/instance/metrics"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/monitoring"
+	"github.com/elastic/fleet-server/v7/internal/pkg/build"
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
 	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
 	"github.com/elastic/fleet-server/v7/internal/pkg/limit"
@@ -32,13 +33,13 @@ var (
 	cntArtifacts artifactStats
 )
 
-func (f *FleetServer) initMetrics(ctx context.Context, cfg *config.Config) (*api.Server, error) {
+func InitMetrics(ctx context.Context, cfg *config.Config, bi build.Info) (*api.Server, error) {
 	registry := monitoring.GetNamespace("info").GetRegistry()
 	if registry.Get("version") == nil {
-		monitoring.NewString(registry, "version").Set(f.bi.Version)
+		monitoring.NewString(registry, "version").Set(bi.Version)
 	}
 	if registry.Get("name") == nil {
-		monitoring.NewString(registry, "name").Set(kServiceName)
+		monitoring.NewString(registry, "name").Set(build.ServiceName)
 	}
 
 	if !cfg.HTTP.Enabled {
@@ -84,7 +85,7 @@ func (rt *routeStats) Register(registry *monitoring.Registry) {
 }
 
 func init() {
-	metrics.SetupMetrics(kServiceName)
+	metrics.SetupMetrics(build.ServiceName)
 	registry = monitoring.Default.NewRegistry("http_server")
 	cntHttpNew = monitoring.NewUint(registry, "tcp_open")
 	cntHttpClose = monitoring.NewUint(registry, "tcp_close")

--- a/internal/pkg/api/metrics.go
+++ b/internal/pkg/api/metrics.go
@@ -18,13 +18,14 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/logger"
 
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 )
 
 var (
 	registry *monitoring.Registry
 
-	cntHttpNew   *monitoring.Uint
-	cntHttpClose *monitoring.Uint
+	cntHTTPNew   *monitoring.Uint
+	cntHTTPClose *monitoring.Uint
 
 	cntCheckin   routeStats
 	cntEnroll    routeStats
@@ -85,10 +86,14 @@ func (rt *routeStats) Register(registry *monitoring.Registry) {
 }
 
 func init() {
-	metrics.SetupMetrics(build.ServiceName)
+	err := metrics.SetupMetrics(build.ServiceName)
+	if err != nil {
+		log.Error().Err(err).Msg("unable to initialize metrics")
+	}
+
 	registry = monitoring.Default.NewRegistry("http_server")
-	cntHttpNew = monitoring.NewUint(registry, "tcp_open")
-	cntHttpClose = monitoring.NewUint(registry, "tcp_close")
+	cntHTTPNew = monitoring.NewUint(registry, "tcp_open")
+	cntHTTPClose = monitoring.NewUint(registry, "tcp_close")
 
 	routesRegistry := registry.NewRegistry("routes")
 

--- a/internal/pkg/api/router.go
+++ b/internal/pkg/api/router.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package fleet
+package api
 
 import (
 	"context"

--- a/internal/pkg/api/router.go
+++ b/internal/pkg/api/router.go
@@ -19,17 +19,16 @@ import (
 )
 
 const (
-	ROUTE_STATUS    = "/api/status"
-	ROUTE_ENROLL    = "/api/fleet/agents/:id"
-	ROUTE_CHECKIN   = "/api/fleet/agents/:id/checkin"
-	ROUTE_ACKS      = "/api/fleet/agents/:id/acks"
-	ROUTE_ARTIFACTS = "/api/fleet/artifacts/:id/:sha2"
+	RouteStatus    = "/api/status"
+	RouteEnroll    = "/api/fleet/agents/:id"
+	RouteCheckin   = "/api/fleet/agents/:id/checkin"
+	RouteAcks      = "/api/fleet/agents/:id/acks"
+	RouteArtifacts = "/api/fleet/artifacts/:id/:sha2"
 )
 
 type Router struct {
 	ctx    context.Context
 	bulker bulk.Bulk
-	ver    string
 	ct     *CheckinT
 	et     *EnrollerT
 	at     *ArtifactT
@@ -40,7 +39,6 @@ type Router struct {
 }
 
 func NewRouter(ctx context.Context, bulker bulk.Bulk, ct *CheckinT, et *EnrollerT, at *ArtifactT, ack *AckT, st *StatusT, sm policy.SelfMonitor, tracer *apm.Tracer, bi build.Info) *httprouter.Router {
-
 	r := Router{
 		ctx:    ctx,
 		bulker: bulker,
@@ -60,27 +58,27 @@ func NewRouter(ctx context.Context, bulker bulk.Bulk, ct *CheckinT, et *Enroller
 	}{
 		{
 			http.MethodGet,
-			ROUTE_STATUS,
+			RouteStatus,
 			r.handleStatus,
 		},
 		{
 			http.MethodPost,
-			ROUTE_ENROLL,
+			RouteEnroll,
 			r.handleEnroll,
 		},
 		{
 			http.MethodPost,
-			ROUTE_CHECKIN,
+			RouteCheckin,
 			r.handleCheckin,
 		},
 		{
 			http.MethodPost,
-			ROUTE_ACKS,
+			RouteAcks,
 			r.handleAcks,
 		},
 		{
 			http.MethodGet,
-			ROUTE_ARTIFACTS,
+			RouteArtifacts,
 			r.handleArtifacts,
 		},
 	}

--- a/internal/pkg/api/schema.go
+++ b/internal/pkg/api/schema.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	AGENT_ACTION_SAVED_OBJECT_TYPE = "fleet-agent-actions"
+	AgentActionSavedObjectType = "fleet-agent-actions"
 )
 
 const (
@@ -35,11 +35,12 @@ const kFleetAccessRolesJSON = `
 }
 `
 
+// AgentAction details agent action payload
 // Wrong: no AAD;
 // This defeats the signature check;
 // can copy from one to another and will dispatch.
 type AgentAction struct {
-	AgentId   string `json:"agent_id"`
+	AgentID   string `json:"agent_id"`
 	Type      string `json:"type"`
 	SentAt    string `json:"sent_at"`
 	CreatedAt string `json:"created_at"`
@@ -48,7 +49,7 @@ type AgentAction struct {
 
 type EnrollRequest struct {
 	Type     string `json:"type"`
-	SharedId string `json:"shared_id"`
+	SharedID string `json:"shared_id"`
 	Meta     struct {
 		User  json.RawMessage `json:"user_provided"`
 		Local json.RawMessage `json:"local"`
@@ -58,13 +59,13 @@ type EnrollRequest struct {
 type EnrollResponseItem struct {
 	ID             string          `json:"id"`
 	Active         bool            `json:"active"`
-	PolicyId       string          `json:"policy_id"`
+	PolicyID       string          `json:"policy_id"`
 	Type           string          `json:"type"`
 	EnrolledAt     string          `json:"enrolled_at"`
 	UserMeta       json.RawMessage `json:"user_provided_metadata"`
 	LocalMeta      json.RawMessage `json:"local_metadata"`
 	Actions        []interface{}   `json:"actions"`
-	AccessApiKeyId string          `json:"access_api_key_id"`
+	AccessAPIKeyID string          `json:"access_api_key_id"`
 	AccessAPIKey   string          `json:"access_api_key"`
 	Status         string          `json:"status"`
 }
@@ -131,10 +132,10 @@ func (a *AckResponse) SetError(pos int, err error) {
 }
 
 type ActionResp struct {
-	AgentId   string      `json:"agent_id"`
+	AgentID   string      `json:"agent_id"`
 	CreatedAt string      `json:"created_at"`
 	Data      interface{} `json:"data"`
-	Id        string      `json:"id"`
+	ID        string      `json:"id"`
 	Type      string      `json:"type"`
 	InputType string      `json:"input_type"`
 	Timeout   int64       `json:"timeout,omitempty"`
@@ -143,11 +144,11 @@ type ActionResp struct {
 type Event struct {
 	Type            string          `json:"type"`
 	SubType         string          `json:"subtype"`
-	AgentId         string          `json:"agent_id"`
-	ActionId        string          `json:"action_id"`
+	AgentID         string          `json:"agent_id"`
+	ActionID        string          `json:"action_id"`
 	ActionInputType string          `json:"action_input_type"`
-	PolicyId        string          `json:"policy_id"`
-	StreamId        string          `json:"stream_id"`
+	PolicyID        string          `json:"policy_id"`
+	StreamID        string          `json:"stream_id"`
 	Timestamp       string          `json:"timestamp"`
 	Message         string          `json:"message"`
 	Payload         json.RawMessage `json:"payload,omitempty"`

--- a/internal/pkg/api/schema.go
+++ b/internal/pkg/api/schema.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package fleet
+package api
 
 import (
 	"encoding/json"

--- a/internal/pkg/api/server.go
+++ b/internal/pkg/api/server.go
@@ -39,7 +39,7 @@ func diagConn(c net.Conn, s http.ConnState) {
 	}
 }
 
-// Run runst the passed router with the config.
+// Run runs the passed router with the config.
 func Run(ctx context.Context, router http.Handler, cfg *config.Server) error {
 	listeners := cfg.BindEndpoints()
 	rdto := cfg.Timeouts.Read

--- a/internal/pkg/api/server.go
+++ b/internal/pkg/api/server.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package fleet
+package api
 
 import (
 	"context"
@@ -38,7 +38,8 @@ func diagConn(c net.Conn, s http.ConnState) {
 	}
 }
 
-func runServer(ctx context.Context, router http.Handler, cfg *config.Server) error {
+// Run runst the passed router with the config.
+func Run(ctx context.Context, router http.Handler, cfg *config.Server) error {
 	listeners := cfg.BindEndpoints()
 	rdto := cfg.Timeouts.Read
 	wrto := cfg.Timeouts.Write

--- a/internal/pkg/api/server.go
+++ b/internal/pkg/api/server.go
@@ -132,7 +132,7 @@ func Run(ctx context.Context, router http.Handler, cfg *config.Server) error {
 		log.Debug().Msgf("Listening on %s", addr)
 
 		go func(_ context.Context, errChan chan error, ln net.Listener) {
-			if err := server.Serve(ln); err != nil && errors.Is(err, http.ErrServerClosed) {
+			if err := server.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 				errChan <- err
 			}
 		}(cancelCtx, errChan, ln)
@@ -141,7 +141,7 @@ func Run(ctx context.Context, router http.Handler, cfg *config.Server) error {
 
 	select {
 	case err := <-errChan:
-		if errors.Is(err, context.Canceled) {
+		if !errors.Is(err, context.Canceled) {
 			return err
 		}
 	case <-cancelCtx.Done():

--- a/internal/pkg/api/server_integration_test.go
+++ b/internal/pkg/api/server_integration_test.go
@@ -5,7 +5,7 @@
 //go:build integration
 // +build integration
 
-package fleet
+package api
 
 import (
 	"bytes"

--- a/internal/pkg/api/server_test.go
+++ b/internal/pkg/api/server_test.go
@@ -67,7 +67,7 @@ func TestRun(t *testing.T) {
 	cancel()
 	wg.Wait()
 	require.NoError(t, errFromChan)
-	if errors.Is(err, http.ErrServerClosed) {
+	if !errors.Is(err, http.ErrServerClosed) {
 		require.NoError(t, err)
 	}
 }

--- a/internal/pkg/api/server_test.go
+++ b/internal/pkg/api/server_test.go
@@ -9,6 +9,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"sync"
 	"testing"
@@ -66,7 +67,7 @@ func TestRun(t *testing.T) {
 	cancel()
 	wg.Wait()
 	require.NoError(t, errFromChan)
-	if err != http.ErrServerClosed {
+	if errors.Is(err, http.ErrServerClosed) {
 		require.NoError(t, err)
 	}
 }

--- a/internal/pkg/api/server_test.go
+++ b/internal/pkg/api/server_test.go
@@ -5,7 +5,7 @@
 //go:build !integration
 // +build !integration
 
-package fleet
+package api
 
 import (
 	"context"
@@ -25,7 +25,7 @@ import (
 	ftesting "github.com/elastic/fleet-server/v7/internal/pkg/testing"
 )
 
-func TestRunServer(t *testing.T) {
+func TestRun(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -53,7 +53,7 @@ func TestRunServer(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		err = runServer(ctx, router, cfg)
+		err = Run(ctx, router, cfg)
 		wg.Done()
 	}()
 	var errFromChan error

--- a/internal/pkg/api/userAgent.go
+++ b/internal/pkg/api/userAgent.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package fleet
+package api
 
 import (
 	"errors"
@@ -28,9 +28,9 @@ var (
 	ErrUnsupportedVersion = errors.New("version is not supported")
 )
 
-// buildVersionConstraint turns the version into a constraint to ensure that the connecting Elastic Agent's are
+// BuildVersionConstraint turns the version into a constraint to ensure that the connecting Elastic Agent's are
 // a supported version.
-func buildVersionConstraint(verStr string) (version.Constraints, error) {
+func BuildVersionConstraint(verStr string) (version.Constraints, error) {
 	ver, err := version.NewVersion(verStr)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/api/userAgent_test.go
+++ b/internal/pkg/api/userAgent_test.go
@@ -5,7 +5,7 @@
 //go:build !integration
 // +build !integration
 
-package fleet
+package api
 
 import (
 	"net/http/httptest"
@@ -125,7 +125,7 @@ func TestValidateUserAgent(t *testing.T) {
 }
 
 func mustBuildConstraints(verStr string) version.Constraints {
-	con, err := buildVersionConstraint(verStr)
+	con, err := BuildVersionConstraint(verStr)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/pkg/api/userAgent_test.go
+++ b/internal/pkg/api/userAgent_test.go
@@ -8,6 +8,7 @@
 package api
 
 import (
+	"errors"
 	"net/http/httptest"
 	"testing"
 
@@ -117,7 +118,7 @@ func TestValidateUserAgent(t *testing.T) {
 			req := httptest.NewRequest("GET", "/", nil)
 			req.Header.Set("User-Agent", tr.userAgent)
 			_, res := validateUserAgent(log.Logger, req, tr.verCon)
-			if tr.err != res {
+			if errors.Is(tr.err, res) {
 				t.Fatalf("err mismatch: %v != %v", tr.err, res)
 			}
 		})

--- a/internal/pkg/api/userAgent_test.go
+++ b/internal/pkg/api/userAgent_test.go
@@ -118,7 +118,7 @@ func TestValidateUserAgent(t *testing.T) {
 			req := httptest.NewRequest("GET", "/", nil)
 			req.Header.Set("User-Agent", tr.userAgent)
 			_, res := validateUserAgent(log.Logger, req, tr.verCon)
-			if errors.Is(tr.err, res) {
+			if !errors.Is(tr.err, res) {
 				t.Fatalf("err mismatch: %v != %v", tr.err, res)
 			}
 		})

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -6,6 +6,8 @@ package build
 
 import "time"
 
+const ServiceName = "fleet-server"
+
 type Info struct {
 	Version, Commit string
 	BuildTime       time.Time


### PR DESCRIPTION
## What is the problem this PR solves?

Start refactoring cmd so api server code is in internal/pkg/api.

## How does this PR solve the problem?

This makes it a bit clearer where to find API related code when developing the fleet-server.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.