### PR TITLE
ci: enable build notifications as GitHub issues

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -150,7 +150,9 @@ pipeline {
   }
   post {
     cleanup {
-      notifyBuildResult(prComment: true)
+      notifyBuildResult(prComment: true,
+                        githubIssue: isBranch() && currentBuild.currentResult != "SUCCESS",
+                        githubLabels: 'Team:Elastic-Agent-Data-Plane')
     }
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -152,7 +152,7 @@ pipeline {
     cleanup {
       notifyBuildResult(prComment: true,
                         githubIssue: isBranch() && currentBuild.currentResult != "SUCCESS",
-                        githubLabels: 'Team:Elastic-Agent-Data-Plane')
+                        githubLabels: 'Team:Elastic-Agent-Control-Plane')
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Create a GitHub issue:
* As soon as a build is failing an issue should be created
* It should be assigned to Elastic Agent Data Plane team (it relies on the GitHub labels to do so)

## Why is it important?

Use GitHub to drive the on-call process when the CI fails


## Related issues

Similar to https://github.com/elastic/beats/pull/31954