### PR TITLE
codeowners: grant auto-merge for auto-bumps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # Team responsable for Fleet Server
 * @elastic/elastic-agent-control-plane
+
+# Allow to auto-merge PRs with Mergify
+dev-tools/integration/.env


### PR DESCRIPTION
### What

Allow auto-merge PRs targetting ``dev-tools/integration/.env


### Why

The auto-bump is not anymore auto-merge with the existing CODEOWNERS policy.


### Issue

See https://github.com/elastic/fleet-server/issues/1472