### PR TITLE
mergify: remove backport automation for non active branches

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -33,35 +33,6 @@ pull_request_rules:
         message: |
           This pull request has been automatically closed by Mergify.
           There are some other up-to-date pull requests.
-
-  - name: backport patches to 8.0 branch
-    conditions:
-      - merged
-      - base=main
-      - label=backport-v8.0.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.0"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to 8.1 branch
-    conditions:
-      - merged
-      - base=main
-      - label=backport-v8.1.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.1"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.2 branch
     conditions:
       - merged
@@ -101,34 +72,6 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "7.17"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to 7.16 branch
-    conditions:
-      - merged
-      - base=main
-      - label=backport-v7.16.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "7.16"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to 7.15 branch
-    conditions:
-      - merged
-      - base=main
-      - label=backport-v7.15.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "7.15"
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"


### PR DESCRIPTION
## What does this PR do?

Support only active release branches.

## Why is it important?

Avoid backports to non-active releases

## Issue

Similar to https://github.com/elastic/beats/pull/32092