### PR TITLE
Remove direct pkg/errors dependency

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2709,39 +2709,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 --------------------------------------------------------------------------------
-Dependency : github.com/pkg/errors
-Version: v0.9.1
-Licence type (autodetected): BSD-2-Clause
---------------------------------------------------------------------------------
-
-Contents of probable licence file $GOMODCACHE/github.com/pkg/errors@v0.9.1/LICENSE:
-
-Copyright (c) 2015, Dave Cheney <dave@cheney.net>
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
---------------------------------------------------------------------------------
 Dependency : github.com/rs/xid
 Version: v1.3.0
 Licence type (autodetected): MIT
@@ -46857,6 +46824,39 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+Dependency : github.com/pkg/errors
+Version: v0.9.1
+Licence type (autodetected): BSD-2-Clause
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/github.com/pkg/errors@v0.9.1/LICENSE:
+
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 
 --------------------------------------------------------------------------------
 Dependency : github.com/pkg/sftp

--- a/dev-tools/buildlimits/buildlimits.go
+++ b/dev-tools/buildlimits/buildlimits.go
@@ -36,6 +36,7 @@ var tmpl = template.Must(template.New("specs").Parse(`
 package config
 
 import (
+	"fmt"
 	"math"
 	"runtime"
 	"strings"
@@ -44,7 +45,6 @@ import (
 	"github.com/elastic/elastic-agent/pkg/packer"
 	"github.com/elastic/go-ucfg/yaml"
 	"github.com/pbnjay/memory"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
 
@@ -184,12 +184,12 @@ func init() {
 	for f, v := range unpacked {
 		cfg, err := yaml.NewConfig(v, DefaultOptions...)
 		if err != nil {
-			panic(errors.Wrap(err, "Cannot read spec from "+f))
+			panic(fmt.Errorf("cannot read spec from %s: %w", f, err))
 		}
 
 		l := defaultEnvLimits()
 		if err := cfg.Unpack(&l, DefaultOptions...); err != nil {
-			panic(errors.Wrap(err, "Cannot unpack spec from "+f))
+			panic(fmt.Errorf("cannot unpack spec from %s: %w", f, err))
 		}
 
 		defaults = append(defaults, l)

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/mailru/easyjson v0.7.7
 	github.com/miolini/datacounter v1.0.3
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
-	github.com/pkg/errors v0.9.1
 	github.com/rs/xid v1.3.0
 	github.com/rs/zerolog v1.27.0
 	github.com/spf13/cobra v1.3.0
@@ -57,6 +56,7 @@ require (
 	github.com/magefile/mage v1.14.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/santhosh-tekuri/jsonschema v1.2.4 // indirect

--- a/internal/pkg/api/error.go
+++ b/internal/pkg/api/error.go
@@ -7,6 +7,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"os"
 	"strings"
@@ -14,7 +15,6 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
 	"github.com/elastic/fleet-server/v7/internal/pkg/logger"
 
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 )
 

--- a/internal/pkg/api/handleAck.go
+++ b/internal/pkg/api/handleAck.go
@@ -428,7 +428,10 @@ func (ack *AckT) updateAPIKey(ctx context.Context,
 		Int64("policyCoordinator", currCoord).
 		Msg("ack policy")
 
-	return fmt.Errorf("handlePolicyChange update: %w", err)
+	if err != nil {
+		return fmt.Errorf("handlePolicyChange update: %w", err)
+	}
+	return nil
 }
 
 func cleanRoles(roles json.RawMessage) (json.RawMessage, int, error) {
@@ -453,7 +456,10 @@ func cleanRoles(roles json.RawMessage) (json.RawMessage, int, error) {
 	}
 
 	r, err := json.Marshal(rr)
-	return r, len(keys), fmt.Errorf("failed to marshal resulting role definition: %w", err)
+	if err != nil {
+		return r, len(keys), fmt.Errorf("failed to marshal resulting role definition: %w", err)
+	}
+	return r, len(keys), nil
 }
 
 func (ack *AckT) invalidateAPIKeys(ctx context.Context, toRetireAPIKeyIDs []model.ToRetireAPIKeyIdsItems, skip string) {

--- a/internal/pkg/api/handleAck.go
+++ b/internal/pkg/api/handleAck.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -16,7 +17,6 @@ import (
 	"time"
 
 	"github.com/julienschmidt/httprouter"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
@@ -112,14 +112,14 @@ func (ack *AckT) processRequest(zlog zerolog.Logger, w http.ResponseWriter, r *h
 
 	raw, err := ioutil.ReadAll(body)
 	if err != nil {
-		return errors.Wrap(err, "handleAcks read body")
+		return fmt.Errorf("handleAcks read body: %w", err)
 	}
 
 	cntAcks.bodyIn.Add(uint64(len(raw)))
 
 	var req AckRequest
 	if err := json.Unmarshal(raw, &req); err != nil {
-		return errors.Wrap(err, "handleAcks unmarshal")
+		return fmt.Errorf("handleAcks unmarshal: %w", err)
 	}
 
 	zlog.Trace().RawJSON("raw", raw).Msg("Ack request")
@@ -140,7 +140,7 @@ func (ack *AckT) processRequest(zlog zerolog.Logger, w http.ResponseWriter, r *h
 	// Always write response body even if the error HTTP status code was set
 	data, err := json.Marshal(&resp)
 	if err != nil {
-		return errors.Wrap(err, "handleAcks marshal response")
+		return fmt.Errorf("handleAcks marshal response: %w", err)
 	}
 
 	var nWritten int
@@ -428,13 +428,13 @@ func (ack *AckT) updateAPIKey(ctx context.Context,
 		Int64("policyCoordinator", currCoord).
 		Msg("ack policy")
 
-	return errors.Wrap(err, "handlePolicyChange update")
+	return fmt.Errorf("handlePolicyChange update: %w", err)
 }
 
 func cleanRoles(roles json.RawMessage) (json.RawMessage, int, error) {
 	rr := smap.Map{}
 	if err := json.Unmarshal(roles, &rr); err != nil {
-		return nil, 0, errors.Wrap(err, "failed to unmarshal provided roles")
+		return nil, 0, fmt.Errorf("failed to unmarshal provided roles: %w", err)
 	}
 
 	keys := make([]string, 0, len(rr))
@@ -453,7 +453,7 @@ func cleanRoles(roles json.RawMessage) (json.RawMessage, int, error) {
 	}
 
 	r, err := json.Marshal(rr)
-	return r, len(keys), errors.Wrap(err, "failed to marshal resulting role definition")
+	return r, len(keys), fmt.Errorf("failed to marshal resulting role definition: %w", err)
 }
 
 func (ack *AckT) invalidateAPIKeys(ctx context.Context, toRetireAPIKeyIDs []model.ToRetireAPIKeyIdsItems, skip string) {
@@ -479,7 +479,7 @@ func (ack *AckT) handleUnenroll(ctx context.Context, zlog zerolog.Logger, agent 
 		zlog = zlog.With().Strs(LogAPIKeyID, apiKeys).Logger()
 
 		if err := ack.bulk.APIKeyInvalidate(ctx, apiKeys...); err != nil {
-			return errors.Wrap(err, "handleUnenroll invalidate apikey")
+			return fmt.Errorf("handleUnenroll invalidate apikey: %w", err)
 		}
 	}
 
@@ -492,11 +492,11 @@ func (ack *AckT) handleUnenroll(ctx context.Context, zlog zerolog.Logger, agent 
 
 	body, err := doc.Marshal()
 	if err != nil {
-		return errors.Wrap(err, "handleUnenroll marshal")
+		return fmt.Errorf("handleUnenroll marshal: %w", err)
 	}
 
 	if err = ack.bulk.Update(ctx, dl.FleetAgents, agent.Id, body, bulk.WithRefresh(), bulk.WithRetryOnConflict(3)); err != nil {
-		return errors.Wrap(err, "handleUnenroll update")
+		return fmt.Errorf("handleUnenroll update: %w", err)
 	}
 
 	zlog.Info().Msg("ack unenroll")
@@ -538,11 +538,11 @@ func (ack *AckT) handleUpgrade(ctx context.Context, zlog zerolog.Logger, agent *
 
 	body, err := doc.Marshal()
 	if err != nil {
-		return errors.Wrap(err, "handleUpgrade marshal")
+		return fmt.Errorf("handleUpgrade marshal: %w", err)
 	}
 
 	if err = ack.bulk.Update(ctx, dl.FleetAgents, agent.Id, body, bulk.WithRefresh(), bulk.WithRetryOnConflict(3)); err != nil {
-		return errors.Wrap(err, "handleUpgrade update")
+		return fmt.Errorf("handleUpgrade update: %w", err)
 	}
 
 	zlog.Info().

--- a/internal/pkg/api/handleArtifacts.go
+++ b/internal/pkg/api/handleArtifacts.go
@@ -245,7 +245,10 @@ func (at ArtifactT) fetchArtifact(ctx context.Context, zlog zerolog.Logger, iden
 		Int64(ECSEventDuration, time.Since(start).Nanoseconds()).
 		Msg("fetch artifact")
 
-	return artifact, fmt.Errorf("fetchArtifact: %w", err)
+	if err != nil {
+		return artifact, fmt.Errorf("fetchArtifact: %w", err)
+	}
+	return artifact, nil
 }
 
 func validateSha2String(sha2 string) error {

--- a/internal/pkg/api/handleArtifacts.go
+++ b/internal/pkg/api/handleArtifacts.go
@@ -11,6 +11,8 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -24,7 +26,6 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/throttle"
 
 	"github.com/julienschmidt/httprouter"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
@@ -244,7 +245,7 @@ func (at ArtifactT) fetchArtifact(ctx context.Context, zlog zerolog.Logger, iden
 		Int64(ECSEventDuration, time.Since(start).Nanoseconds()).
 		Msg("fetch artifact")
 
-	return artifact, errors.Wrap(err, "fetchArtifact")
+	return artifact, fmt.Errorf("fetchArtifact: %w", err)
 }
 
 func validateSha2String(sha2 string) error {
@@ -263,7 +264,7 @@ func validateSha2String(sha2 string) error {
 func validateSha2Data(data []byte, sha2 string) error {
 	src, err := hex.DecodeString(sha2)
 	if err != nil {
-		return errors.Wrap(err, "sha2 hex decode")
+		return fmt.Errorf("sha2 hex decode: %w", err)
 	}
 
 	sum := sha256.Sum256(data)

--- a/internal/pkg/api/metrics.go
+++ b/internal/pkg/api/metrics.go
@@ -6,6 +6,8 @@ package api
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/elastic/elastic-agent-libs/api"
 	cfglib "github.com/elastic/elastic-agent-libs/config"
@@ -18,7 +20,6 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/logger"
 	"github.com/elastic/fleet-server/v7/version"
 
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
 
@@ -56,7 +57,7 @@ func InitMetrics(ctx context.Context, cfg *config.Config, bi build.Info) (*api.S
 	}
 	s, err := api.NewWithDefaultRoutes(zapStub, cfgStub, monitoring.GetNamespace)
 	if err != nil {
-		err = errors.Wrap(err, "could not start the HTTP server for the API")
+		err = fmt.Errorf("could not start the HTTP server for the API: %w", err)
 	} else {
 		s.Start()
 	}

--- a/internal/pkg/apikey/apikey.go
+++ b/internal/pkg/apikey/apikey.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -16,7 +17,6 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/internal/pkg/config/env_defaults.go
+++ b/internal/pkg/config/env_defaults.go
@@ -7,6 +7,7 @@
 package config
 
 import (
+	"fmt"
 	"math"
 	"runtime"
 	"strings"
@@ -15,7 +16,6 @@ import (
 	"github.com/elastic/elastic-agent/pkg/packer"
 	"github.com/elastic/go-ucfg/yaml"
 	"github.com/pbnjay/memory"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
 
@@ -159,12 +159,12 @@ func init() {
 	for f, v := range unpacked {
 		cfg, err := yaml.NewConfig(v, DefaultOptions...)
 		if err != nil {
-			panic(errors.Wrap(err, "Cannot read spec from "+f))
+			panic(fmt.Errorf("cannot read spec from %s: %w", f, err))
 		}
 
 		l := defaultEnvLimits()
 		if err := cfg.Unpack(&l, DefaultOptions...); err != nil {
-			panic(errors.Wrap(err, "Cannot unpack spec from "+f))
+			panic(fmt.Errorf("cannot unpack spec from %s: %w", f, err))
 		}
 
 		defaults = append(defaults, l)

--- a/internal/pkg/dl/migration.go
+++ b/internal/pkg/dl/migration.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/elastic/go-elasticsearch/v7/esapi"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
@@ -116,7 +115,7 @@ func applyMigration(ctx context.Context, name string, index string, bulker bulk.
 
 	decoder := json.NewDecoder(res.Body)
 	if err := decoder.Decode(&resp); err != nil {
-		return migrationResponse{}, errors.Wrap(err, "decode UpdateByQuery response")
+		return migrationResponse{}, fmt.Errorf("decode UpdateByQuery response: %w", err)
 	}
 
 	log.Info().


### PR DESCRIPTION
Go has error wrapping as part. of the stdlib since v1.13.0.
This PR removes an external library that was used in the repo to provide the same functions.
The library is still an indirect requirement as other imports use it.