### PR TITLE
Start on week POC to get fleet-agent running correctly in standalone

### DIFF
--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -163,10 +163,10 @@ func (ct *CheckinT) handleCheckin(zlog *zerolog.Logger, w http.ResponseWriter, r
 	dfunc := cntCheckin.IncStart()
 	defer dfunc()
 
-	return ct.processRequest(*zlog, w, r, start, agent, newVer)
+	return ct.ProcessRequest(*zlog, w, r, start, agent, newVer)
 }
 
-func (ct *CheckinT) processRequest(zlog zerolog.Logger, w http.ResponseWriter, r *http.Request, start time.Time, agent *model.Agent, ver string) error {
+func (ct *CheckinT) ProcessRequest(zlog zerolog.Logger, w http.ResponseWriter, r *http.Request, start time.Time, agent *model.Agent, ver string) error {
 
 	ctx := r.Context()
 

--- a/internal/pkg/policy/self.go
+++ b/internal/pkg/policy/self.go
@@ -35,6 +35,8 @@ type SelfMonitor interface {
 	Run(ctx context.Context) error
 	// Status gets current status of monitor.
 	Status() proto.StateObserved_Status
+	// Policy returns the policy retrieved from the self monitor
+	Policy() *model.Policy
 }
 
 type selfMonitorT struct {
@@ -136,6 +138,12 @@ func (m *selfMonitorT) Status() proto.StateObserved_Status {
 	m.mut.Lock()
 	defer m.mut.Unlock()
 	return m.status
+}
+
+func (m *selfMonitorT) Policy() *model.Policy {
+	m.mut.Lock()
+	defer m.mut.Unlock()
+	return m.policy
 }
 
 func (m *selfMonitorT) waitStart(ctx context.Context) error { //nolint:unused // not sure if this is used in tests


### PR DESCRIPTION
Allow an server not running under the agent to enroll and check itself
in periodically.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

// Please do not just reference an issue. Explain WHAT the problem this PR solves here.

## How does this PR solve the problem?

// Explain HOW you solved the problem in your code. It is possible that during PR reviews this changes and then this section should be updated.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->