### PR TITLE
Updated migration query to match items with deprecated field present

### DIFF
--- a/internal/pkg/dl/migration.go
+++ b/internal/pkg/dl/migration.go
@@ -217,13 +217,14 @@ func migrateToV8_5(ctx context.Context, bulker bulk.Bulk) error {
 // this change fixes.
 func migrateAgentOutputs() (string, string, []byte, error) {
 	const (
-		migrationName  = "AgentOutputs"
-		fieldOutputs   = "outputs"
-		fieldRetiredAt = "retiredAt"
+		migrationName        = "AgentOutputs"
+		fieldOutputs         = "outputs"
+		fieldDefaultAPIKeyID = "default_api_key_id"
+		fieldRetiredAt       = "retiredAt"
 	)
 
 	query := dsl.NewRoot()
-	query.Query().Bool().MustNot().Exists(fieldOutputs)
+	query.Query().Bool().Must().Exists(fieldDefaultAPIKeyID)
 
 	fields := map[string]interface{}{fieldRetiredAt: timeNow().UTC().Format(time.RFC3339)}
 	painless := `

--- a/internal/pkg/dl/migration.go
+++ b/internal/pkg/dl/migration.go
@@ -224,7 +224,7 @@ func migrateAgentOutputs() (string, string, []byte, error) {
 	)
 
 	query := dsl.NewRoot()
-	query.Query().Bool().Must().Term(fieldDefaultAPIKeyID, "", nil)
+	query.Query().Bool().MustNot().Term(fieldDefaultAPIKeyID, "", nil)
 
 	fields := map[string]interface{}{fieldRetiredAt: timeNow().UTC().Format(time.RFC3339)}
 	painless := `

--- a/internal/pkg/dl/migration.go
+++ b/internal/pkg/dl/migration.go
@@ -226,7 +226,7 @@ func migrateAgentOutputs() (string, string, []byte, error) {
 	root := dsl.NewRoot()
 	tmpl := dsl.NewTmpl()
 
-	root.Query().Bool().Must().Term(fieldDefaultAPIKeyID, tmpl.Bind(fieldDefaultAPIKeyID), nil)
+	root.Query().Bool().MustNot().Term(fieldDefaultAPIKeyID, tmpl.Bind(fieldDefaultAPIKeyID), nil)
 
 	fields := map[string]interface{}{fieldRetiredAt: timeNow().UTC().Format(time.RFC3339)}
 	painless := `

--- a/internal/pkg/dl/migration.go
+++ b/internal/pkg/dl/migration.go
@@ -224,7 +224,7 @@ func migrateAgentOutputs() (string, string, []byte, error) {
 	)
 
 	query := dsl.NewRoot()
-	query.Query().Bool().MustNot().Term(fieldDefaultAPIKeyID, "", nil)
+	query.Query().Bool().Must().Exists(fieldDefaultAPIKeyID)
 
 	fields := map[string]interface{}{fieldRetiredAt: timeNow().UTC().Format(time.RFC3339)}
 	painless := `

--- a/internal/pkg/dl/migration.go
+++ b/internal/pkg/dl/migration.go
@@ -219,7 +219,7 @@ func migrateAgentOutputs() (string, string, []byte, error) {
 	const (
 		migrationName        = "AgentOutputs"
 		fieldOutputs         = "outputs"
-		fieldDefaultAPIKeyID = "default_api_key_id"
+		fieldDefaultAPIKeyID = "default_api_key_id" // nolint:gosec,G101 // this is not a credential
 		fieldRetiredAt       = "retiredAt"
 	)
 

--- a/internal/pkg/dl/migration.go
+++ b/internal/pkg/dl/migration.go
@@ -254,9 +254,9 @@ ctx._source['` + fieldOutputs + `']['default'].permissions_hash=ctx._source.poli
 
 // Erase deprecated fields
 ctx._source.default_api_key_history=null;
-ctx._source.default_api_key="";
-ctx._source.default_api_key_id="";
-ctx._source.policy_output_permissions_hash="";
+ctx._source.default_api_key=null;
+ctx._source.default_api_key_id=null;
+ctx._source.policy_output_permissions_hash=null;
 `
 	query.Param("script", map[string]interface{}{
 		"lang":   "painless",


### PR DESCRIPTION
## What is the problem this PR solves?

There's an issue with large number of agent and ongoing migration. Migration is stuck in a loop and queries also documents which were already updated. 

Issue: https://github.com/elastic/fleet-server/issues/1958

## How does this PR solve the problem?

Query was looking for agent based on missing fields from newly introduced set.
This PR changed the approach around and returns agent with deprecated fields present. These fields are removed by a script so in other run they're not returned

## How to test this PR locally

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

https://github.com/elastic/fleet-server/issues/1958