### PR TITLE
fix for action_seq_no being overwritten with 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,12 @@ make test-unit
 
 This make target will execute the go unit tests and should normally pass without an issue.
 
+To run tests in a package or a function, run like this:
+
+```
+go test -v ./internal/pkg/checkin -run TestBulkSimple
+```
+
 #### Running go benchmark tests
 
 It's a good practice before you start your changes to establish the current baseline of the benchmarks in your machine.

--- a/changelog/fragments/1684151814-fix-action-seq-no.yaml
+++ b/changelog/fragments/1684151814-fix-action-seq-no.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: fix-action-seq-no
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: Fix for a bug where agent `action_seq_no` was overwritten with 0 if the `ackToken` was not provided.
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 2582
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 2519

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -387,7 +387,7 @@ func (ct *CheckinT) resolveSeqNo(ctx context.Context, zlog zerolog.Logger, req C
 				zlog.Debug().Str("token", *ackToken).Msg("revision token not found")
 				err = nil
 				// should be left the ActionSeqNo if no ackToken, otherwise would be overwritten with 0 on a Fleet Server restart
-				return seqno, nil
+				return seqno, err
 			} else {
 				return seqno, fmt.Errorf("resolveSeqNo: %w", err)
 			}

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -295,12 +295,14 @@ func (ct *CheckinT) writeResponse(zlog zerolog.Logger, w http.ResponseWriter, r 
 		}
 	}
 
-	span, _ := apm.StartSpanOptions(r.Context(), "action delivery", "fleet-server", apm.SpanOptions{
-		Links: links,
-	})
-	span.Context.SetLabel("action_count", len(fromPtr(resp.Actions)))
-	span.Context.SetLabel("agent_id", agent.Id)
-	defer span.End()
+	if len(fromPtr(resp.Actions)) > 0 {
+		span, _ := apm.StartSpanOptions(r.Context(), "action delivery", "fleet-server", apm.SpanOptions{
+			Links: links,
+		})
+		span.Context.SetLabel("action_count", len(fromPtr(resp.Actions)))
+		span.Context.SetLabel("agent_id", agent.Id)
+		defer span.End()
+	}
 
 	for _, action := range fromPtr(resp.Actions) {
 		zlog.Info().
@@ -384,6 +386,8 @@ func (ct *CheckinT) resolveSeqNo(ctx context.Context, zlog zerolog.Logger, req C
 			if errors.Is(err, dl.ErrNotFound) {
 				zlog.Debug().Str("token", *ackToken).Msg("revision token not found")
 				err = nil
+				// should be left the ActionSeqNo if no ackToken, otherwise would be overwritten with 0 on a Fleet Server restart
+				return seqno, nil
 			} else {
 				return seqno, fmt.Errorf("resolveSeqNo: %w", err)
 			}

--- a/internal/pkg/checkin/bulk.go
+++ b/internal/pkg/checkin/bulk.go
@@ -209,11 +209,6 @@ func (bc *Bulk) flush(ctx context.Context) error {
 				fields[dl.FieldAgent] = map[string]interface{}{
 					dl.FieldAgentVersion: pendingData.extra.ver,
 				}
-				// Duplicates the writes done when an upgrade is ack'd by the agent.
-				// This helps eliminate the case where the agent is stuck in upgrading after it's already upgraded if the ack
-				// is never received.
-				fields[dl.FieldUpgradeStartedAt] = nil
-				fields[dl.FieldUpgradedAt] = nowTimestamp
 			}
 
 			// Update local metadata if provided

--- a/internal/pkg/checkin/bulk.go
+++ b/internal/pkg/checkin/bulk.go
@@ -208,12 +208,12 @@ func (bc *Bulk) flush(ctx context.Context) error {
 			if pendingData.extra.ver != "" {
 				fields[dl.FieldAgent] = map[string]interface{}{
 					dl.FieldAgentVersion: pendingData.extra.ver,
-					// Duplicates the writes done when an upgrade is ack'd by the agent.
-					// This helps eliminate the case where the agent is stuck in upgrading after it's already upgraded if the ack
-					// is never received.
-					dl.FieldUpgradeStartedAt: nil,
-					dl.FieldUpgradedAt:       nowTimestamp,
 				}
+				// Duplicates the writes done when an upgrade is ack'd by the agent.
+				// This helps eliminate the case where the agent is stuck in upgrading after it's already upgraded if the ack
+				// is never received.
+				fields[dl.FieldUpgradeStartedAt] = nil
+				fields[dl.FieldUpgradedAt] = nowTimestamp
 			}
 
 			// Update local metadata if provided

--- a/internal/pkg/checkin/bulk.go
+++ b/internal/pkg/checkin/bulk.go
@@ -208,6 +208,11 @@ func (bc *Bulk) flush(ctx context.Context) error {
 			if pendingData.extra.ver != "" {
 				fields[dl.FieldAgent] = map[string]interface{}{
 					dl.FieldAgentVersion: pendingData.extra.ver,
+					// Duplicates the writes done when an upgrade is ack'd by the agent.
+					// This helps eliminate the case where the agent is stuck in upgrading after it's already upgraded if the ack
+					// is never received.
+					dl.FieldUpgradeStartedAt: nil,
+					dl.FieldUpgradedAt:       nowTimestamp,
 				}
 			}
 

--- a/internal/pkg/checkin/bulk_test.go
+++ b/internal/pkg/checkin/bulk_test.go
@@ -41,21 +41,14 @@ func matchOp(tb testing.TB, c bulkcase, ts time.Time) func(ops []bulk.MultiOp) b
 		}
 		tb.Log("Operation match! validating details...")
 
-		type AgentObj struct {
-			Version string `json:"version"`
-		}
-
 		// Decode and match operation
 		// NOTE putting the extra validation here seems strange, maybe we should read the args in the test body intstead?
 		type updateT struct {
-			LastCheckin      string          `json:"last_checkin"`
-			Status           string          `json:"last_checkin_status"`
-			UpdatedAt        string          `json:"updated_at"`
-			Meta             json.RawMessage `json:"local_metadata"`
-			SeqNo            sqn.SeqNo       `json:"action_seq_no"`
-			Agent            json.RawMessage `json:"agent"`
-			UpgradeStartedAt string          `json:"upgrade_started_at"`
-			UpgradedAt       string          `json:"upgraded_at"`
+			LastCheckin string          `json:"last_checkin"`
+			Status      string          `json:"last_checkin_status"`
+			UpdatedAt   string          `json:"updated_at"`
+			Meta        json.RawMessage `json:"local_metadata"`
+			SeqNo       sqn.SeqNo       `json:"action_seq_no"`
 		}
 
 		m := make(map[string]updateT)
@@ -83,19 +76,6 @@ func matchOp(tb testing.TB, c bulkcase, ts time.Time) func(ops []bulk.MultiOp) b
 			tb.Error("status mismatch")
 		}
 
-		if c.ver != "" {
-			var agentObj AgentObj
-			if err := json.Unmarshal(sub.Agent, &agentObj); err != nil {
-				tb.Fatalf("unable to validate operation: %v", err)
-			}
-			if c.ver != agentObj.Version {
-				tb.Error("version mismatch")
-			}
-			if sub.UpgradeStartedAt != "" {
-				tb.Error("expected UpgradeStartedAt to be cleared on version update")
-			}
-			validateTimestamp(tb, ts.Truncate(time.Second), sub.UpgradedAt)
-		}
 		return true
 	}
 }

--- a/internal/pkg/checkin/bulk_test.go
+++ b/internal/pkg/checkin/bulk_test.go
@@ -101,15 +101,14 @@ func matchOp(tb testing.TB, c bulkcase, ts time.Time) func(ops []bulk.MultiOp) b
 }
 
 type bulkcase struct {
-	desc               string
-	id                 string
-	status             string
-	message            string
-	meta               []byte
-	components         []byte
-	seqno              sqn.SeqNo
-	ver                string
-	upgrade_started_at string
+	desc       string
+	id         string
+	status     string
+	message    string
+	meta       []byte
+	components []byte
+	seqno      sqn.SeqNo
+	ver        string
 }
 
 func TestBulkSimple(t *testing.T) {
@@ -126,7 +125,6 @@ func TestBulkSimple(t *testing.T) {
 			nil,
 			nil,
 			"",
-			"",
 		},
 		{
 			"Singled field case",
@@ -136,7 +134,6 @@ func TestBulkSimple(t *testing.T) {
 			[]byte(`{"hey":"now"}`),
 			[]byte(`[{"id":"winlog-default"}]`),
 			nil,
-			"",
 			"",
 		},
 		{
@@ -148,7 +145,6 @@ func TestBulkSimple(t *testing.T) {
 			[]byte(`[{"id":"winlog-default","type":"winlog"}]`),
 			nil,
 			ver,
-			"started_at",
 		},
 		{
 			"Multi field nested case",
@@ -158,7 +154,6 @@ func TestBulkSimple(t *testing.T) {
 			[]byte(`{"hey":"now","wee":{"little":"doggie"}}`),
 			[]byte(`[{"id":"winlog-default","type":"winlog"}]`),
 			nil,
-			"",
 			"",
 		},
 		{
@@ -170,7 +165,6 @@ func TestBulkSimple(t *testing.T) {
 			nil,
 			sqn.SeqNo{1, 2, 3, 4},
 			ver,
-			"started_at",
 		},
 		{
 			"Field case with seqNo",
@@ -181,7 +175,6 @@ func TestBulkSimple(t *testing.T) {
 			[]byte(`[{"id":"log-default"}]`),
 			sqn.SeqNo{5, 6, 7, 8},
 			ver,
-			"started_at",
 		},
 		{
 			"Unusual status",
@@ -192,7 +185,6 @@ func TestBulkSimple(t *testing.T) {
 			nil,
 			nil,
 			"",
-			"",
 		},
 		{
 			"Empty status",
@@ -202,7 +194,6 @@ func TestBulkSimple(t *testing.T) {
 			nil,
 			nil,
 			nil,
-			"",
 			"",
 		},
 	}


### PR DESCRIPTION
Bugfix

## What is the problem this PR solves?

Fix for a bug noticed in upgrades, where the upgrade action is the first action (`_seq_no:0`), and the agent doesn't get the action delivered on the next checkin if it misses the first checkin.

## How does this PR solve the problem?

In `resolveSeqNo`, the agent's `action_seq_no` was incorrectly overwritten with 0 if the `ackToken` was not provided, which is the case for the first action.
In this case the agent doesn't get the action with `seq_no:0`, as Fleet Server considers it already delivered.
The agent should keep `action_seq_on:-1` until it gets an action delivered.

The overwrite is also wrong after Fleet Server restart, where the `ackToken` is empty (if I understand this correctly).

## How to test this PR locally

- Start a fresh ES, kibana, fleet-server (no actions created before)
- Enroll 1 drone with horde
- restart fleet-server
- trigger an upgrade action, the action is pesristed with `_seq_no:0`
- wait for the drone to checkin, it should receive the action and upgrade successfully.

Agent (drone) after enroll:
```
        "_source": {
          "action_seq_no": [
            -1
          ],
          "local_metadata": {
            "elastic": {
              "agent": {
                "id": "e28a2fa7-346f-42da-a7e9-76d8f0fe17fd",
                "version": "8.2.0"
              }
            },
```

After upgrade:
```
          "action_seq_no": [
            0
          ],
          "local_metadata": {
            "elastic": {
              "agent": {
                "id": "e28a2fa7-346f-42da-a7e9-76d8f0fe17fd",
                "version": "8.2.1"
              }
            },
```

Action with seq_no:
```
 {
        "_index": ".fleet-actions-7",
        "_id": "5347065f-2b26-4c5b-a253-9f34e6fcddc5",
        "_seq_no": 0,
        "_primary_term": 1,
        "_score": 1,
        "_source": {
          "@timestamp": "2023-05-12T12:12:27.247Z",
          "expiration": "2023-06-11T12:12:27.247Z",
          "agents": [
            "e28a2fa7-346f-42da-a7e9-76d8f0fe17fd"
          ],
          "action_id": "3d8ade67-388a-48ba-aa15-842bd8dd64a8",
          "data": {
            "version": "8.2.1"
          },
          "type": "UPGRADE",
          "traceparent": "00-330370b9dfdceb2b46606abefe21224d-7600178b8a212d24-01"
        }
      }
```

Fleet server delivered the action:
```
12:13:21.535 INF Action delivered to agent on checkin ackToken=5347065f-2b26-4c5b-a253-9f34e6fcddc5 createdAt=2023-05-12T12:12:27.247Z ecs.version=1.6.0 fleet.access.apikey.id=Fs7fD4gBC7gel4XV8JLp fleet.agent.id=e28a2fa7-346f-42da-a7e9-76d8f0fe17fd http.request.id=aea58b3c-18f8-4675-9ad5-74077d5a3228 id=3d8ade67-388a-48ba-aa15-842bd8dd64a8 inputType= server.address= service.name=fleet-server timeout=0 type=UPGRADE
```

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [x] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

Relates https://github.com/elastic/fleet-server/issues/2519
