### PR TITLE
ci: enable flaky test detector

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -148,9 +148,12 @@ pipeline {
       }
     }
   }
+
+
   post {
     cleanup {
       notifyBuildResult(prComment: true,
+                        analyzeFlakey: !isTag(), jobName: getFlakyJobName(withBranch: (isPR() ? env.CHANGE_TARGET : env.BRANCH_NAME)),
                         githubIssue: isBranch() && currentBuild.currentResult != "SUCCESS",
                         githubLabels: 'Team:Elastic-Agent-Control-Plane')
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -148,8 +148,6 @@ pipeline {
       }
     }
   }
-
-
   post {
     cleanup {
       notifyBuildResult(prComment: true,


### PR DESCRIPTION
## What does this PR do?

Enable `test-flakiness` detection

## Why is it important?

Track `test-flakiness` help to monitor how often a particular test failure happens and has been categorised as flaky.

This is similar done for Beats -> https://github.com/elastic/beats/issues?q=is%3Aissue+is%3Aopen+label%3Aflaky-test