### PR TITLE
add the trigger package-registry pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -124,7 +124,12 @@ steps:
 
   - label: ":jenkins: Release - Package Registry Distribution"
     key: "release-package-registry"
-    command: echo "Triggering the Jenkins Job 'release-package-registry-distribution'..."
+    trigger: "package-registry-release-package-registry-distribution"
+    build:
+      branch: "main"
+      meta_data:
+        DOCKER_TAG: "${BUILDKITE_TAG}"
+    if: "build.env('BUILDKITE_TAG') != ''"
     depends_on:
       - step: "release-test"
         allow_failure: false


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

The partial migration of the Jenkins pipeline to the Buildkite pipeline. 

## How does this PR solve the problem?

Migrating the "Release - Package Registry Distribution" part
Instead the https://github.com/elastic/fleet-server/pull/2724, only changes according to the "Release - Package Registry Distribution" stage

## How to test this PR locally

It doesn't be checked locally, that's why it's a partial "step by step" migration

## Checklist

The Buildkite pipeline will be triggered by this PR and we will see the result

## Related issues

Related to the issue: https://github.com/elastic/fleet-server/issues/2517

**Pipeline steps:**
- [x] Release - Package Registry Distribution
