### PR TITLE
On Fleet Server reboot gives a grace period

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -1,6 +1,7 @@
 ==== Bugfixes
 
 - Return a better error on enrolling and the Elasticsearch version is incompatible. {pull}1211[1211]
+- Give a grace period when starting the unenroll monitor. {issue}1500[1500]
 
 ==== New Features
 

--- a/internal/pkg/coordinator/monitor.go
+++ b/internal/pkg/coordinator/monitor.go
@@ -453,6 +453,23 @@ func runCoordinatorOutput(ctx context.Context, cord Coordinator, bulker bulk.Bul
 }
 
 func runUnenroller(ctx context.Context, bulker bulk.Bulk, policyID string, unenrollTimeout time.Duration, l zerolog.Logger, checkInterval time.Duration, agentsIndex string) {
+	// When fleet-server is offline for a long period and finally recover, it means that the connected
+	// agent will be offline for a long period of time since their last checkin and fleet server will
+	// start unenrolling every Elastic Agent from the system. Instead on boot the Elastic Agent
+	// should wait at least the unenrolltimeout period before actively unenrolling agents in the system.
+	// This give a grace period to the Elastic Agent to connect back to the system.
+	l.Info().
+		Dur("checkInterval", checkInterval).
+		Dur("unenrollTimeout", unenrollTimeout).
+		Msg("giving a grace period to Elastic Agent before enforcing unenrollTimeout monitor")
+
+	select {
+	case <-time.After(unenrollTimeout):
+		// skip to the next loop.
+	case <-ctx.Done():
+		return
+	}
+
 	l.Info().
 		Dur("checkInterval", checkInterval).
 		Dur("unenrollTimeout", unenrollTimeout).

--- a/internal/pkg/coordinator/monitor_integration_test.go
+++ b/internal/pkg/coordinator/monitor_integration_test.go
@@ -147,7 +147,7 @@ func TestMonitorUnenroller(t *testing.T) {
 		CoordinatorIdx:  0,
 		Data:            []byte("{}"),
 		RevisionIdx:     1,
-		UnenrollTimeout: 300, // 5 minutes (300 seconds)
+		UnenrollTimeout: 5,
 	}
 	_, err = dl.CreatePolicy(ctx, bulker, policy1, dl.WithIndexName(policiesIndex))
 	require.NoError(t, err)
@@ -213,7 +213,7 @@ func TestMonitorUnenroller(t *testing.T) {
 			return fmt.Errorf("agent %s is still active", agentID)
 		}
 		return nil
-	}, ftesting.RetrySleep(100*time.Millisecond), ftesting.RetryCount(50))
+	}, ftesting.RetrySleep(5*time.Second), ftesting.RetryCount(50))
 
 	// stop the monitors
 	cn()


### PR DESCRIPTION
When Fleet Server is offline for a period bigger or equal to the
unenrollTimeout, on reboot the Server will start to automatically
unenroll Elastic Agent without giving them a chance to communicate with
the system. Instead on reboot we will give a grace period equivalent to
the unenrollTimeout this will give enough time to the Elastic Agent to
communicate back to Fleet Server and update their last checkin time.

Fixes: #1500

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

// Please do not just reference an issue. Explain WHAT the problem this PR solves here.

## How does this PR solve the problem?

// Explain HOW you solved the problem in your code. It is possible that during PR reviews this changes and then this section should be updated.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->