### PR TITLE
[Fleet] Fleet server standalone should be healthy before .fleet-policies is created

### DIFF
--- a/internal/pkg/policy/standalone.go
+++ b/internal/pkg/policy/standalone.go
@@ -92,7 +92,7 @@ func (m *standAloneSelfMonitorT) check(ctx context.Context) client.UnitState {
 	if err != nil {
 		if errors.Is(err, es.ErrIndexNotFound) {
 			m.log.Debug().Str("index", m.policiesIndex).Msg(es.ErrIndexNotFound.Error())
-			return m.updateState(client.UnitStateStarting, "Policies not available yet")
+			return m.updateState(client.UnitStateHealthy, "Running: Policies not available yet")
 		}
 		if err != nil {
 			return m.updateState(client.UnitStateFailed, fmt.Sprintf("Failed to request policies: %s", err))

--- a/internal/pkg/policy/standalone_test.go
+++ b/internal/pkg/policy/standalone_test.go
@@ -40,7 +40,7 @@ func TestStandAloneSelfMonitor(t *testing.T) {
 			title:         "index not found",
 			searchResult:  nil,
 			searchErr:     es.ErrIndexNotFound,
-			expectedState: client.UnitStateStarting,
+			expectedState: client.UnitStateHealthy,
 		},
 		{
 			title:         "failed to connect with Elasticsearch",


### PR DESCRIPTION
## Description 

Resolve #2421 

Mark Fleet server as healthy in standalone even if the `.fleet-policies` index is not yet created.

## Tests

I updated the unit test.

I manually tested this like this:
1. With a fresh ES and Kibana
2. Create a service token
```
curl -X POST http://localhost:9200/_security/service/elastic/fleet-server/credential/token/test -u elastic:changeme
```
3.  Run fleet server in standalone
```shell
ELASTICSEARCH_CA_TRUSTED_FINGERPRINT=notused ELASTICSEARCH_SERVICE_TOKEN=<TOKEN_CREATED_BEFORE> ELASTICSEARCH_HOSTS=http://localhost:9200  go run main.go
```
4. Get the status and check it's healthy `http GET http://127.0.0.1:8220/api/status`
5. Create a policy in Kibana and  it's still healthy `http GET http://127.0.0.1:8220/api/status`
