### PR TITLE
Fix path to the packaging

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -139,7 +139,7 @@ pipeline {
       options { skipDefaultCheckout() }
       when { expression { isBranch() } }
       steps {
-        build(job: "Ingest-manager/fleet-server-package-mbp/${env.JOB_BASE_NAME}",
+        build(job: "fleet-server/fleet-server-package-mbp/${env.JOB_BASE_NAME}",
               propagate: false,
               wait: false,
               parameters: [string(name: 'COMMIT', value: "${env.GIT_BASE_COMMIT}")])


### PR DESCRIPTION
Caused by the migration to fleet-ci

https://fleet-ci.elastic.co/job/fleet-server/job/fleet-server-package-mbp/


Caused by https://github.com/elastic/fleet-server/pull/1199