### PR TITLE
Replace pre-checkout with post-checkout

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+checkout_merge() {
+    local target_branch=$1
+    local pr_commit=$2
+    local merge_branch=$3
+
+    if [[ -z "${target_branch}" ]]; then
+        echo "No pull request target branch"
+        exit 1
+    fi
+
+    git fetch -v origin "${target_branch}"
+    git checkout FETCH_HEAD
+    echo "Current branch: $(git rev-parse --abbrev-ref HEAD)"
+
+    # create temporal branch to merge the PR with the target branch
+    git checkout -b ${merge_branch}
+    echo "New branch created: $(git rev-parse --abbrev-ref HEAD)"
+
+    # set author identity so it can be run git merge
+    git config user.name "github-merged-pr-post-checkout"
+    git config user.email "auto-merge@buildkite"
+
+    git merge --no-edit "${BUILDKITE_COMMIT}" || {
+        local merge_result=$?
+        echo "Merge failed: ${merge_result}"
+        git merge --abort
+        exit ${merge_result}
+    }
+}
+
+pull_request="${BUILDKITE_PULL_REQUEST:-false}"
+
+if [[ "${pull_request}" == "false" ]]; then
+    echo "Not a pull request, skipping"
+    exit 0
+fi
+
+TARGET_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}"
+PR_COMMIT="${BUILDKITE_COMMIT}"
+PR_ID=${BUILDKITE_PULL_REQUEST}
+MERGE_BRANCH="pr_merge_${PR_ID}"
+
+checkout_merge "${TARGET_BRANCH}" "${PR_COMMIT}" "${MERGE_BRANCH}"
+
+echo "Commit information"
+git log --format=%B -n 1
+
+# Ensure buildkite groups are rendered
+echo ""

--- a/.buildkite/hooks/pre-checkout
+++ b/.buildkite/hooks/pre-checkout
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -eu
-
-# Configure the remote to have access to the PR refs needed for buildkite-pr-bot 
-# with the enabled use_merge_commit setting
-git config remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pull/*'

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -9,7 +9,6 @@
         "build_on_comment": true,
         "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$",
         "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$",
-        "use_merge_commit": true,
         "fail_on_not_mergeable": true
       }]
 }


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

The pre-checkout hook is only working on the agent level and not in the repo scope.

In order to have working the option to use the merge commit of the PR I am migrating the post-checkout script that we used in elastic-package

## How does this PR solve the problem?

Using the `use_merge_commit` instructs the bot to trigger Buildkite with the `ref/pull/{id}/merge` sha. Which is not reachable if you have not fetched the `refs/pull*`. 

Until we fix this with the bot, this PR changes the setting of the bot, and adds a hook that would take care of merging the target branch with the tip of the PR. 

