### PR TITLE
Remove agent tag duplicates

### DIFF
--- a/internal/pkg/api/handleEnroll.go
+++ b/internal/pkg/api/handleEnroll.go
@@ -199,7 +199,7 @@ func (et *EnrollerT) _enroll(
 			LocalMetadata:        agentData.LocalMetadata,
 			PolicyId:             agentData.PolicyID,
 			Status:               "online",
-			Tags:                 removeDuplicateStr(agentData.Tags),
+			Tags:                 agentData.Tags,
 			Type:                 agentData.Type,
 			UserProvidedMetadata: agentData.UserProvidedMetadata,
 		},

--- a/internal/pkg/api/handleEnroll.go
+++ b/internal/pkg/api/handleEnroll.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/elastic/elastic-agent-libs/str"
 	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/cache"
@@ -211,17 +212,10 @@ func (et *EnrollerT) _enroll(
 	return &resp, nil
 }
 
+// Helper function to remove duplicate agent tags.
+// Note that this implementation will also sort the tags alphabetically.
 func removeDuplicateStr(strSlice []string) []string {
-	allKeys := make(map[string]bool)
-	list := []string{}
-	for _, item := range strSlice {
-		if _, value := allKeys[item]; !value {
-			allKeys[item] = true
-			list = append(list, item)
-		}
-	}
-
-	return list
+	return str.MakeSet(strSlice...).ToSlice()
 }
 
 func deleteAgent(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, agentID string) error {

--- a/internal/pkg/api/handleEnroll.go
+++ b/internal/pkg/api/handleEnroll.go
@@ -175,7 +175,7 @@ func (et *EnrollerT) _enroll(
 			ID:      agentID,
 			Version: ver,
 		},
-		Tags: req.Metadata.Tags,
+		Tags: removeDuplicateStr(req.Metadata.Tags),
 	}
 
 	err = createFleetAgent(ctx, et.bulker, agentID, agentData)
@@ -199,7 +199,7 @@ func (et *EnrollerT) _enroll(
 			LocalMetadata:        agentData.LocalMetadata,
 			PolicyId:             agentData.PolicyID,
 			Status:               "online",
-			Tags:                 agentData.Tags,
+			Tags:                 removeDuplicateStr(agentData.Tags),
 			Type:                 agentData.Type,
 			UserProvidedMetadata: agentData.UserProvidedMetadata,
 		},
@@ -209,6 +209,19 @@ func (et *EnrollerT) _enroll(
 	et.cache.SetAPIKey(*accessAPIKey, true)
 
 	return &resp, nil
+}
+
+func removeDuplicateStr(strSlice []string) []string {
+	allKeys := make(map[string]bool)
+	list := []string{}
+	for _, item := range strSlice {
+		if _, value := allKeys[item]; !value {
+			allKeys[item] = true
+			list = append(list, item)
+		}
+	}
+
+	return list
 }
 
 func deleteAgent(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, agentID string) error {

--- a/internal/pkg/api/handleEnroll_test.go
+++ b/internal/pkg/api/handleEnroll_test.go
@@ -5,7 +5,6 @@
 package api
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 )
@@ -32,7 +31,6 @@ func TestRemoveDuplicateStr(t *testing.T) {
 			agentTags: []string{"foo", "bar", "baz"},
 		},
 	}
-	fmt.Println(tests)
 	for _, tr := range tests {
 		t.Run(tr.name, func(t *testing.T) {
 			uniqueTags := removeDuplicateStr(tr.inputTags)

--- a/internal/pkg/api/handleEnroll_test.go
+++ b/internal/pkg/api/handleEnroll_test.go
@@ -28,7 +28,7 @@ func TestRemoveDuplicateStr(t *testing.T) {
 		{
 			name:      "multiple duplicated tags",
 			inputTags: []string{"foo", "bar", "bar", "baz", "foo"},
-			agentTags: []string{"foo", "bar", "baz"},
+			agentTags: []string{"bar", "baz", "foo"},
 		},
 	}
 	for _, tr := range tests {

--- a/internal/pkg/api/handleEnroll_test.go
+++ b/internal/pkg/api/handleEnroll_test.go
@@ -1,0 +1,44 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package api
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestRemoveDuplicateStr(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputTags []string
+		agentTags []string
+	}{
+		{
+			name:      "empty array",
+			inputTags: []string{},
+			agentTags: []string{},
+		},
+		{
+			name:      "one duplicated tag",
+			inputTags: []string{"foo", "foo", "foo", "foo"},
+			agentTags: []string{"foo"},
+		},
+		{
+			name:      "multiple duplicated tags",
+			inputTags: []string{"foo", "bar", "bar", "baz", "foo"},
+			agentTags: []string{"foo", "bar", "baz"},
+		},
+	}
+	fmt.Println(tests)
+	for _, tr := range tests {
+		t.Run(tr.name, func(t *testing.T) {
+			uniqueTags := removeDuplicateStr(tr.inputTags)
+			if !reflect.DeepEqual(uniqueTags, tr.agentTags) {
+				t.Fatalf("failed to remove tag duplicates from %v: expected %v, found %v", tr.inputTags, uniqueTags, tr.agentTags)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

When an Elastic Agent is enrolled with the same tag multiple tags, they are treated as separate tags.
Issue: https://github.com/elastic/fleet-server/issues/1596

## How does this PR solve the problem?

This PR adds a helper method to remove duplicate tags during Elastic Agent enrollment.

## How to test this PR locally

1. Run fleet-server locally with these changes.
2. Enroll a new Elastic Agent with duplicate tags. For instance, if running elastic-agent locally using Docker, pass the flag `-e ELASTIC_AGENT_TAGS=foo,foo,foo,foo`.
3. The duplicated tag should only appear once in the new Agent.

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc. 

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Closes [#123](https://github.com/elastic/fleet-server/issues/1596)
