### PR TITLE
Allow the the Warn log level to be specified as "warning" and "warn"

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -21,7 +21,7 @@
 - Fixed unenroll offline agents logic {issue}2091[2091] {pull}2092[2092]
 - Ignore UPDATE_TAGS and FORCE_UNENROLL actions on agent checkin {issue}2199[2199] {pull}2200[2200]
 - Fix the index monitor checkpoint tracking for when the documents are deleted {issue}2205[2205] {pull}2206[2206]
-- Change the representation for the Warn log level from "warning" to "warn" {issue}2328[2328] {pull}2331[2331]
+- Allow the the Warn log level to be specified as "warning" and "warn" {issue}2328[2328] {pull}2331[2331]
 
 ==== New Features
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -21,7 +21,7 @@
 - Fixed unenroll offline agents logic {issue}2091[2091] {pull}2092[2092]
 - Ignore UPDATE_TAGS and FORCE_UNENROLL actions on agent checkin {issue}2199[2199] {pull}2200[2200]
 - Fix the index monitor checkpoint tracking for when the documents are deleted {issue}2205[2205] {pull}2206[2206]
-
+- Change the representation for the Warn log level from "warning" to "warn" {issue}2328[2328] {pull}2331[2331]
 
 ==== New Features
 

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -146,7 +146,7 @@ func TestConfig(t *testing.T) {
 			err: "only 1 fleet-server input can be defined",
 		},
 		"bad-logging": {
-			err: "invalid log level; must be one of: trace, debug, info, warning, error",
+			err: "invalid log level; must be one of: trace, debug, info, warn, error",
 		},
 		"bad-output": {
 			err: "can only contain elasticsearch key",

--- a/internal/pkg/config/fleet.go
+++ b/internal/pkg/config/fleet.go
@@ -67,7 +67,7 @@ func strToLevel(s string) (zerolog.Level, error) {
 		l = zerolog.DebugLevel
 	case "info":
 		l = zerolog.InfoLevel
-	case "warn":
+	case "warn", "warning":
 		l = zerolog.WarnLevel
 	case "error":
 		l = zerolog.ErrorLevel

--- a/internal/pkg/config/fleet.go
+++ b/internal/pkg/config/fleet.go
@@ -67,12 +67,12 @@ func strToLevel(s string) (zerolog.Level, error) {
 		l = zerolog.DebugLevel
 	case "info":
 		l = zerolog.InfoLevel
-	case "warning":
+	case "warn":
 		l = zerolog.WarnLevel
 	case "error":
 		l = zerolog.ErrorLevel
 	default:
-		return l, fmt.Errorf("invalid log level; must be one of: trace, debug, info, warning, error")
+		return l, fmt.Errorf("invalid log level; must be one of: trace, debug, info, warn, error")
 	}
 
 	return l, nil


### PR DESCRIPTION
## What is the problem this PR solves?

The log level provided by the Agent is "warn", and crashes the fleet-server as it expects "warning".

## How does this PR solve the problem?

Config will parse "warning" and "warn" as `zerolog.WarnLevel`

## Checklist

- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #2328 