### PR TITLE
Improve migration logs on 8.5 branch

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -106,7 +106,7 @@ func initLogger(cfg *config.Config, version, commit string) (*logger.Logger, err
 		Str("exe", os.Args[0]).
 		Strs("args", os.Args[1:]).
 		Msg("Boot fleet-server")
-	log.Debug().Strs("env", os.Environ()).Msg("environment")
+	log.Debug().Strs("env", os.Environ()).Msg("environment variables")
 
 	return l, err
 }
@@ -832,7 +832,7 @@ func (f *FleetServer) runSubsystems(ctx context.Context, cfg *config.Config, g *
 		return dl.Migrate(ctx, bulker)
 	})
 	if err = loggedMigration(); err != nil {
-		return fmt.Errorf("failed to run subsystems: %w", err)
+		return fmt.Errorf("failed to run migrations: %w", err)
 	}
 
 	// Run scheduler for periodic GC/cleanup

--- a/internal/pkg/dl/migration.go
+++ b/internal/pkg/dl/migration.go
@@ -61,11 +61,16 @@ func migrate(ctx context.Context, bulker bulk.Bulk, fn migrationBodyFn) (int, er
 	for {
 		name, index, body, err := fn()
 		if err != nil {
-			return updatedDocs, fmt.Errorf(": %w", err)
+			return updatedDocs,
+				fmt.Errorf("failed to prepare request for migration %s: %w",
+					name, err)
 		}
 
 		resp, err := applyMigration(ctx, name, index, bulker, body)
 		if err != nil {
+			log.Err(err).
+				Bytes("http.request.body.content", body).
+				Msgf("migration %s failed: %w", name, err)
 			return updatedDocs, fmt.Errorf("failed to apply migration %q: %w",
 				name, err)
 		}

--- a/internal/pkg/dl/migration.go
+++ b/internal/pkg/dl/migration.go
@@ -70,7 +70,7 @@ func migrate(ctx context.Context, bulker bulk.Bulk, fn migrationBodyFn) (int, er
 		if err != nil {
 			log.Err(err).
 				Bytes("http.request.body.content", body).
-				Msgf("migration %s failed: %w", name, err)
+				Msgf("migration %s failed", name)
 			return updatedDocs, fmt.Errorf("failed to apply migration %q: %w",
 				name, err)
 		}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

The forward port of https://github.com/elastic/fleet-server/pull/1921, the https://github.com/elastic/fleet-server/pull/1926 PR, includes a few improvements on the log messages, this PR backports those improvements.

## How does this PR solve the problem?

By backporting the extra changes on the forwardport https://github.com/elastic/fleet-server/pull/1926

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
