### PR TITLE
ci: deploy Package Registry

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -118,6 +118,21 @@ pipeline {
         }
       }
     }
+    stage('Deploy - Package Registry') {
+      options { skipDefaultCheckout() }
+      when { expression { isTag() }
+      steps {
+        build(job: "deploy-package-registry",
+              propagate: false,
+              wait: false,
+              parameters: [
+                string(name: 'BUILD_VERSION', value: "${env.GIT_BASE_COMMIT}"),
+                string(name: 'BUILD_BRANCH', value: "${env.TAG_NAME}"),
+                string(name: 'PUSH_IMAGES', value: "true")
+              ]
+            )
+      }
+    }
     stage('Downstream - Package') {
       options { skipDefaultCheckout() }
       when {


### PR DESCRIPTION
### What

Deploy the package registry when a tag release has been created


### Why

Ensure the versioning matches with the release cycle.

Fleet Server is the potential repository that supports the Daily Releasable Artifacts stage for 7.17 and 8.x therefore we can use the tag discovery approach to trigger the job in charge to deploy the package registry

