### PR TITLE
Add duration format to openapi spec

### DIFF
--- a/internal/pkg/api/openapi.gen.go
+++ b/internal/pkg/api/openapi.gen.go
@@ -175,6 +175,7 @@ type CheckinRequest struct {
 
 	// PollTimeout An optional timeout value that informs fleet-server of when a client will time out on it's checkin request.
 	// If not specified fleet-server will use the timeout values specified in the config (defaults to 5m polling and a 10m write timeout).
+	// The value, if specified is expected to be a string that is parsable by [time.ParseDuration](https://pkg.go.dev/time#ParseDuration).
 	// If specified fleet-server will set its poll timeout to `max(1m, poll_timeout-2m)` and its write timeout to `max(2m, poll_timout-1m)`.
 	PollTimeout *string `json:"poll_timeout,omitempty"`
 

--- a/model/openapi.yml
+++ b/model/openapi.yml
@@ -259,6 +259,7 @@ components:
           description: |
             An optional timeout value that informs fleet-server of when a client will time out on it's checkin request.
             If not specified fleet-server will use the timeout values specified in the config (defaults to 5m polling and a 10m write timeout).
+            The value, if specified is expected to be a string that is parsable by [time.ParseDuration](https://pkg.go.dev/time#ParseDuration).
             If specified fleet-server will set its poll timeout to `max(1m, poll_timeout-2m)` and its write timeout to `max(2m, poll_timout-1m)`.
           type: string
           format: duration


### PR DESCRIPTION
Add expected form for `poll_timeout` value.

- Closes #2505 