### PR TITLE
Revert "Bump the version on main to 8.10.0"

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,4 +6,4 @@ package version
 
 // DefaultVersion is the current release version of Fleet-server, this version must match the
 // Elastic Agent version.
-const DefaultVersion = "8.10.0"
+const DefaultVersion = "8.9.0"


### PR DESCRIPTION
Reverts elastic/fleet-server#2720.

E2E tests are failing since this change, it seems they require a 8.10 SNAPSHOT, that is not available yet.