### PR TITLE
Log listening address

### DIFF
--- a/internal/pkg/api/server.go
+++ b/internal/pkg/api/server.go
@@ -133,7 +133,7 @@ func (s *server) Run(ctx context.Context) error {
 	defer cancel()
 
 	go func(_ context.Context, errCh chan error, ln net.Listener) {
-		log.Debug().Msgf("Listening on %s", s.addr)
+		log.Info().Msgf("Listening on %s", s.addr)
 		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errCh <- err
 		}


### PR DESCRIPTION
Make sure we log the Fleet Server listening address as INFO instead of DEBUG.

## What is the problem this PR solves?

Unable to verify without tests which is the listening address & port.

## How does this PR solve the problem?

Logs the information as INFO

## How to test this PR locally

Run the Fleet Server