### PR TITLE
Remove service token from output validation

### DIFF
--- a/internal/pkg/config/output.go
+++ b/internal/pkg/config/output.go
@@ -63,16 +63,6 @@ func (c *Elasticsearch) InitDefaults() {
 
 // Validate ensures that the configuration is valid.
 func (c *Elasticsearch) Validate() error {
-	if c.ServiceToken == "" {
-		if c.ServiceTokenPath == "" {
-			return fmt.Errorf("service_token is undefined")
-		}
-		if p, err := os.ReadFile(c.ServiceTokenPath); err != nil {
-			return fmt.Errorf("unable to read service_token_path: %w", err)
-		} else if len(p) == 0 {
-			return fmt.Errorf("empty service_token_path")
-		}
-	}
 	if c.ProxyURL != "" && !c.ProxyDisable {
 		if _, err := urlutil.ParseURL(c.ProxyURL); err != nil {
 			return err


### PR DESCRIPTION
## What is the problem this PR solves?

Cloud deployments for latest snapshot are broken with: `Error: service_token is undefined accessing config`.

## How does this PR solve the problem?

Remove validation for service_token value from config spec

## How to test this PR locally

Run `make build-and-push-cloud-image`

Deploy with
```
curl -XPOST "https://public-api.qa.cld.elstc.co/api/v1/deployments?validate_only=false" -H "Authorization: ApiKey $API_KEY" -H "kbn-xsrf: reporting" -H "Content-Type: application/json" -d'
{
  "resources": {
    "integrations_server": [
      {
        "elasticsearch_cluster_ref_id": "main-elasticsearch",
        "region": "gcp-us-central1",
        "plan": {
          "cluster_topology": [
            {
              "instance_configuration_id": "gcp.integrationsserver.n2.68x32x45.2",
              "zone_count": 1,
              "size": {
                "resource": "memory",
                "value": 1024
              }
            }
          ],
          "integrations_server": {
            "version": "8.8.0-SNAPSHOT",
            "docker_image": "docker.elastic.co/observability-ci/elastic-agent:8.8.0-SNAPSHOT-laterman-1681227221"
          }
        },
        "ref_id": "main-integrations_server"
      }
    ],
    "elasticsearch": [
      {
        "region": "gcp-us-central1",
        "settings": {
          "dedicated_masters_threshold": 6
        },
        "plan": {
          "cluster_topology": [
            {
              "zone_count": 2,
              "elasticsearch": {
                "node_attributes": {
                  "data": "hot"
                }
              },
              "instance_configuration_id": "gcp.es.datahot.n2.68x10x45",
              "node_roles": [
                "master",
                "ingest",
                "transform",
                "data_hot",
                "remote_cluster_client",
                "data_content"
              ],
              "id": "hot_content",
              "size": {
                "value": 1024,
                "resource": "memory"
              }
            },
            {
              "zone_count": 2,
              "elasticsearch": {
                "node_attributes": {
                  "data": "warm"
                }
              },
              "instance_configuration_id": "gcp.es.datawarm.n2.68x10x190",
              "node_roles": [
                "data_warm",
                "remote_cluster_client"
              ],
              "id": "warm",
              "size": {
                "resource": "memory",
                "value": 0
              }
            },
            {
              "zone_count": 1,
              "elasticsearch": {
                "node_attributes": {
                  "data": "cold"
                }
              },
              "instance_configuration_id": "gcp.es.datacold.n2.68x10x190",
              "node_roles": [
                "data_cold",
                "remote_cluster_client"
              ],
              "id": "cold",
              "size": {
                "resource": "memory",
                "value": 0
              }
            },
            {
              "zone_count": 1,
              "elasticsearch": {
                "node_attributes": {
                  "data": "frozen"
                }
              },
              "instance_configuration_id": "gcp.es.datafrozen.n2.68x10x95",
              "node_roles": [
                "data_frozen"
              ],
              "id": "frozen",
              "size": {
                "resource": "memory",
                "value": 0
              }
            },
            {
              "zone_count": 3,
              "instance_configuration_id": "gcp.es.master.n2.68x32x45.2",
              "node_roles": [
                "master",
                "remote_cluster_client"
              ],
              "id": "master",
              "size": {
                "resource": "memory",
                "value": 0
              }
            },
            {
              "zone_count": 2,
              "instance_configuration_id": "gcp.es.coordinating.n2.68x16x45.2",
              "node_roles": [
                "ingest",
                "remote_cluster_client"
              ],
              "id": "coordinating",
              "size": {
                "resource": "memory",
                "value": 0
              }
            },
            {
              "zone_count": 1,
              "instance_configuration_id": "gcp.es.ml.n2.68x32x45",
              "node_roles": [
                "ml",
                "remote_cluster_client"
              ],
              "id": "ml",
              "size": {
                "resource": "memory",
                "value": 0
              }
            }
          ],
          "elasticsearch": {
            "version": "8.8.0-SNAPSHOT",
            "enabled_built_in_plugins": []
          },
          "deployment_template": {
            "id": "gcp-storage-optimized-v5"
          }
        },
        "ref_id": "main-elasticsearch"
      }
    ],
    "enterprise_search": [
      {
        "elasticsearch_cluster_ref_id": "main-elasticsearch",
        "region": "gcp-us-central1",
        "plan": {
          "cluster_topology": [
            {
              "node_type": {
                "connector": true,
                "appserver": true,
                "worker": true
              },
              "instance_configuration_id": "gcp.enterprisesearch.n2.68x32x45",
              "zone_count": 1,
              "size": {
                "resource": "memory",
                "value": 2048
              }
            }
          ],
          "enterprise_search": {
            "version": "8.8.0-SNAPSHOT"
          }
        },
        "ref_id": "main-enterprise_search"
      }
    ],
    "kibana": [
      {
        "elasticsearch_cluster_ref_id": "main-elasticsearch",
        "region": "gcp-us-central1",
        "plan": {
          "cluster_topology": [
            {
              "instance_configuration_id": "gcp.kibana.n2.68x32x45",
              "zone_count": 1,
              "size": {
                "resource": "memory",
                "value": 1024
              }
            }
          ],
          "kibana": {
            "version": "8.8.0-SNAPSHOT"
          }
        },
        "ref_id": "main-kibana"
      }
    ]
  },
  "settings": {
    "autoscaling_enabled": false
  },
  "name": "my-test-deployment",
  "metadata": {
    "system_owned": false
  }
}'
```
Where `$API_KEY` is provided by the cloud console
and the integrations docker image is the one you generated with the make command

## Related issues

- Closes #2479