### PR TITLE
actions: use go-version-file: .go-version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,16 +26,11 @@ jobs:
           GOOS: ${{ matrix.GOOS }}
         run: echo Go GOOS=$GOOS
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      # Uses Go version from the repository.
-      - name: Read .go-version file
-        id: goversion
-        run: echo "::set-output name=version::$(cat .go-version)"
-
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: "${{ steps.goversion.outputs.version }}"
+          go-version-file: .go-version
 
       - name: golangci-lint
         env:


### PR DESCRIPTION
 ## What does this PR do?

Use the `setup-go` action with the `go-version-file` input so it reads the file `.go-version`

## Why is it important?

Avoid the logic to read and create env variables and use the undocumented `.go-version-file` 

See https://github.com/actions/setup-go/pull/295