### PR TITLE
jjbb: suppress-scm-triggering

### DIFF
--- a/.ci/jobs/fleet-server-package-mbp.yml
+++ b/.ci/jobs/fleet-server-package-mbp.yml
@@ -21,6 +21,9 @@
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
         ssh-checkout:
           credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+        property-strategies:
+          all-branches:
+          - suppress-scm-triggering: true
         build-strategies:
         - skip-initial-build: true
         - named-branches:


### PR DESCRIPTION
use the downstream pattern as stated in https://github.com/elastic/fleet-server/pull/1439