### PR TITLE
ci: use post-builds for reporting only

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -112,14 +112,8 @@ pipeline {
             withGoEnv(){
               sh(label: 'Create release artifacts', script: 'make docker-release')
               uploadPackagesToGoogleBucket(pattern: 'build/distributions/')
+              sh(label: 'Check release artifacts', script: 'make test-release')
             }
-          }
-        }
-      }
-      post {
-        success {
-          dir("${BASE_DIR}"){
-            sh(label: 'Check release artifacts', script: 'make test-release')
           }
         }
       }


### PR DESCRIPTION
## What is the problem this PR solves?

Cosmetic change so the post-builds step do only reporting.
