### PR TITLE
ci: run packaging by default on branches only

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -137,9 +137,7 @@ pipeline {
     }
     stage('Downstream - Package') {
       options { skipDefaultCheckout() }
-      when {
-        not { changeRequest() }
-      }
+      when { expression { isBranch() } }
       steps {
         build(job: "Ingest-manager/fleet-server-package-mbp/${env.JOB_BASE_NAME}",
               propagate: false,

--- a/.ci/jobs/fleet-server-package-mbp.yml
+++ b/.ci/jobs/fleet-server-package-mbp.yml
@@ -14,7 +14,7 @@
         discover-pr-origin: merge-current
         discover-tags: false
         disable-pr-notifications: true
-        head-filter-regex: '(main|7\.17|8\.\d+|PR-.*|v\d+\.\d+\.\d+)'
+        head-filter-regex: '(main|7\.17|8\.\d+|PR-.*)'
         notification-context: 'fleet-server-package'
         repo: fleet-server
         repo-owner: elastic

--- a/.ci/jobs/fleet-server-package-mbp.yml
+++ b/.ci/jobs/fleet-server-package-mbp.yml
@@ -14,7 +14,7 @@
         discover-pr-origin: merge-current
         discover-tags: false
         disable-pr-notifications: true
-        head-filter-regex: '(main|7\.17|8\.\d+|PR-.*)'
+        head-filter-regex: '(main|7\.17|8\.\d+|PR-.*|v\d+\.\d+\.\d+)'
         notification-context: 'fleet-server-package'
         repo: fleet-server
         repo-owner: elastic


### PR DESCRIPTION
## What is the problem this PR solves?

Otherwise it won't be available for tags and will report failures since the packaging does not discover tags

There is no need, to run on tags since the tags are coming from the official releases, so we can save build time