### PR TITLE
Rename secret file attributes to use path suffix

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -671,11 +671,11 @@ SOFTWARE
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/elastic-agent-libs
-Version: v0.3.5
+Version: v0.3.7
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-libs@v0.3.5/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-libs@v0.3.7/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/deepmap/oapi-codegen v1.12.4
 	github.com/dgraph-io/ristretto v0.1.1
 	github.com/elastic/elastic-agent-client/v7 v7.0.3
-	github.com/elastic/elastic-agent-libs v0.3.5
+	github.com/elastic/elastic-agent-libs v0.3.7
 	github.com/elastic/elastic-agent-system-metrics v0.4.4
 	github.com/elastic/go-elasticsearch/v8 v8.6.0
 	github.com/elastic/go-ucfg v0.8.6

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/elastic/elastic-agent-client/v7 v7.0.3 h1:YqZPnO7Z9rlj25sFZEUaxGGK3mZR4v0uSOcfO8GRv7s=
 github.com/elastic/elastic-agent-client/v7 v7.0.3/go.mod h1:cHviLpA5fAwMbfBIHBVNl16qp90bO7pKHMAQaG+9raU=
-github.com/elastic/elastic-agent-libs v0.3.5 h1:QWEaGRqycs3Q3YctiXBimH1t2bbswsZ5pwi/PQmxVUE=
-github.com/elastic/elastic-agent-libs v0.3.5/go.mod h1:h48hzjQcn6XPwfWRM5HimAKlsG0J92ULgAzdX+WedA8=
+github.com/elastic/elastic-agent-libs v0.3.7 h1:81xd4P+aTBp98Gkm54RIvPUr/3306heUfSPyjUgiyjE=
+github.com/elastic/elastic-agent-libs v0.3.7/go.mod h1:h48hzjQcn6XPwfWRM5HimAKlsG0J92ULgAzdX+WedA8=
 github.com/elastic/elastic-agent-system-metrics v0.4.4 h1:Br3S+TlBhijrLysOvbHscFhgQ00X/trDT5VEnOau0E0=
 github.com/elastic/elastic-agent-system-metrics v0.4.4/go.mod h1:tF/f9Off38nfzTZHIVQ++FkXrDm9keFhFpJ+3pQ00iI=
 github.com/elastic/elastic-transport-go/v8 v8.0.0-20211216131617-bbee439d559c/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=

--- a/internal/pkg/config/instrumentation.go
+++ b/internal/pkg/config/instrumentation.go
@@ -25,12 +25,12 @@ type Instrumentation struct {
 	Environment string `config:"environment"`
 	// APIKey specifies the API key value - may be specified with ELASTIC_APM_API_KEY
 	APIKey string `config:"api_key"`
-	// APIKeyFile specifies the path to the API key secret file
-	APIKeyFile string `config:"api_key_file"`
+	// APIKeyPath specifies the path to the API key secret file
+	APIKeyPath string `config:"api_key_path"`
 	// SecretToken specifies the secret token value - may be specified with ELASTIC_APM_SECRET_TOKEN
 	SecretToken string `config:"secret_token"`
-	// SecretTokenFile specifies the path to the secret token file
-	SecretTokenFile string `config:"secret_token_file"`
+	// SecretTokenPath specifies the path to the secret token file
+	SecretTokenPath string `config:"secret_token_path"`
 	// Hosts specifies the APM server urls - may be specified with ELASTIC_APM_SERVER_URL
 	Hosts []string `config:"hosts"`
 	// GlobalLabels specifies apm global labels - may be specified with ELASTIC_APM_GLOBAL_LABELS
@@ -89,8 +89,8 @@ func (c *Instrumentation) APMHTTPTransportOptions() (apmtransport.HTTPTransportO
 	}
 
 	apiKey := c.APIKey
-	if c.APIKey == "" && c.APIKeyFile != "" {
-		p, err := os.ReadFile(c.APIKeyFile)
+	if c.APIKey == "" && c.APIKeyPath != "" {
+		p, err := os.ReadFile(c.APIKeyPath)
 		if err != nil {
 			return apmtransport.HTTPTransportOptions{}, fmt.Errorf("unable to read API key file: %w", err)
 		}
@@ -98,8 +98,8 @@ func (c *Instrumentation) APMHTTPTransportOptions() (apmtransport.HTTPTransportO
 	}
 
 	secretToken := c.SecretToken
-	if c.SecretToken == "" && c.SecretTokenFile != "" {
-		p, err := os.ReadFile(c.SecretTokenFile)
+	if c.SecretToken == "" && c.SecretTokenPath != "" {
+		p, err := os.ReadFile(c.SecretTokenPath)
 		if err != nil {
 			return apmtransport.HTTPTransportOptions{}, fmt.Errorf("unable to read secret token file: %w", err)
 		}

--- a/internal/pkg/config/instrumentation_test.go
+++ b/internal/pkg/config/instrumentation_test.go
@@ -117,7 +117,7 @@ func TestAPMHTTPTransportOptions(t *testing.T) {
 	t.Run("api key file", func(t *testing.T) {
 		fileName := testFile(t, "test-key")
 		i := &Instrumentation{
-			APIKeyFile: fileName,
+			APIKeyPath: fileName,
 		}
 		cfg, err := i.APMHTTPTransportOptions()
 		require.NoError(t, err)
@@ -129,7 +129,7 @@ func TestAPMHTTPTransportOptions(t *testing.T) {
 		fileName := testFile(t, "test-value")
 		i := &Instrumentation{
 			APIKey:     "test-key",
-			APIKeyFile: fileName,
+			APIKeyPath: fileName,
 		}
 		cfg, err := i.APMHTTPTransportOptions()
 		require.NoError(t, err)
@@ -140,7 +140,7 @@ func TestAPMHTTPTransportOptions(t *testing.T) {
 	t.Run("secret token file", func(t *testing.T) {
 		fileName := testFile(t, "test-token")
 		i := &Instrumentation{
-			SecretTokenFile: fileName,
+			SecretTokenPath: fileName,
 		}
 		cfg, err := i.APMHTTPTransportOptions()
 		require.NoError(t, err)
@@ -152,7 +152,7 @@ func TestAPMHTTPTransportOptions(t *testing.T) {
 		fileName := testFile(t, "test-value")
 		i := &Instrumentation{
 			SecretToken:     "test-token",
-			SecretTokenFile: fileName,
+			SecretTokenPath: fileName,
 		}
 		cfg, err := i.APMHTTPTransportOptions()
 		require.NoError(t, err)
@@ -162,7 +162,7 @@ func TestAPMHTTPTransportOptions(t *testing.T) {
 
 	t.Run("api key file does not exist", func(t *testing.T) {
 		i := &Instrumentation{
-			APIKeyFile: "/path/does/not/exist",
+			APIKeyPath: "/path/does/not/exist",
 		}
 		_, err := i.APMHTTPTransportOptions()
 		assert.ErrorAs(t, err, &os.ErrNotExist)

--- a/internal/pkg/config/output.go
+++ b/internal/pkg/config/output.go
@@ -40,7 +40,7 @@ type Elasticsearch struct {
 	Path             string            `config:"path"`
 	Headers          map[string]string `config:"headers"`
 	ServiceToken     string            `config:"service_token"`
-	ServiceTokenFile string            `config:"service_token_file"`
+	ServiceTokenPath string            `config:"service_token_path"`
 	ProxyURL         string            `config:"proxy_url"`
 	ProxyDisable     bool              `config:"proxy_disable"`
 	ProxyHeaders     map[string]string `config:"proxy_headers"`
@@ -64,13 +64,13 @@ func (c *Elasticsearch) InitDefaults() {
 // Validate ensures that the configuration is valid.
 func (c *Elasticsearch) Validate() error {
 	if c.ServiceToken == "" {
-		if c.ServiceTokenFile == "" {
+		if c.ServiceTokenPath == "" {
 			return fmt.Errorf("service_token is undefined")
 		}
-		if p, err := os.ReadFile(c.ServiceTokenFile); err != nil {
-			return fmt.Errorf("unable to read service_token_file: %w", err)
+		if p, err := os.ReadFile(c.ServiceTokenPath); err != nil {
+			return fmt.Errorf("unable to read service_token_path: %w", err)
 		} else if len(p) == 0 {
-			return fmt.Errorf("empty service_token_file")
+			return fmt.Errorf("empty service_token_path")
 		}
 	}
 	if c.ProxyURL != "" && !c.ProxyDisable {
@@ -165,10 +165,10 @@ func (c *Elasticsearch) ToESConfig(longPoll bool) (elasticsearch.Config, error) 
 	h.Set("X-elastic-product-origin", "fleet")
 
 	serviceToken := c.ServiceToken
-	if c.ServiceToken == "" && c.ServiceTokenFile != "" {
-		p, err := os.ReadFile(c.ServiceTokenFile)
+	if c.ServiceToken == "" && c.ServiceTokenPath != "" {
+		p, err := os.ReadFile(c.ServiceTokenPath)
 		if err != nil {
-			return elasticsearch.Config{}, fmt.Errorf("unable to read service_token_file: %w", err)
+			return elasticsearch.Config{}, fmt.Errorf("unable to read service_token_path: %w", err)
 		}
 		serviceToken = string(p)
 	}

--- a/internal/pkg/config/output_test.go
+++ b/internal/pkg/config/output_test.go
@@ -57,12 +57,12 @@ func TestToESConfig(t *testing.T) {
 				},
 			},
 		},
-		"service_token and service_token_file defined": {
+		"service_token and service_token_path defined": {
 			cfg: Elasticsearch{
 				Protocol:         "http",
 				Hosts:            []string{"localhost:9200"},
 				ServiceToken:     "test-token",
-				ServiceTokenFile: "/path/is/ignored",
+				ServiceTokenPath: "/path/is/ignored",
 				MaxRetries:       3,
 				MaxConnPerHost:   128,
 				Timeout:          90 * time.Second,
@@ -209,12 +209,12 @@ func TestToESConfig(t *testing.T) {
 		})
 	}
 
-	t.Run("service_token_file is ok", func(t *testing.T) {
+	t.Run("service_token_path is ok", func(t *testing.T) {
 		fileName := writeTestFile(t, "test-token")
 		cfg := &Elasticsearch{
 			Protocol:         schemeHTTP,
 			Hosts:            []string{"localhost:9200"},
-			ServiceTokenFile: fileName,
+			ServiceTokenPath: fileName,
 			MaxRetries:       3,
 			MaxConnPerHost:   128,
 			Timeout:          90 * time.Second,
@@ -242,12 +242,12 @@ func TestToESConfig(t *testing.T) {
 		assert.True(t, cmp.Equal(expect, es, copts...), "mismatch (-want +got)\n%s", cmp.Diff(expect, es, copts...))
 	})
 
-	t.Run("service_token_file is empty", func(t *testing.T) {
+	t.Run("service_token_path is empty", func(t *testing.T) {
 		fileName := writeTestFile(t, "")
 		cfg := &Elasticsearch{
 			Protocol:         schemeHTTP,
 			Hosts:            []string{"localhost:9200"},
-			ServiceTokenFile: fileName,
+			ServiceTokenPath: fileName,
 			MaxRetries:       3,
 			MaxConnPerHost:   128,
 			Timeout:          90 * time.Second,
@@ -274,11 +274,11 @@ func TestToESConfig(t *testing.T) {
 		assert.True(t, cmp.Equal(expect, es, copts...), "mismatch (-want +got)\n%s", cmp.Diff(expect, es, copts...))
 	})
 
-	t.Run("service_token_file does not exist", func(t *testing.T) {
+	t.Run("service_token_path does not exist", func(t *testing.T) {
 		cfg := &Elasticsearch{
 			Protocol:         schemeHTTP,
 			Hosts:            []string{"localhost:9200"},
-			ServiceTokenFile: filepath.Join(t.TempDir(), "some-file"),
+			ServiceTokenPath: filepath.Join(t.TempDir(), "some-file"),
 			MaxRetries:       3,
 			MaxConnPerHost:   128,
 			Timeout:          90 * time.Second,


### PR DESCRIPTION
Rename secret files attributes to use `_path` suffix to be consistent with existing naming conventions in the elastic-agent