### PR TITLE
Avoid mapping conflict on debug log

### DIFF
--- a/internal/pkg/api/handleAck.go
+++ b/internal/pkg/api/handleAck.go
@@ -333,9 +333,9 @@ func (ack *AckT) handlePolicyChange(ctx context.Context, zlog zerolog.Logger, ag
 			Str("agent.policyId", agent.PolicyID).
 			Int64("agent.revisionIdx", currRev).
 			Int64("agent.coordinatorIdx", currCoord).
-			Str("rev.policyId", rev.PolicyID).
-			Int64("rev.revisionIdx", rev.RevisionIdx).
-			Int64("rev.coordinatorIdx", rev.CoordinatorIdx).
+			Str("rev_policyId", rev.PolicyID).
+			Int64("rev_revisionIdx", rev.RevisionIdx).
+			Int64("rev_coordinatorIdx", rev.CoordinatorIdx).
 			Msg("ack policy revision")
 
 		if ok && rev.PolicyID == agent.PolicyID &&


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?
Fixes a minor bug when debugging logs were enabled resulting in dropped logs:

```
        "error": {
          "type": "mapper_parsing_exception",
          "reason": "failed to parse field [rev] of type [long] in document with id 'PVsnrKOYhCal1hE0hJotzUFoA9s='. Preview of field's value: '{policyId=981d1020-3028-11ed-893b-67610e46ff24}'",
          "caused_by": {
            "type": "illegal_argument_exception",
            "reason": "Cannot parse object as number"
          }
        }
```