### PR TITLE
Make authc log debug and add cache hit field

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -4,6 +4,7 @@
 - Give a grace period when starting the unenroll monitor. {issue}1500[1500]
 - Fixes a race condition between the unenroller goroutine and the main goroutine for the coordinator monitor. {issues}1738[1738]
 - Remove events from agent checkin body. {issue}1774[1774]
+- Improve authc debug logging. {pull}1870[1870]
 
 ==== New Features
 

--- a/internal/pkg/api/auth.go
+++ b/internal/pkg/api/auth.go
@@ -54,7 +54,6 @@ func authAPIKey(r *http.Request, bulker bulk.Bulk, c cache.Cache) (*apikey.APIKe
 		span.Context.SetLabel("api_key_cache_hit", false)
 	}
 
-
 	info, err := bulker.APIKeyAuth(ctx, *key)
 
 	if err != nil {


### PR DESCRIPTION
## What is the problem this PR solves?

This allows us to run a scale test with debug logging enabled (trace is not supported right now) and measure how long API key auth is taking, including cache hit rate.

## How does this PR solve the problem?

Updates the logging code

## How to test this PR locally

Enable debug logging, see the `ApiKey authenticated` logs.

## Checklist

- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

Closes #1125