### PR TITLE
[Fleet] Test replacing refreh=true => refresh=wait_for

### DIFF
--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -337,7 +337,7 @@ func (b *Bulker) parseOpts(opts ...Opt) optionsT {
 func (b *Bulker) newBlk(action actionT, opts optionsT) *bulkT {
 	blk := b.blkPool.Get().(*bulkT) //nolint:errcheck // we control what is placed in the pool
 	blk.action = action
-	if opts.Refresh {
+	if opts.Refresh == "wait_for" {
 		blk.flags.Set(flagRefresh)
 	}
 	return blk

--- a/internal/pkg/bulk/opBulk.go
+++ b/internal/pkg/bulk/opBulk.go
@@ -189,7 +189,7 @@ func (b *Bulker) flushBulk(ctx context.Context, queue queueT) error {
 	}
 
 	if queue.ty == kQueueRefreshBulk {
-		req.Refresh = "true"
+		req.Refresh = "wait_for"
 	}
 
 	res, err := req.Do(ctx, b.es)

--- a/internal/pkg/bulk/opMulti.go
+++ b/internal/pkg/bulk/opMulti.go
@@ -80,7 +80,7 @@ func (b *Bulker) multiWaitBulkOp(ctx context.Context, action actionT, ops []Mult
 		bulk.idx = int32(i)
 		bulk.action = action
 		bulk.buf.Set(bodySlice)
-		if opt.Refresh {
+		if opt.Refresh == "wait_for" {
 			bulk.flags.Set(flagRefresh)
 		}
 	}

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -17,7 +17,7 @@ import (
 // Transaction options
 
 type optionsT struct {
-	Refresh            bool
+	Refresh            string
 	RetryOnConflict    string
 	Indices            []string
 	WaitForCheckpoints []int64
@@ -27,7 +27,7 @@ type Opt func(*optionsT)
 
 func WithRefresh() Opt {
 	return func(opt *optionsT) {
-		opt.Refresh = true
+		opt.Refresh = "wait_for"
 	}
 }
 

--- a/internal/pkg/uploader/es.go
+++ b/internal/pkg/uploader/es.go
@@ -129,7 +129,7 @@ func IndexChunk(ctx context.Context, client *elasticsearch.Client, body *cbor.Ch
 		}
 		req.Header.Set("Content-Type", "application/cbor")
 		req.Header.Set("Accept", "application/json")
-		req.Refresh = "true"
+		req.Refresh = "wait_for"
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
For testing purpose => do not merge

That PR replace all refresh=true by refresh=wait_for to simulate the effect of stateless ES.
@joshdover @michel-laterman I am going to run some scale tests with an image of this does it make sense to you is there any place I miss?