### PR TITLE
Add go-benchmark pipeline entity definition

### DIFF
--- a/.buildkite/pipeline.bennchmark.yml
+++ b/.buildkite/pipeline.bennchmark.yml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+steps:
+  - label: ":wave: Initial step"
+    command: echo "Hello!"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -42,3 +42,34 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-benchmark-fleet-server
+  description: Buildkite go-benchmark pipeline for Elastic Fleet Server project
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/fleet-server
+
+spec:
+  type: buildkite-pipeline
+  owner: group:ingest-fp
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: go-benchmark-fleet-server
+      description: Buildkite go-benchmark pipeline for Elastic Fleet Server project
+    spec:
+      repository: elastic/fleet-server
+      pipeline_file: ".buildkite/pipeline.benchmark.yml"
+      cancel_intermediate_builds: true
+      teams:
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

We have already a go-benchmark test running as part of the GH actions, but it does not work as we want it to be. 
For this reason, we are trying out Buildkite.

This commit adds the required definition for adding a new Buildkite
pipeline that would run the go-benchmark steps.

Signed-off-by: Alexandros, Sapranidis <alexandros@elastic.co>

## How does this PR solve the problem?

This PR introduce a new Buildkite pipeline that is intended to run the go-benchmark tests. 

## How to test this PR locally

There is no local testing for running pipelines with Buildkite
