### PR TITLE
mergify: delete branches created by the updatecli, update backports

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -33,34 +33,6 @@ pull_request_rules:
         message: |
           This pull request has been automatically closed by Mergify.
           There are some other up-to-date pull requests.
-  - name: backport patches to 8.2 branch
-    conditions:
-      - merged
-      - base=main
-      - label=backport-v8.2.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.2"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to 8.3 branch
-    conditions:
-      - merged
-      - base=main
-      - label=backport-v8.3.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.3"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 7.17 branch
     conditions:
       - merged
@@ -127,36 +99,10 @@ pull_request_rules:
         - closed
       - and:
         - label=automation
-        - head~=^update-.*-version
+        - head~=^updatecli.*
         - files~=^(dev-tools/integration/.env|.go-version)$
     actions:
       delete_head_branch:
-  - name: backport patches to 8.4 branch
-    conditions:
-      - merged
-      - label=backport-v8.4.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.4"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to 8.5 branch
-    conditions:
-      - merged
-      - label=backport-v8.5.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.5"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.6 branch
     conditions:
       - merged


### PR DESCRIPTION
## What is the problem this PR solves?

Remove closed branches created by the automation

## How does this PR solve the problem?
Remove backports to old 8.x branches but 8.6 and 8.7
Delete updatecli branches when PRs were merged/closed

