### PR TITLE
Correct build using docker image

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,7 +1,11 @@
 ARG GO_VERSION
 FROM golang:${GO_VERSION}-buster
 
-RUN apt-get update && apt-get install -y zip
+RUN \
+  apt-get update \
+  && apt-get install -y zip \
+  && mkdir /.cache \
+  && chmod 777 /.cache
 
 WORKDIR /go/src/github.com/elastic/fleet-server
 

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ build-releaser: ## - Build a Docker image to run make package including all buil
 
 .PHONY: docker-release
 docker-release: build-releaser ## - Builds a release for all platforms in a dockerised environment
-	docker run --rm --volume $(PWD):/go/src/github.com/elastic/fleet-server $(BUILDER_IMAGE)
+	docker run --rm -u $(shell id -u):$(shell id -g) --volume $(PWD):/go/src/github.com/elastic/fleet-server $(BUILDER_IMAGE)
 
 .PHONY: release
 release: $(PLATFORM_TARGETS) ## - Builds a release. Specify exact platform with PLATFORMS env.


### PR DESCRIPTION
Signed-off-by: Adrien Mannocci <adrien.mannocci@elastic.co>

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

* This PR solves CI build issues.
* Ref: https://fleet-ci.elastic.co//blue/rest/organizations/jenkins/pipelines/fleet-server/pipelines/fleet-server-mbp/pipelines/PR-2180/runs/4/steps/290/log/?start=0

## How does this PR solve the problem?

* Create a cache directory within the docker image at `/.cache`
* Forward local uid and gid when we run the docker image.


## How to test this PR locally

* Run the following make target `make docker-release`.
<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

