### PR TITLE
using percolator query to fetch actions

### DIFF
--- a/internal/pkg/api/handleAck.go
+++ b/internal/pkg/api/handleAck.go
@@ -29,6 +29,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"go.elastic.co/apm"
 )
 
 type HTTPError struct {
@@ -220,6 +221,13 @@ func (ack *AckT) handleAckEvents(ctx context.Context, zlog zerolog.Logger, agent
 			Int("n", n).Logger()
 
 		log.Info().Msg("ack event")
+
+		span, ctx := apm.StartSpan(ctx, "ack agent actions", "ack")
+		defer span.End()
+
+		span.Context.SetLabel("actionType", ev.Type)
+		span.Context.SetLabel("actionID", ev.ActionID)
+		span.Context.SetLabel("agentID", ev.AgentID)
 
 		// Check agent id mismatch
 		if ev.AgentID != "" && ev.AgentID != agent.Id {


### PR DESCRIPTION
https://github.com/elastic/ingest-dev/issues/1165

Spacetime project to use percolator queries to register agent bulk actions by query.
Kibana side changes are here: https://github.com/elastic/kibana/pull/139930

Percolator query takes most of the time <10ms, tested with 1000 agents and 10 docs in percolator index.
Querying agent actions takes ~250ms on every check in (existing functionality)
Added a second agent actions query for this POC, that is why "find agent actions" takes now ~500ms, this can be optimized back to one query.

<img width="1458" alt="image" src="https://user-images.githubusercontent.com/90178898/187942502-a5db15c6-e3c2-464d-9ffb-c5fc868f5abc.png">

<img width="1565" alt="image" src="https://user-images.githubusercontent.com/90178898/187943182-a6ed8267-072f-462f-a437-a8b576eef392.png">

