### PR TITLE
ci: rename dra staging for release dra release staging 

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -133,7 +133,7 @@ pipeline {
             }
           }
         }
-        stage('DRA Staging (if no main)') {
+        stage('DRA Staging (release branches only)') {
           options { skipDefaultCheckout() }
           when {
             allOf {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -133,7 +133,7 @@ pipeline {
             }
           }
         }
-        stage('DRA Staging') {
+        stage('DRA Staging (if no main)') {
           options { skipDefaultCheckout() }
           when {
             allOf {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -133,7 +133,7 @@ pipeline {
             }
           }
         }
-        stage('DRA Staging (release branches only)') {
+        stage('DRA Release Staging') {
           options { skipDefaultCheckout() }
           when {
             allOf {


### PR DESCRIPTION
## What is the problem this PR solves?

Change stage name to reflect `DRA staging` is not available for `main`


## Why

DRA staging does not run for the `main` branch but the `release branches` (7.17, 8.4...)

<img width="256" alt="image" src="https://user-images.githubusercontent.com/2871786/189318438-a0a75b17-feca-4987-8fea-10e5a4244b25.png">



I manually triggered the [build](https://fleet-ci.elastic.co/blue/organizations/jenkins/fleet-server%2Ffleet-server-package-mbp/detail/PR-1840/3/pipeline/) for this PR, so the change is just the stage name.