### PR TITLE
Bump version to 8.6.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,4 +6,4 @@ package version
 
 // DefaultVersion is the current release version of Fleet-server, this version must match the
 // Elastic Agent version.
-const DefaultVersion = "8.5.0"
+const DefaultVersion = "8.6.0"


### PR DESCRIPTION
The 8.5.0 branch is created, bump the version on main to 8.6.0.

@v1v I think we can automate this for fleet server like we have for Beats (see https://github.com/elastic/beats/pull/33154).