### PR TITLE
Disable Buildkite builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,7 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+
 steps:
-  - command: ls
+  - label: "Update git fetch refmap"
     plugins:
       - Hivebrite/git-flags#v0.0.1:
           fetch: "-v --prune --refmap='+refs/pull/{{BUILDKITE_PULL_REQUEST}}/merge:refs/pull/{{BUILDKITE_PULL_REQUEST}}/merge'"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,8 @@
 steps:
+  - command: ls
+    plugins:
+      - Hivebrite/git-flags#v0.0.1:
+          fetch: "-v --prune --refmap='+refs/pull/{{BUILDKITE_PULL_REQUEST}}/merge:refs/pull/{{BUILDKITE_PULL_REQUEST}}/merge'"
+
   - label: "Example test"
     command: echo "Hello!"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,11 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 steps:
-  - label: "Update git fetch refmap"
-    command: echo "Updating fetch refmap"
-    plugins:
-      - Hivebrite/git-flags#v0.0.1:
-          fetch: "-v --prune --refmap='+refs/pull/{{BUILDKITE_PULL_REQUEST}}/merge:refs/pull/{{BUILDKITE_PULL_REQUEST}}/merge'"
 
   - label: "Example test"
     command: echo "Hello!"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,6 +2,7 @@
 
 steps:
   - label: "Update git fetch refmap"
+    command: echo "Updating fetch refmap"
     plugins:
       - Hivebrite/git-flags#v0.0.1:
           fetch: "-v --prune --refmap='+refs/pull/{{BUILDKITE_PULL_REQUEST}}/merge:refs/pull/{{BUILDKITE_PULL_REQUEST}}/merge'"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -37,6 +37,9 @@ spec:
     spec:
       repository: elastic/fleet-server
       pipeline_file: ".buildkite/pipeline.yml"
+      provider_settings:
+        build_pull_request_forks: false
+        build_pull_requests: false # PR builds are managed by buildkite-pr-bot
       teams:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

Set the appropriate settings for the build_pull* parameters so that we dont try and trigger anything.

## How does this PR solve the problem?

Right now with onboarding to Backstage, the system provisioned a new Buildkite pipeline for the repository, this pipeline is not yet ready, so we should not trigger it. 
The trigger will happen through the API and not the automatic build trigger. 


## How to test this PR locally

No tests mechanism to locally test buildkite/backstage


## Related issues

- Relates #2517 