### PR TITLE
Protect access to policiesCanceller using a mutext

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -2,6 +2,7 @@
 
 - Return a better error on enrolling and the Elasticsearch version is incompatible. {pull}1211[1211]
 - Give a grace period when starting the unenroll monitor. {issue}1500[1500]
+- Fixes a race condition between the unenroller goroutine and the main goroutine for the coordinator monitor. {issues}1738[1738]
 
 ==== New Features
 

--- a/internal/pkg/bulk/bulk_test.go
+++ b/internal/pkg/bulk/bulk_test.go
@@ -251,9 +251,10 @@ func TestCancelCtx(t *testing.T) {
 		},
 	}
 
+	_ = testlog.SetLogger(t)
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_ = testlog.SetLogger(t)
 			ctx, cancelF := context.WithCancel(context.Background())
 
 			var wg sync.WaitGroup

--- a/internal/pkg/coordinator/monitor.go
+++ b/internal/pkg/coordinator/monitor.go
@@ -74,8 +74,10 @@ type monitorT struct {
 	leadersIndex  string
 	agentsIndex   string
 
-	policies          map[string]policyT
-	policiesCanceller map[string]context.CancelFunc
+	policies map[string]policyT
+
+	muPoliciesCanceller sync.Mutex
+	policiesCanceller   map[string]context.CancelFunc
 }
 
 // NewMonitor creates a new coordinator policy monitor.
@@ -311,7 +313,10 @@ func (m *monitorT) ensureLeadership(ctx context.Context) error {
 		if r.cord == nil {
 			// either failed to take leadership or lost leadership
 			delete(m.policies, r.id)
+
+			m.muPoliciesCanceller.Lock()
 			delete(m.policiesCanceller, r.id)
+			m.muPoliciesCanceller.Unlock()
 		} else {
 			m.policies[r.id] = r
 		}
@@ -396,6 +401,9 @@ func (m *monitorT) getIPs() ([]string, error) {
 }
 
 func (m *monitorT) rescheduleUnenroller(ctx context.Context, pt *policyT, p *model.Policy) {
+	m.muPoliciesCanceller.Lock()
+	defer m.muPoliciesCanceller.Unlock()
+
 	u := uuid.Must(uuid.NewV4())
 	l := m.log.With().Str(dl.FieldPolicyID, pt.id).Str("unenroller_uuid", u.String()).Logger()
 	unenrollTimeout := time.Duration(p.UnenrollTimeout) * time.Second

--- a/internal/pkg/coordinator/monitor.go
+++ b/internal/pkg/coordinator/monitor.go
@@ -426,6 +426,13 @@ func (m *monitorT) rescheduleUnenroller(ctx context.Context, pt *policyT, p *mod
 	}
 }
 
+func (m *monitorT) ActivePoliciesCancellerCount() int {
+	m.muPoliciesCanceller.Lock()
+	defer m.muPoliciesCanceller.Unlock()
+
+	return len(m.policiesCanceller)
+}
+
 func runCoordinator(ctx context.Context, cord Coordinator, l zerolog.Logger, d time.Duration) {
 	cnt := 0
 	for {

--- a/internal/pkg/coordinator/monitor_integration_test.go
+++ b/internal/pkg/coordinator/monitor_integration_test.go
@@ -226,7 +226,7 @@ func TestMonitorUnenroller(t *testing.T) {
 	assert.NotEmpty(t, agent.UnenrolledAt)
 	assert.Equal(t, unenrolledReasonTimeout, agent.UnenrolledReason)
 	assert.Len(t, pm.(*monitorT).policies, 1)
-	assert.Len(t, pm.(*monitorT).policiesCanceller, 1)
+	assert.Equal(t, pm.(*monitorT).ActivePoliciesCancellerCount(), 1)
 
 	// should error as they are now invalidated
 	_, err = bulker.APIKeyAuth(bulkCtx, *accessKey)
@@ -347,7 +347,7 @@ func TestMonitorUnenrollerSetAndClear(t *testing.T) {
 	assert.True(t, agent.Active)
 	// Make sure canceller is no longer there
 	assert.Len(t, pm.(*monitorT).policies, 1)
-	assert.Len(t, pm.(*monitorT).policiesCanceller, 0)
+	assert.Equal(t, pm.(*monitorT).ActivePoliciesCancellerCount(), 0)
 
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

There were a race condition possible with between the enrolling goroutine and the main coordinator routine. I've added a mutex to protect the access of the `policiesCanceller` and audited the remaining part of the code. Everything else are executed in the same goroutine (via channel's select) so the `policies` field is unaffected. But, I think the code would benefit to be `cleanup` and the _policies_ and the _policiesCanceller_  field to be consolidated in a single field AND moving the manipulation the values either using channel or via methods on the struct. I've initially looked to refactor the code, but I would clearly have taking more time. Looking a the panic described in #1738 the critical field field would be the _policiesCanceller_.




## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #1738
- Relates #1739