### PR TITLE
ci: use downstream pattern

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -124,6 +124,18 @@ pipeline {
         }
       }
     }
+    stage('Downstream - Package') {
+      options { skipDefaultCheckout() }
+      when {
+        not { changeRequest() }
+      }
+      steps {
+        build(job: "Ingest-manager/fleet-server-package-mbp/${env.JOB_BASE_NAME}",
+              propagate: false,
+              wait: false,
+              parameters: [string(name: 'COMMIT', value: "${env.GIT_BASE_COMMIT}")])
+      }
+    }
   }
   post {
     cleanup {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -13,6 +13,8 @@ pipeline {
     DOCKER_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
     DRA_OUTPUT = 'release-manager.out'
+    COMMIT = "${params?.COMMIT}"
+    JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
   }
   options {
     timeout(time: 2, unit: 'HOURS')
@@ -24,9 +26,8 @@ pipeline {
     rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
     quietPeriod(10)
   }
-  triggers {
-    // disable upstream trigger on a PR basis
-    upstream("Ingest-manager/fleet-server/${ env.JOB_BASE_NAME.startsWith('PR-') ? 'none' : env.JOB_BASE_NAME }")
+  parameters {
+    string(name: 'COMMIT', defaultValue: '', description: 'The Git commit to be used (empty will checkout the latest commit)')
   }
   stages {
     stage('Filter build') {
@@ -58,9 +59,8 @@ pipeline {
           steps {
             pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
             deleteDir()
-            gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: false,
-                        shallow: false, reference: "/var/lib/jenkins/.git-references/${REPO}.git")
-            stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+            smartGitCheckout()
+            stash(allowEmpty: true, name: 'source', useDefaultExcludes: false)
             setEnvVar('IS_BRANCH_AVAILABLE', isBranchUnifiedReleaseAvailable(env.BRANCH_NAME))
             dir("${BASE_DIR}") {
               setEnvVar('VERSION', sh(label: 'Get version', script: 'make get-version', returnStdout: true)?.trim())
@@ -113,7 +113,6 @@ pipeline {
             }
           }
         }
-
         stage('DRA Snapshot') {
           options { skipDefaultCheckout() }
           // The Unified Release process keeps moving branches as soon as a new
@@ -248,5 +247,20 @@ def runIfNoMainAndNoStaging(Closure body) {
     echo 'INFO: staging artifacts for the main branch are not required.'
   } else {
     body()
+  }
+}
+
+def smartGitCheckout() {
+  // Checkout the given commit
+  if (env.COMMIT?.trim()) {
+    gitCheckout(basedir: "${BASE_DIR}",
+                branch: "${env.COMMIT}",
+                credentialsId: "${JOB_GIT_CREDENTIALS}",
+                repo: "https://github.com/elastic/${REPO}.git")
+  } else {
+    gitCheckout(basedir: "${BASE_DIR}",
+                githubNotifyFirstTimeContributor: false,
+                shallow: false,
+                reference: "/var/lib/jenkins/.git-references/${REPO}.git")
   }
 }


### PR DESCRIPTION
## Motivation/summary

Use the downstream pattern to run the packaging pipeline and then pass over the Git commit to be used.

The parentstream pattern does not support the Git commit approach by default and therefore it requires further changes to accomplish the same.

## How to test these changes

In the CI.

## Further context

When the `packaging` pipeline runs there is a chance that a new commit has been pushed to the `main` branch before the `packaging` has even get triggered, therefore the `packaging` pipeline will run but it will not use the original commit.

While using the downtream pattern, then we can orchestrate what builds to run from the `main pipeline` and the pass the sha commit to those jobs. 


## Issue

Similar to https://github.com/elastic/apm-server/pull/7982