### PR TITLE
Bugfix: Avoid panic when check-in setup duration is longer than poll …

### DIFF
--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -566,7 +566,7 @@ func calcPollDuration(zlog zerolog.Logger, cfg *config.Server, setupDuration tim
 
 	if setupDuration >= pollDuration {
 		// We took so long to setup that we need to exit immediately
-		pollDuration = 0
+		pollDuration = time.Millisecond
 		zlog.Warn().
 			Dur("setupDuration", setupDuration).
 			Dur("pollDuration", cfg.Timeouts.CheckinLongPoll).


### PR DESCRIPTION
…duration

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

HTTP handler panics if the setup duration, ie. the time time it takes to communicate with Elastic is longer than the poll time.  This is a very edgy case; only happens when Elastic and/or the Fleet Server is under extreme load.

// Please do not just reference an issue. Explain WHAT the problem this PR solves here.

## How does this PR solve the problem?

// Explain HOW you solved the problem in your code. It is possible that during PR reviews this changes and then this section should be updated.

Zero duration is illegal for time.NewTimer().  Replace with time.Milllisecond.

