### PR TITLE
[Fleet] Allow to enable instrumentation through environment variable

### DIFF
--- a/internal/pkg/server/fleet.go
+++ b/internal/pkg/server/fleet.go
@@ -537,8 +537,10 @@ func (f *Fleet) Reload(ctx context.Context, cfg *config.Config) error {
 	return nil
 }
 
+const envAPMActive = "ELASTIC_APM_ACTIVE"
+
 func (f *Fleet) initTracer(cfg config.Instrumentation) (*apm.Tracer, error) {
-	if !cfg.Enabled {
+	if !cfg.Enabled && os.Getenv(envAPMActive) != "true" {
 		return nil, nil
 	}
 

--- a/internal/pkg/server/fleet_test.go
+++ b/internal/pkg/server/fleet_test.go
@@ -113,3 +113,45 @@ func Test_configChangedServer(t *testing.T) {
 		})
 	}
 }
+
+func Test_initTracer(t *testing.T) {
+	testcases := []struct {
+		name                 string
+		apmActiveEnvVariable string
+		expectTracer         bool
+		cfg                  config.Instrumentation
+	}{{
+		name:                 "enabled with env variable",
+		apmActiveEnvVariable: "true",
+		expectTracer:         true,
+		cfg:                  config.Instrumentation{},
+	}, {
+		name:                 "enabled with config",
+		apmActiveEnvVariable: "",
+		expectTracer:         true,
+		cfg: config.Instrumentation{
+			Enabled: true,
+		},
+	}, {
+		name:                 "not enabled",
+		apmActiveEnvVariable: "",
+		expectTracer:         false,
+		cfg:                  config.Instrumentation{},
+	}}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := Fleet{}
+			t.Setenv("ELASTIC_APM_ACTIVE", tc.apmActiveEnvVariable)
+			tarcer, err := f.initTracer(tc.cfg)
+			assert.Nil(t, err)
+
+			if tc.expectTracer {
+				assert.NotNil(t, tarcer)
+			} else {
+				assert.Nil(t, tarcer)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
## Description 

Allow to enabled instrumentation through environment variable through `ELASTIC_APM_ACTIVE` environment variables

```
ELASTIC_APM_ENVIRONMENT=dev ELASTIC_APM_ACTIVE=true ELASTIC_APM_SERVICE_NAME=fleet-server ELASTIC_APM_SECRET_TOKEN=<TOKEN> ELASTIC_APM_SERVER_URL=<SERVER_URL> ./main
```

<img width="1226" alt="Screenshot 2023-05-12 at 9 21 24 AM" src="https://github.com/elastic/fleet-server/assets/1336873/4ccdd5a3-5537-4857-864b-83376676c99f">




## Todo 

- [x] add unit tests