### PR TITLE
[8.5] updated codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Team responsible for Fleet Server
-* @elastic/fleet
+* @elastic/fleet @elastic/elastic-agent-control-plane
 
 # Allow to auto-merge PRs with Mergify
 dev-tools/integration/.env

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-# Team responsable for Fleet Server
-* @elastic/elastic-agent-control-plane
+# Team responsible for Fleet Server
+* @elastic/fleet
 
 # Allow to auto-merge PRs with Mergify
 dev-tools/integration/.env


### PR DESCRIPTION
Updated codeowners as done in main: https://github.com/elastic/fleet-server/blob/main/.github/CODEOWNERS

Currently this prevents me from merging a backport pr: https://github.com/elastic/fleet-server/pull/2109