### PR TITLE
Add git-flags buildkite plugin

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,10 @@
 steps:
+  - label: "Update git fetch refmap"
+    command: echo "Updating fetch refmap"
+    plugins:
+      - Hivebrite/git-flags#v0.0.1:
+          fetch: "-v --prune --refmap='+refs/pull/{{BUILDKITE_PULL_REQUEST}}/merge:refs/pull/{{BUILDKITE_PULL_REQUEST}}/merge'"
+
+
   - label: "Example test"
     command: echo "Hello!"


### PR DESCRIPTION

## What is the problem this PR solves?

This plugin triggers the pre-checkout hook of buildkite and adjusts the git fetch flags by adding a refmap.

## How does this PR solve the problem?

This is intended for the buildkite migration.
