### PR TITLE
Improve default error handling

### DIFF
--- a/internal/pkg/api/error.go
+++ b/internal/pkg/api/error.go
@@ -7,6 +7,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -159,8 +160,8 @@ func NewHTTPErrResp(err error) HTTPErrResp {
 
 	// Default
 	return HTTPErrResp{
-		StatusCode: http.StatusBadRequest,
-		Error:      "BadRequest",
+		StatusCode: http.StatusInternalServerError,
+		Error:      fmt.Sprintf("Unexpected error: %s", err.Error()),
 		Level:      zerolog.InfoLevel,
 	}
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

We often see errors like this in SDHs without any helpful information to go on:

```
Error: fail to enroll: fail to execute request to fleet-server: status code: 400, fleet-server returned an error: BadRequest
```

## How does this PR solve the problem?

This adds the underlying error message to the HTTP response so that we can better diagnose what the issue is. This is important in cases where Fleet Server logs may not be collected correctly, but the Agent that makes an enrollment request to Fleet Server will log the response.

This also changes the status code to be a 500 if the error is unknown or unexpected which is more accurate than a 400 error.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->