### PR TITLE
backport: Add 7.17 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -65,7 +65,7 @@ pull_request_rules:
     conditions:
       - merged
       - base=main
-      - label=backport-v7.17.0
+      - label=backport-v7.18.0
     actions:
       backport:
         assignees:
@@ -154,6 +154,19 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "8.5"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 7.17 branch
+    conditions:
+      - merged
+      - label=backport-v7.17.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "7.17"
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"


### PR DESCRIPTION
Merge as soon as 7.17 branch was created. Auto-merge is not yet supported, see https://github.com/Mergifyio/mergify-engine/discussions/2821