### PR TITLE
Fix issue with newlines when reading secret files

### DIFF
--- a/internal/pkg/config/instrumentation.go
+++ b/internal/pkg/config/instrumentation.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 
@@ -94,7 +95,7 @@ func (c *Instrumentation) APMHTTPTransportOptions() (apmtransport.HTTPTransportO
 		if err != nil {
 			return apmtransport.HTTPTransportOptions{}, fmt.Errorf("unable to read API key file: %w", err)
 		}
-		apiKey = string(p)
+		apiKey = strings.TrimSpace(string(p))
 	}
 
 	secretToken := c.SecretToken
@@ -103,7 +104,7 @@ func (c *Instrumentation) APMHTTPTransportOptions() (apmtransport.HTTPTransportO
 		if err != nil {
 			return apmtransport.HTTPTransportOptions{}, fmt.Errorf("unable to read secret token file: %w", err)
 		}
-		secretToken = string(p)
+		secretToken = strings.TrimSpace(string(p))
 	}
 
 	return apmtransport.HTTPTransportOptions{

--- a/internal/pkg/config/output.go
+++ b/internal/pkg/config/output.go
@@ -160,7 +160,7 @@ func (c *Elasticsearch) ToESConfig(longPoll bool) (elasticsearch.Config, error) 
 		if err != nil {
 			return elasticsearch.Config{}, fmt.Errorf("unable to read service_token_path: %w", err)
 		}
-		serviceToken = string(p)
+		serviceToken = strings.TrimSpace(string(p))
 	}
 
 	return elasticsearch.Config{


### PR DESCRIPTION
Fix an issue that didn't occur in unit tests, but occurred in a real end to end test case where os.ReadFile would attach a newline to secret files.

Running under the agent and in stand-alone mode showed an issue where secret file values were being incorrectly returned with a newline character at the end.

For example when the service_token was incorrctly read the error message was:
```
21:45:39.813 ERR fail elasticsearch info error.message="net/http: invalid header field value for \"Authorization\"" cluster.addr=["https://192.168.4.20:9200"] cluster.maxConnsPersHost=128 ecs.version=1.6.0 service.name=fleet-server
```

To recreate:
```
echo MY-SERVICE-TOKEN > /tmp/service-token
```
In fleet-server.yml:
```
output.elasticsearch:
  ...
  service_token_path: /tmp/service-token
```