### PR TITLE
Increase e2e tests timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,7 @@ test-e2e-set: ## - Run the blackbox end to end tests without setup.
 	ELASTICSEARCH_HOSTS=${TEST_ELASTICSEARCH_HOSTS} ELASTICSEARCH_USERNAME=${ELASTICSEARCH_USERNAME} ELASTICSEARCH_PASSWORD=${ELASTICSEARCH_PASSWORD} \
 	AGENT_E2E_IMAGE=$(shell cat "build/e2e-image") \
 	CGO_ENABLED=1 \
-	go test -v -tags=e2e -count=1 -race -p 1 ./...
+	go test -v -timeout 30m -tags=e2e -count=1 -race -p 1 ./...
 
 ##################################################
 # Cloud testing targets


### PR DESCRIPTION
## What is the problem this PR solves?

Try to reduce flakiness in E2E tests in Buildkite.

## How does this PR solve the problem?

Increase `go test` timeouts.

Go tests default timeout is 10 minutes, and current E2E tests are taking around this time in buildkite, even when they pass:
![imagen](https://github.com/elastic/fleet-server/assets/15763/888974a0-e140-4e07-8d11-ef36c977edfc)

When they fail, they are failing on different tests, but always with:
```
panic: test timed out after 10m0s
```

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->
```
make test-e2e
```