### PR TITLE
[8.9](backport #2692) Adds delivery module tests

### DIFF
--- a/internal/pkg/api/handleFileDelivery_test.go
+++ b/internal/pkg/api/handleFileDelivery_test.go
@@ -1,0 +1,432 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !integration
+
+package api
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
+	"github.com/elastic/fleet-server/v7/internal/pkg/cache"
+	"github.com/elastic/fleet-server/v7/internal/pkg/config"
+	"github.com/elastic/fleet-server/v7/internal/pkg/es"
+	"github.com/elastic/fleet-server/v7/internal/pkg/file"
+	"github.com/elastic/fleet-server/v7/internal/pkg/file/delivery"
+	"github.com/elastic/fleet-server/v7/internal/pkg/model"
+
+	itesting "github.com/elastic/fleet-server/v7/internal/pkg/testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	isFileMetaSearch = mock.MatchedBy(func(idx string) bool {
+		return strings.HasPrefix(idx, fmt.Sprintf(delivery.FileHeaderIndexPattern, ""))
+	})
+	isFileChunkSearch = mock.MatchedBy(func(idx string) bool {
+		return strings.HasPrefix(idx, fmt.Sprintf(delivery.FileDataIndexPattern, ""))
+	})
+)
+
+func TestFileDeliveryRouteDisallowedMethods(t *testing.T) {
+	hr, _, _, fakebulk := prepareFileDeliveryMock(t)
+	rec := httptest.NewRecorder()
+	fakebulk.On("Search",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	).Return(&es.ResultT{}, nil)
+
+	disallowed := []string{
+		http.MethodPost,
+		http.MethodDelete,
+		http.MethodPut,
+	}
+
+	for _, method := range disallowed {
+		t.Run("filedelivery"+method, func(t *testing.T) {
+			hr.ServeHTTP(rec, httptest.NewRequest(method, "/api/fleet/file/X", nil))
+			assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+		})
+	}
+}
+
+func TestFileDeliveryRouteGetMissingFile(t *testing.T) {
+	hr, _, _, fakebulk := prepareFileDeliveryMock(t)
+	rec := httptest.NewRecorder()
+	fakebulk.On("Search",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	).Return(&es.ResultT{}, nil)
+	hr.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/fleet/file/X", nil))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// if metadata exists, but no chunks, file should be 404
+func TestFileDeliveryNoChunks(t *testing.T) {
+	hr, _, _, fakebulk := prepareFileDeliveryMock(t)
+	rec := httptest.NewRecorder()
+
+	fakebulk.On("Search", mock.Anything, isFileMetaSearch, mock.Anything, mock.Anything, mock.Anything).Return(
+		&es.ResultT{
+			HitsT: es.HitsT{
+				Hits: []es.HitT{
+					{
+						ID:      "X",
+						SeqNo:   1,
+						Version: 1,
+						Index:   fmt.Sprintf(delivery.FileHeaderIndexPattern, "endpoint"),
+						Source: []byte(`{
+							"file": {
+								"created": "2023-06-05T15:23:37.499Z",
+								"Status": "READY",
+								"Updated": "2023-06-05T15:23:37.499Z",
+								"name": "test.txt",
+								"mime_type": "text/plain",
+								"Meta": {
+									"target_agents": ["someagent"],
+									"action_id": ""
+								},
+								"size": 256
+							}
+						}`),
+					},
+				},
+			},
+		}, nil,
+	).Once()
+	fakebulk.On("Search", mock.Anything, isFileChunkSearch, mock.Anything, mock.Anything, mock.Anything).Return(
+		&es.ResultT{
+			HitsT: es.HitsT{
+				Hits: []es.HitT{},
+			},
+		}, nil,
+	)
+
+	hr.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/fleet/file/X", nil))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestFileDelivery(t *testing.T) {
+	hr, _, tx, bulk := prepareFileDeliveryMock(t)
+	rec := httptest.NewRecorder()
+
+	bulk.On("Search", mock.Anything, isFileMetaSearch, mock.Anything, mock.Anything, mock.Anything).Return(
+		&es.ResultT{
+			HitsT: es.HitsT{
+				Hits: []es.HitT{{
+					ID:      "X",
+					SeqNo:   1,
+					Version: 1,
+					Index:   fmt.Sprintf(delivery.FileHeaderIndexPattern, "endpoint"),
+					Source: []byte(`{
+						"file": {
+							"created": "2023-06-05T15:23:37.499Z",
+							"Status": "READY",
+							"Updated": "2023-06-05T15:23:37.499Z",
+							"name": "somefile",
+							"mime_type": "application/octet-stream",
+							"Meta": {
+								"target_agents": ["someagent"],
+								"action_id": ""
+							},
+							"size": 2
+						}
+					}`),
+				}},
+			},
+		}, nil,
+	)
+	bulk.On("Search", mock.Anything, isFileChunkSearch, mock.Anything, mock.Anything, mock.Anything).Return(
+		&es.ResultT{
+			HitsT: es.HitsT{
+				Hits: []es.HitT{
+					{
+						ID:      "X.0",
+						SeqNo:   1,
+						Version: 1,
+						Index:   fmt.Sprintf(delivery.FileDataIndexPattern, "endpoint"),
+						Fields: map[string]interface{}{
+							file.FieldBaseID: []interface{}{"X"},
+							file.FieldLast:   []interface{}{true},
+						},
+					},
+				},
+			},
+		}, nil,
+	)
+
+	tx.Response = sendBodyBytes(hexDecode("A7665F696E64657878212E666C6565742D66696C6564656C69766572792D646174612D656E64706F696E74635F69646578797A2E30685F76657273696F6E01675F7365715F6E6F016D5F7072696D6172795F7465726D0165666F756E64F5666669656C6473A164646174618142ABCD"))
+
+	hr.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/fleet/file/X", nil))
+
+	bulk.AssertCalled(t, "Search", mock.Anything, isFileMetaSearch, mock.Anything, mock.Anything, mock.Anything)
+	bulk.AssertCalled(t, "Search", mock.Anything, isFileChunkSearch, mock.Anything, mock.Anything, mock.Anything)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, []byte{0xAB, 0xCD}, rec.Body.Bytes())
+}
+
+func TestFileDeliveryMultipleChunks(t *testing.T) {
+	hr, _, tx, bulk := prepareFileDeliveryMock(t)
+	rec := httptest.NewRecorder()
+
+	bulk.On("Search", mock.Anything, isFileMetaSearch, mock.Anything, mock.Anything, mock.Anything).Return(
+		&es.ResultT{
+			HitsT: es.HitsT{
+				Hits: []es.HitT{{
+					ID:      "X",
+					SeqNo:   1,
+					Version: 1,
+					Index:   fmt.Sprintf(delivery.FileHeaderIndexPattern, "endpoint"),
+					Source: []byte(`{
+						"file": {
+							"created": "2023-06-05T15:23:37.499Z",
+							"Status": "READY",
+							"Updated": "2023-06-05T15:23:37.499Z",
+							"name": "somefile",
+							"mime_type": "application/octet-stream",
+							"Meta": {
+								"target_agents": ["someagent"],
+								"action_id": ""
+							},
+							"size": 4
+						}
+					}`),
+				}},
+			},
+		}, nil,
+	)
+	bulk.On("Search", mock.Anything, isFileChunkSearch, mock.Anything, mock.Anything, mock.Anything).Return(
+		&es.ResultT{
+			HitsT: es.HitsT{
+				Hits: []es.HitT{
+					{
+						ID:      "X.0",
+						SeqNo:   1,
+						Version: 1,
+						Index:   fmt.Sprintf(delivery.FileDataIndexPattern, "endpoint"),
+						Fields: map[string]interface{}{
+							file.FieldBaseID: []interface{}{"X"},
+						},
+					},
+					{
+						ID:      "X.1",
+						SeqNo:   1,
+						Version: 1,
+						Index:   fmt.Sprintf(delivery.FileDataIndexPattern, "endpoint"),
+						Fields: map[string]interface{}{
+							file.FieldBaseID: []interface{}{"X"},
+							file.FieldLast:   []interface{}{true},
+						},
+					},
+				},
+			},
+		}, nil,
+	)
+
+	mockChunks := []string{
+		"A7665F696E64657878212E666C6565742D66696C6564656C69766572792D646174612D656E64706F696E74635F69646578797A2E30685F76657273696F6E01675F7365715F6E6F016D5F7072696D6172795F7465726D0165666F756E64F5666669656C6473A164646174618142ABCD",
+		"A7665F696E64657878212E666C6565742D66696C6564656C69766572792D646174612D656E64706F696E74635F69646578797A2E31685F76657273696F6E01675F7365715F6E6F016D5F7072696D6172795F7465726D0165666F756E64F5666669656C6473A164646174618142EF01",
+	}
+
+	tx.RoundTripFn = func(req *http.Request) (*http.Response, error) {
+		if strings.HasSuffix(req.URL.Path, "X.0") {
+			return sendBodyBytes(hexDecode(mockChunks[0])), nil
+		} else if strings.HasSuffix(req.URL.Path, "X.1") {
+			return sendBodyBytes(hexDecode(mockChunks[1])), nil
+		} else {
+			return nil, errors.New("invalid chunk index!")
+		}
+	}
+
+	hr.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/fleet/file/X", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, []byte{0xAB, 0xCD, 0xEF, 0x01}, rec.Body.Bytes())
+}
+
+func TestFileDeliverySetsHeaders(t *testing.T) {
+	hr, _, tx, bulk := prepareFileDeliveryMock(t)
+	rec := httptest.NewRecorder()
+
+	bulk.On("Search", mock.Anything, isFileMetaSearch, mock.Anything, mock.Anything, mock.Anything).Return(
+		&es.ResultT{
+			HitsT: es.HitsT{
+				Hits: []es.HitT{{
+					ID:      "X",
+					SeqNo:   1,
+					Version: 1,
+					Index:   fmt.Sprintf(delivery.FileHeaderIndexPattern, "endpoint"),
+					Source: []byte(`{
+						"file": {
+							"created": "2023-06-05T15:23:37.499Z",
+							"Status": "READY",
+							"Updated": "2023-06-05T15:23:37.499Z",
+							"name": "test.csv",
+							"mime_type": "text/csv",
+							"Meta": {
+								"target_agents": ["someagent"],
+								"action_id": ""
+							},
+							"size": 4
+						}
+					}`),
+				}},
+			},
+		}, nil,
+	)
+	bulk.On("Search", mock.Anything, isFileChunkSearch, mock.Anything, mock.Anything, mock.Anything).Return(
+		&es.ResultT{
+			HitsT: es.HitsT{
+				Hits: []es.HitT{
+					{
+						ID:      "X.0",
+						SeqNo:   1,
+						Version: 1,
+						Index:   fmt.Sprintf(delivery.FileDataIndexPattern, "endpoint"),
+						Fields: map[string]interface{}{
+							file.FieldBaseID: []interface{}{"X"},
+							file.FieldLast:   []interface{}{true},
+						},
+					},
+				},
+			},
+		}, nil,
+	)
+	tx.Response = sendBodyBytes(hexDecode("A7665F696E64657878212E666C6565742D66696C6564656C69766572792D646174612D656E64706F696E74635F69646578797A2E30685F76657273696F6E01675F7365715F6E6F016D5F7072696D6172795F7465726D0165666F756E64F5666669656C6473A164646174618142ABCD"))
+
+	hr.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/fleet/file/X", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "text/csv", rec.Header().Get("Content-Type"))
+	assert.Equal(t, "4", rec.Header().Get("Content-Length"))
+	assert.Empty(t, rec.Header().Get("X-File-SHA2"))
+}
+
+func TestFileDeliverySetsHashWhenPresent(t *testing.T) {
+	hr, _, tx, bulk := prepareFileDeliveryMock(t)
+	rec := httptest.NewRecorder()
+
+	bulk.On("Search", mock.Anything, isFileMetaSearch, mock.Anything, mock.Anything, mock.Anything).Return(
+		&es.ResultT{
+			HitsT: es.HitsT{
+				Hits: []es.HitT{{
+					ID:      "X",
+					SeqNo:   1,
+					Version: 1,
+					Index:   fmt.Sprintf(delivery.FileHeaderIndexPattern, "endpoint"),
+					Source: []byte(`{
+						"file": {
+							"created": "2023-06-05T15:23:37.499Z",
+							"Status": "READY",
+							"Updated": "2023-06-05T15:23:37.499Z",
+							"name": "test.csv",
+							"mime_type": "text/csv",
+							"Meta": {
+								"target_agents": ["someagent"],
+								"action_id": ""
+							},
+							"size": 4,
+							"hash": {
+								"sha256": "deadbeef"
+							}
+						}
+					}`),
+				}},
+			},
+		}, nil,
+	)
+	bulk.On("Search", mock.Anything, isFileChunkSearch, mock.Anything, mock.Anything, mock.Anything).Return(
+		&es.ResultT{
+			HitsT: es.HitsT{
+				Hits: []es.HitT{
+					{
+						ID:      "X.0",
+						SeqNo:   1,
+						Version: 1,
+						Index:   fmt.Sprintf(delivery.FileDataIndexPattern, "endpoint"),
+						Fields: map[string]interface{}{
+							file.FieldBaseID: []interface{}{"X"},
+							file.FieldLast:   []interface{}{true},
+						},
+					},
+				},
+			},
+		}, nil,
+	)
+	tx.Response = sendBodyBytes(hexDecode("A7665F696E64657878212E666C6565742D66696C6564656C69766572792D646174612D656E64706F696E74635F69646578797A2E30685F76657273696F6E01675F7365715F6E6F016D5F7072696D6172795F7465726D0165666F756E64F5666669656C6473A164646174618142ABCD"))
+
+	hr.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/fleet/file/X", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "deadbeef", rec.Header().Get("X-File-SHA2"))
+}
+
+/*
+	Helpers and mocks
+*/
+
+// prepareUploaderMock sets up common dependencies and registers upload routes to a returned router
+func prepareFileDeliveryMock(t *testing.T) (http.Handler, apiServer, *MockTransport, *itesting.MockBulk) {
+	// chunk index operations skip the bulker in order to send binary docs directly
+	// so a mock *elasticsearch.Client needs to be be prepared
+	mockES, tx := mockESClient(t)
+
+	fakebulk := itesting.NewMockBulk()
+	fakebulk.On("Client",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	).Return(mockES, nil)
+
+	c, err := cache.New(config.Cache{NumCounters: 100, MaxCost: 100000})
+	require.NoError(t, err)
+
+	si := apiServer{
+		ft: &FileDeliveryT{
+			bulker:      fakebulk,
+			chunkClient: mockES,
+			cache:       c,
+			deliverer:   delivery.New(mockES, fakebulk, maxFileSize),
+			authAgent: func(r *http.Request, id *string, bulker bulk.Bulk, c cache.Cache) (*model.Agent, error) {
+				return &model.Agent{
+					ESDocument: model.ESDocument{
+						Id: "foo",
+					},
+					Agent: &model.AgentMetadata{
+						ID: "foo",
+					},
+				}, nil
+			},
+		},
+	}
+
+	return Handler(&si), si, tx, fakebulk
+}
+
+func hexDecode(s string) []byte {
+	data, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}

--- a/internal/pkg/api/handleUpload_test.go
+++ b/internal/pkg/api/handleUpload_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -857,7 +858,7 @@ func TestUploadCompleteIncorrectTransitHash(t *testing.T) {
 func prepareUploaderMock(t *testing.T) (http.Handler, apiServer, *itesting.MockBulk) {
 	// chunk index operations skip the bulker in order to send binary docs directly
 	// so a mock *elasticsearch.Client needs to be be prepared
-	es := mockESClient(t)
+	es, _ := mockESClient(t)
 
 	fakebulk := itesting.NewMockBulk()
 	fakebulk.On("Create",
@@ -1024,13 +1025,9 @@ func (t *MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.RoundTripFn(req)
 }
 
-func mockESClient(t *testing.T) *elasticsearch.Client {
+func mockESClient(t *testing.T) (*elasticsearch.Client, *MockTransport) {
 	mocktrans := MockTransport{
-		Response: &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       ioutil.NopCloser(strings.NewReader(`{}`)),
-			Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
-		},
+		Response: sendBodyString("{}"), //nolint:bodyclose // nopcloser is used, linter does not see it
 	}
 
 	mocktrans.RoundTripFn = func(req *http.Request) (*http.Response, error) { return mocktrans.Response, nil }
@@ -1038,5 +1035,18 @@ func mockESClient(t *testing.T) *elasticsearch.Client {
 		Transport: &mocktrans,
 	})
 	require.NoError(t, err)
-	return client
+	return client, &mocktrans
+}
+
+func sendBodyString(body string) *http.Response { return sendBody(strings.NewReader(body)) }
+func sendBodyBytes(body []byte) *http.Response  { return sendBody(bytes.NewReader(body)) }
+func sendBody(body io.Reader) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       ioutil.NopCloser(body),
+		Header: http.Header{
+			"X-Elastic-Product": []string{"Elasticsearch"},
+			"Content-Type":      []string{"application/cbor"},
+		},
+	}
 }

--- a/internal/pkg/file/delivery/delivery_test.go
+++ b/internal/pkg/file/delivery/delivery_test.go
@@ -1,0 +1,303 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package delivery
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/es"
+	"github.com/elastic/fleet-server/v7/internal/pkg/file"
+	itesting "github.com/elastic/fleet-server/v7/internal/pkg/testing"
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// cbor decoding and encoding tools can be helpful for examining or changing the test data here
+// https://cbor.me/ may be helpful in verifying the shapes of the data
+
+func TestFindFile(t *testing.T) {
+	fakeBulk := itesting.NewMockBulk()
+
+	agentID := "abcagent"
+	fileID := "xyzfile"
+
+	fakeBulk.Mock.On("Search",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	).Return(&es.ResultT{
+		HitsT: es.HitsT{
+			Hits: []es.HitT{
+				{
+					ID:    fileID,
+					Index: fmt.Sprintf(FileHeaderIndexPattern, "endpoint"),
+					Source: []byte(`{
+						"file": {
+							"created": "2023-06-05T15:23:37.499Z",
+							"Status": "READY",
+							"Updated": "2023-06-05T15:23:37.499Z",
+							"name": "test.txt",
+							"mime_type": "text/plain",
+							"Meta": {
+								"target_agents": ["` + agentID + `"],
+								"action_id": ""
+							},
+							"size": 256,
+							"hash": {
+								"sha256": "b94276997f744bab637c2e937bb349947bc2c3b6c6397feb5b252c6928c7799b"
+							}
+						}
+					}`),
+				},
+			},
+		},
+	}, nil)
+
+	d := New(nil, fakeBulk, -1)
+
+	info, err := d.FindFileForAgent(context.Background(), fileID, agentID)
+	require.NoError(t, err)
+
+	assert.NotNil(t, info.File.Hash)
+	assert.Equal(t, "READY", info.File.Status)
+}
+
+func TestFindFileHandlesNoResults(t *testing.T) {
+	fakeBulk := itesting.NewMockBulk()
+
+	// handles case where ES does not return an error, simply no results
+	fakeBulk.Mock.On("Search",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	).Return(&es.ResultT{
+		HitsT: es.HitsT{
+			Hits: []es.HitT{},
+		},
+	}, nil)
+
+	d := New(nil, fakeBulk, -1)
+
+	_, err := d.FindFileForAgent(context.Background(), "somefile", "anyagent")
+	assert.ErrorIs(t, ErrNoFile, err)
+}
+
+func TestLocateChunks(t *testing.T) {
+	fakeBulk := itesting.NewMockBulk()
+
+	baseID := "somefile"
+
+	fakeBulk.Mock.On("Search",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	).Return(&es.ResultT{
+		HitsT: es.HitsT{
+			Hits: []es.HitT{
+				{
+					ID:     baseID + ".0",
+					Index:  "",
+					Source: []byte(""),
+					Fields: map[string]interface{}{
+						"bid": []interface{}{baseID},
+					},
+				},
+				{
+					ID:     baseID + ".1",
+					Index:  "",
+					Source: []byte(""),
+					Fields: map[string]interface{}{
+						"bid":  []interface{}{baseID},
+						"last": []interface{}{true},
+					},
+				},
+			},
+		},
+	}, nil)
+
+	d := New(nil, fakeBulk, -1)
+
+	chunks, err := d.LocateChunks(context.Background(), zerolog.Logger{}, baseID)
+	require.NoError(t, err)
+
+	assert.Len(t, chunks, 2)
+}
+
+func TestLocateChunksEmpty(t *testing.T) {
+	fakeBulk := itesting.NewMockBulk()
+
+	fakeBulk.Mock.On("Search",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	).Return(&es.ResultT{
+		HitsT: es.HitsT{
+			Hits: []es.HitT{},
+		},
+	}, nil)
+
+	d := New(nil, fakeBulk, -1)
+
+	_, err := d.LocateChunks(context.Background(), zerolog.Logger{}, "afile")
+	assert.Error(t, err)
+}
+
+func TestSendFile(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+
+	fakeBulk := itesting.NewMockBulk()
+	esClient, esMock := mockESClient(t)
+
+	const fileID = "xyz"
+	chunks := []file.ChunkInfo{
+		{Index: fmt.Sprintf(FileDataIndexPattern, "endpoint"), ID: fileID + ".0"},
+	}
+	// Chunk data from a tiny PNG, as a full CBOR document
+	esMock.Response = sendBodyBytes(hexDecode("bf665f696e64657878212e666c6565742d66696c6564656c69766572792d646174612d656e64706f696e74635f6964654142432e30685f76657273696f6e02675f7365715f6e6f016d5f7072696d6172795f7465726d0165666f756e64f5666669656c6473bf64646174619f586789504e470d0a1a0a0000000d494844520000010000000100010300000066bc3a2500000003504c5445b5d0d0630416ea0000001f494441546881edc1010d000000c2a0f74f6d0e37a00000000000000000be0d210000019a60e1d50000000049454e44ae426082ffffff")) //nolint:bodyclose // nopcloser is used, linter does not see it
+	d := New(esClient, fakeBulk, -1)
+	err := d.SendFile(context.Background(), zerolog.Logger{}, buf, chunks, fileID)
+	require.NoError(t, err)
+
+	// the byte string is the bare PNG file data
+	assert.Equal(t, hexDecode("89504e470d0a1a0a0000000d494844520000010000000100010300000066bc3a2500000003504c5445b5d0d0630416ea0000001f494441546881edc1010d000000c2a0f74f6d0e37a00000000000000000be0d210000019a60e1d50000000049454e44ae426082"), buf.Bytes())
+}
+
+// sending a file that spans more than 1 chunk
+func TestSendFileMultipleChunks(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+
+	fakeBulk := itesting.NewMockBulk()
+	esClient, esMock := mockESClient(t)
+
+	const fileID = "xyz"
+	chunks := []file.ChunkInfo{
+		{Index: fmt.Sprintf(FileDataIndexPattern, "endpoint"), ID: fileID + ".0"},
+		{Index: fmt.Sprintf(FileDataIndexPattern, "endpoint"), ID: fileID + ".1"},
+	}
+
+	mockChunks := []string{
+		"A7665F696E64657878212E666C6565742D66696C6564656C69766572792D646174612D656E64706F696E74635F69646578797A2E30685F76657273696F6E01675F7365715F6E6F016D5F7072696D6172795F7465726D0165666F756E64F5666669656C6473A164646174618142ABCD",
+		"A7665F696E64657878212E666C6565742D66696C6564656C69766572792D646174612D656E64706F696E74635F69646578797A2E31685F76657273696F6E01675F7365715F6E6F016D5F7072696D6172795F7465726D0165666F756E64F5666669656C6473A164646174618142EF01",
+	}
+
+	esMock.RoundTripFn = func(req *http.Request) (*http.Response, error) {
+		if strings.HasSuffix(req.URL.Path, fileID+".0") {
+			return sendBodyBytes(hexDecode(mockChunks[0])), nil
+		} else if strings.HasSuffix(req.URL.Path, fileID+".1") {
+			return sendBodyBytes(hexDecode(mockChunks[1])), nil
+		} else {
+			return nil, errors.New("invalid chunk index!")
+		}
+	}
+
+	d := New(esClient, fakeBulk, -1)
+	err := d.SendFile(context.Background(), zerolog.Logger{}, buf, chunks, fileID)
+	require.NoError(t, err)
+
+	// the collective bytes sent (0xabcd in first chunk, 0xef01 in second)
+	assert.Equal(t, hexDecode("abcdef01"), buf.Bytes())
+}
+
+// when chunks may be located in different backing indices behind an alias or data stream, they should be fetched from the backing index directly
+func TestSendFileMultipleChunksUsesBackingIndex(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+
+	fakeBulk := itesting.NewMockBulk()
+	esClient, esMock := mockESClient(t)
+
+	const fileID = "xyz"
+
+	idx1 := fmt.Sprintf(FileDataIndexPattern, "endpoint") + "-0001"
+	idx2 := fmt.Sprintf(FileDataIndexPattern, "endpoint") + "-0002"
+	chunks := []file.ChunkInfo{
+		{Index: idx1, ID: fileID + ".0"},
+		{Index: idx2, ID: fileID + ".1"},
+	}
+
+	mockData := hexDecode("A7665F696E64657878212E666C6565742D66696C6564656C69766572792D646174612D656E64706F696E74635F69646578797A2E30685F76657273696F6E01675F7365715F6E6F016D5F7072696D6172795F7465726D0165666F756E64F5666669656C6473A164646174618142ABCD")
+
+	esMock.RoundTripFn = func(req *http.Request) (*http.Response, error) {
+		parts := strings.Split(req.URL.Path, "/") // ["", ".fleet-filedelivery-data-endpoint-0001", "_doc", "xyz.1"]
+
+		if parts[3] == fileID+".0" {
+			assert.Equal(t, idx1, parts[1])
+		} else if parts[3] == fileID+".1" {
+			assert.Equal(t, idx2, parts[1])
+		} else {
+			return nil, errors.New("invalid chunk index!")
+		}
+
+		return sendBodyBytes(mockData), nil
+	}
+
+	d := New(esClient, fakeBulk, -1)
+	err := d.SendFile(context.Background(), zerolog.Logger{}, buf, chunks, fileID)
+	require.NoError(t, err)
+}
+
+/*
+	Setup to convert a *elasticsearch.Client as a harmless mock
+	by replacing the Transport to nowhere
+*/
+
+type MockTransport struct {
+	Response    *http.Response
+	RoundTripFn func(req *http.Request) (*http.Response, error)
+}
+
+func (t *MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.RoundTripFn(req)
+}
+
+func mockESClient(t *testing.T) (*elasticsearch.Client, *MockTransport) {
+	mocktrans := MockTransport{
+		Response: sendBodyString(""), //nolint:bodyclose // nopcloser is used, linter does not see it
+	}
+
+	mocktrans.RoundTripFn = func(req *http.Request) (*http.Response, error) { return mocktrans.Response, nil }
+	client, err := elasticsearch.NewClient(elasticsearch.Config{
+		Transport: &mocktrans,
+	})
+	require.NoError(t, err)
+	return client, &mocktrans
+}
+
+func sendBodyString(body string) *http.Response { return sendBody(strings.NewReader(body)) }
+func sendBodyBytes(body []byte) *http.Response  { return sendBody(bytes.NewReader(body)) }
+func sendBody(body io.Reader) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       ioutil.NopCloser(body),
+		Header: http.Header{
+			"X-Elastic-Product": []string{"Elasticsearch"},
+			"Content-Type":      []string{"application/cbor"},
+		},
+	}
+}
+
+// helper to turn hex data strings into bytes
+func hexDecode(s string) []byte {
+	data, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}

--- a/internal/pkg/file/delivery/es.go
+++ b/internal/pkg/file/delivery/es.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/dsl"
 	"github.com/elastic/fleet-server/v7/internal/pkg/es"
+	"github.com/elastic/fleet-server/v7/internal/pkg/file"
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/esapi"
 )
@@ -24,6 +25,7 @@ const (
 
 	FieldDocID        = "_id"
 	FieldTargetAgents = "file.Meta.target_agents"
+	FieldStatus       = "file.Status"
 )
 
 var (
@@ -36,6 +38,7 @@ func prepareQueryMetaByIDAndAgent() *dsl.Tmpl {
 	node := root.Query().Bool().Must()
 	node.Term(FieldDocID, tmpl.Bind(FieldDocID), nil)
 	node.Term(FieldTargetAgents, tmpl.Bind("target_agents"), nil)
+	node.Term(FieldStatus, file.StatusDone, nil)
 	tmpl.MustResolve(root)
 	return tmpl
 }


### PR DESCRIPTION
This is a manual backport of #2692, since it was merged in between creating the 8.9 branch, and setting up of the automatic backport stuff.