### PR TITLE
Add `server.instrumentation.global_labels` option

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -918,6 +918,7 @@ func (f *FleetServer) initTracer(cfg config.Instrumentation) (*apm.Tracer, error
 		envVerifyServerCert = "ELASTIC_APM_VERIFY_SERVER_CERT"
 		envServerCert       = "ELASTIC_APM_SERVER_CERT"
 		envCACert           = "ELASTIC_APM_SERVER_CA_CERT_FILE"
+		envGlobalLabels     = "ELASTIC_APM_GLOBAL_LABELS"
 	)
 	if cfg.TLS.SkipVerify {
 		os.Setenv(envVerifyServerCert, "false")
@@ -930,6 +931,10 @@ func (f *FleetServer) initTracer(cfg config.Instrumentation) (*apm.Tracer, error
 	if cfg.TLS.ServerCA != "" {
 		os.Setenv(envCACert, cfg.TLS.ServerCA)
 		defer os.Unsetenv(envCACert)
+	}
+	if cfg.GlobalLabels != "" {
+		os.Setenv(envGlobalLabels, cfg.GlobalLabels)
+		defer os.Unsetenv(envGlobalLabels)
 	}
 	transport, err := apmtransport.NewHTTPTransport()
 	if err != nil {

--- a/internal/pkg/config/instrumentation.go
+++ b/internal/pkg/config/instrumentation.go
@@ -6,12 +6,13 @@ package config
 
 // Instrumentation configures APM Tracing for the `fleet-server`.
 type Instrumentation struct {
-	TLS         InstrumentationTLS `config:"tls"`
-	Environment string             `config:"environment"`
-	APIKey      string             `config:"api_key"`
-	SecretToken string             `config:"secret_token"`
-	Hosts       []string           `config:"hosts"`
-	Enabled     bool               `config:"enabled"`
+	TLS          InstrumentationTLS `config:"tls"`
+	Environment  string             `config:"environment"`
+	APIKey       string             `config:"api_key"`
+	SecretToken  string             `config:"secret_token"`
+	Hosts        []string           `config:"hosts"`
+	Enabled      bool               `config:"enabled"`
+	GlobalLabels string             `config:"global_labels"`
 }
 
 type InstrumentationTLS struct {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

Allows setting `server.instrumentation.global_labels` to something like `testrun=X` to configure APM labels on every transaction and span from an instance. Useful for using APM instrumentation to debug scale tests.

## How does this PR solve the problem?

Expands on https://github.com/elastic/fleet-server/pull/898

## How to test this PR locally

Same as https://github.com/elastic/fleet-server/pull/898

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.