### PR TITLE
Remove backport-skip automation

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -118,22 +118,6 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: notify the backport policy
-    conditions:
-      - -label~=^backport
-      - base=main
-    actions:
-      comment:
-        message: |
-          This pull request does not have a backport label. Could you fix it @{{author}}? 🙏
-          To fixup this pull request, you need to add the backport labels for the needed
-          branches, such as:
-          * `backport-v/d./d./d` is the label to automatically backport to the `7./d` branch. `/d` is the digit
-
-          **NOTE**: `backport-skip` has been added to this pull request.
-      label:
-        add:
-          - backport-skip
   - name: remove backport-skip label
     conditions:
       - label~=backport-v


### PR DESCRIPTION
Since we shipped 8.0, by default not backports are needed anymore. Because of this the default request to add a backport label is removed.
