### PR TITLE
Add Go 1.18 upgrade to breaking changes section

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -1,3 +1,7 @@
+==== Breaking Changes
+
+- Upgrade to Go 1.18. Certificates signed with SHA-1 are now rejected. See the Go 1.18 https://tip.golang.org/doc/go1.18#sha1[release notes] for details. {pull}1709[1709]
+
 ==== Bugfixes
 
 - Return a better error on enrolling and the Elasticsearch version is incompatible. {pull}1211[1211]


### PR DESCRIPTION
Go 1.18 breaks compatibility with SHA-1 signed certificates. Document this in the agent changelog. This is the same text we used for beats with the PR number updated.