### PR TITLE
Remove Elastic Agent control plane team as code owner.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Team responsible for Fleet Server
-* @elastic/fleet @elastic/elastic-agent-control-plane
+* @elastic/fleet
 
 # Allow to auto-merge PRs with Mergify
 dev-tools/integration/.env


### PR DESCRIPTION
We kept both teams as code owners when the Fleet team initially took over as owners of Fleet server. The Elastic Agent team's review hasn't been necessary for a while now, so I'm removing us as code owners. You can still ping us for opinions where needed.