### PR TITLE
Update apikey.cache_hit log field name to match convention

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -11,6 +11,7 @@
 - Improve authc debug logging. {pull}1870[1870]
 - Add error detail to catch-all HTTP error response. {pull}1854[1854]
 - Fix issue were errors where being ignored written to elasticsearch. {pull}1896[1896]
+- Update apikey.cache_hit log field name to match convention. {pull}1900[1900]
 
 ==== New Features
 

--- a/internal/pkg/api/auth.go
+++ b/internal/pkg/api/auth.go
@@ -47,7 +47,7 @@ func authAPIKey(r *http.Request, bulker bulk.Bulk, c cache.Cache) (*apikey.APIKe
 			Str("id", key.ID).
 			Str(ECSHTTPRequestID, reqID).
 			Int64(ECSEventDuration, time.Since(start).Nanoseconds()).
-			Bool("fleet.api_key.cache_hit", true).
+			Bool("fleet.apikey.cache_hit", true).
 			Msg("ApiKey authenticated")
 		return key, nil
 	} else {
@@ -74,7 +74,7 @@ func authAPIKey(r *http.Request, bulker bulk.Bulk, c cache.Cache) (*apikey.APIKe
 		Strs("roles", info.Roles).
 		Bool("enabled", info.Enabled).
 		RawJSON("meta", info.Metadata).
-		Bool("fleet.api_key.cache_hit", false).
+		Bool("fleet.apikey.cache_hit", false).
 		Msg("ApiKey authenticated")
 
 	c.SetAPIKey(*key, info.Enabled)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

As I was going about updating the fields that get mapped in our logs on Cloud, I noticed that the name of this recent log property that I added in https://github.com/elastic/fleet-server/pull/1870 does not match the `fleet.apikey.id` property we use elsewhere. Updated this to fix.

## How does this PR solve the problem?

Changes the field name to match
## Checklist

- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.