### PR TITLE
Add comments and unit test for gathering variables from env var

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -26,6 +26,14 @@ var DefaultOptions = []ucfg.Option{
 const kRedacted = "[redacted]"
 
 // Config is the global configuration.
+//
+// fleet-server does not provide any builtin env var mappings.
+// The DefaultOptions are set to use env var substitution if it's defined explicity in go-ucfg's input.
+// For example:
+//   output.elasticsearch.service_token: ${MY_TOKEN_VAR}
+//
+// The env vars that `elastic-agent container` command uses are unrelated.
+// The agent will do all substitutions before sending fleet-server the complete config.
 type Config struct {
 	Fleet   Fleet   `config:"fleet"`
 	Output  Output  `config:"output"`

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -28,9 +28,10 @@ const kRedacted = "[redacted]"
 // Config is the global configuration.
 //
 // fleet-server does not provide any builtin env var mappings.
-// The DefaultOptions are set to use env var substitution if it's defined explicity in go-ucfg's input.
+// The DefaultOptions are set to use env var substitution if it's defined explicitly in go-ucfg's input.
 // For example:
-//   output.elasticsearch.service_token: ${MY_TOKEN_VAR}
+//
+//	output.elasticsearch.service_token: ${MY_TOKEN_VAR}
 //
 // The env vars that `elastic-agent container` command uses are unrelated.
 // The agent will do all substitutions before sending fleet-server the complete config.

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -283,3 +283,12 @@ func defaultServer() Server {
 	d.InitDefaults()
 	return d
 }
+
+func TestConfigFromEnv(t *testing.T) {
+	t.Setenv("ELASTICSEARCH_SERVICE_TOKEN", "test-val")
+	_ = testlog.SetLogger(t)
+	path := filepath.Join("..", "testing", "fleet-server-testing.yml")
+	c, err := LoadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "test-val", c.Output.Elasticsearch.ServiceToken)
+}


### PR DESCRIPTION
added a really simple unit test and comments to explicitly state how fleet-server handles env vars