### PR TITLE
Add refresh parameter config option

### DIFF
--- a/changelog/fragments/1689704810-Change-refresh=true-to-refresh=wait_for.yaml
+++ b/changelog/fragments/1689704810-Change-refresh=true-to-refresh=wait_for.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Change refresh=true to refresh=wait_for
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: Change the refresh param from "true" to "wait_for" to better support upcoming serverless offering. Remove refresh param from mget requests.
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 2581

--- a/changelog/fragments/1689704810-add-refresh-param-config.yaml
+++ b/changelog/fragments/1689704810-add-refresh-param-config.yaml
@@ -11,12 +11,12 @@
 kind: feature
 
 # Change summary; a 80ish characters long description of the change.
-summary: Change refresh=true to refresh=wait_for
+summary: Add refresh param config
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.
 # NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
-description: Change the refresh param from "true" to "wait_for" to better support upcoming serverless offering. Remove refresh param from mget requests.
+description: Add a parameter that allows for the change of the refresh param from "true" to "wait_for" that effects file upload and bulk creation calls.
 
 # Affected component; a word indicating the component this changeset affects.
 component:

--- a/fleet-server.reference.yml
+++ b/fleet-server.reference.yml
@@ -192,6 +192,7 @@ fleet:
 #           flush_threshold_cnt: 2048
 #           flush_threshold_size: 1048567 # 1MiB
 #           flush_max_pending: 8
+#           refresh: "true" # The refresh param, must be one of [true, false, wait_for], defaults to "true"
 #
 #         # gc controls fleet-server index garbage collection operations
 #         # currently manages actions cleanup

--- a/internal/pkg/api/handleUpload.go
+++ b/internal/pkg/api/handleUpload.go
@@ -66,7 +66,7 @@ func NewUploadT(cfg *config.Server, bulker bulk.Bulk, chunkClient *elasticsearch
 		uploader:     uploader.New(chunkClient, bulker, cache, maxFileSize, maxUploadTimer),
 		authAgent:    authAgent,
 		authAPIKey:   authAPIKey,
-		refreshParam: string(cfg.Bulk.Refresh),
+		refreshParam: cfg.Bulk.Refresh,
 	}
 }
 

--- a/internal/pkg/apikey/create.go
+++ b/internal/pkg/apikey/create.go
@@ -15,6 +15,8 @@ import (
 )
 
 // Create generates a new APIKey in Elasticsearch using the given client.
+//
+// NOTE this is always invoked with refresh="false"
 func Create(ctx context.Context, client *elasticsearch.Client, name, ttl, refresh string, roles []byte, meta interface{}) (*APIKey, error) {
 	payload := struct {
 		Name       string          `json:"name,omitempty"`

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -392,7 +392,7 @@ func (b *Bulker) dispatch(ctx context.Context, blk *bulkT) respT {
 			Err(ctx.Err()).
 			Str("mod", kModBulk).
 			Str("action", blk.action.String()).
-			Bool("refresh", blk.flags.Has(flagRefresh)).
+			Bool("refresh", blk.flags.Has(flagRefresh)). // TODO change refresh to string and fix mapping
 			Dur("rtt", time.Since(start)).
 			Msg("Dispatch abort queue")
 		return respT{err: ctx.Err()}
@@ -405,7 +405,7 @@ func (b *Bulker) dispatch(ctx context.Context, blk *bulkT) respT {
 			Err(resp.err).
 			Str("mod", kModBulk).
 			Str("action", blk.action.String()).
-			Bool("refresh", blk.flags.Has(flagRefresh)).
+			Bool("refresh", blk.flags.Has(flagRefresh)). // TODO change refresh to string and fix mapping
 			Dur("rtt", time.Since(start)).
 			Msg("Dispatch OK")
 
@@ -415,7 +415,7 @@ func (b *Bulker) dispatch(ctx context.Context, blk *bulkT) respT {
 			Err(ctx.Err()).
 			Str("mod", kModBulk).
 			Str("action", blk.action.String()).
-			Bool("refresh", blk.flags.Has(flagRefresh)).
+			Bool("refresh", blk.flags.Has(flagRefresh)). // TODO change refresh to string and fix mapping
 			Dur("rtt", time.Since(start)).
 			Msg("Dispatch abort response")
 	}

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -84,6 +84,7 @@ const (
 	defaultBlockQueueSz      = 32 // Small capacity to allow multiOp to spin fast
 	defaultAPIKeyMaxParallel = 32
 	defaultApikeyMaxReqSize  = 100 * 1024 * 1024
+	defaultRefreshParam      = "true"
 )
 
 func NewBulker(es esapi.Transport, tracer *apm.Tracer, opts ...BulkOpt) *Bulker {

--- a/internal/pkg/bulk/opBulk.go
+++ b/internal/pkg/bulk/opBulk.go
@@ -189,7 +189,7 @@ func (b *Bulker) flushBulk(ctx context.Context, queue queueT) error {
 	}
 
 	if queue.ty == kQueueRefreshBulk {
-		req.Refresh = "true"
+		req.Refresh = "wait_for"
 	}
 
 	res, err := req.Do(ctx, b.es)
@@ -238,7 +238,7 @@ func (b *Bulker) flushBulk(ctx context.Context, queue queueT) error {
 
 	log.Trace().
 		Err(err).
-		Bool("refresh", queue.ty == kQueueRefreshBulk).
+		Bool("refresh", queue.ty == kQueueRefreshBulk). // TODO we may want to switch this to string, but we will need to ensure that the attribute mapping is correct
 		Str("mod", kModBulk).
 		Int("took", blk.Took).
 		Dur("rtt", time.Since(start)).

--- a/internal/pkg/bulk/opBulk.go
+++ b/internal/pkg/bulk/opBulk.go
@@ -189,7 +189,7 @@ func (b *Bulker) flushBulk(ctx context.Context, queue queueT) error {
 	}
 
 	if queue.ty == kQueueRefreshBulk {
-		req.Refresh = "wait_for"
+		req.Refresh = b.opts.refreshParam
 	}
 
 	res, err := req.Do(ctx, b.es)

--- a/internal/pkg/bulk/opRead.go
+++ b/internal/pkg/bulk/opRead.go
@@ -80,6 +80,13 @@ func (b *Bulker) flushRead(ctx context.Context, queue queueT) error {
 		Body: bytes.NewReader(payload),
 	}
 
+	// FIXME change refresh into a string param once mget supports strings.
+	var refresh bool
+	if queue.ty == kQueueRefreshRead {
+		refresh = true
+		req.Refresh = &refresh
+	}
+
 	res, err := req.Do(ctx, b.es)
 
 	if err != nil {
@@ -115,6 +122,7 @@ func (b *Bulker) flushRead(ctx context.Context, queue queueT) error {
 
 	log.Trace().
 		Err(err).
+		Bool("refresh", refresh).
 		Str("mod", kModBulk).
 		Dur("rtt", time.Since(start)).
 		Int("cnt", len(blk.Items)).

--- a/internal/pkg/bulk/opRead.go
+++ b/internal/pkg/bulk/opRead.go
@@ -80,12 +80,6 @@ func (b *Bulker) flushRead(ctx context.Context, queue queueT) error {
 		Body: bytes.NewReader(payload),
 	}
 
-	var refresh bool
-	if queue.ty == kQueueRefreshRead {
-		refresh = true
-		req.Refresh = &refresh
-	}
-
 	res, err := req.Do(ctx, b.es)
 
 	if err != nil {
@@ -121,7 +115,6 @@ func (b *Bulker) flushRead(ctx context.Context, queue queueT) error {
 
 	log.Trace().
 		Err(err).
-		Bool("refresh", refresh).
 		Str("mod", kModBulk).
 		Dur("rtt", time.Since(start)).
 		Int("cnt", len(blk.Items)).

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -63,6 +63,7 @@ type bulkOptT struct {
 	blockQueueSz      int
 	apikeyMaxParallel int
 	apikeyMaxReqSize  int
+	refreshParam      string
 }
 
 type BulkOpt func(*bulkOptT)
@@ -118,6 +119,12 @@ func WithAPIKeyMaxRequestSize(maxBytes int) BulkOpt {
 	}
 }
 
+func WithRefreshParam(refresh config.Refresh) BulkOpt {
+	return func(opt *bulkOptT) {
+		opt.refreshParam = string(refresh)
+	}
+}
+
 func parseBulkOpts(opts ...BulkOpt) bulkOptT {
 	bopt := bulkOptT{
 		flushInterval:     defaultFlushInterval,
@@ -127,6 +134,7 @@ func parseBulkOpts(opts ...BulkOpt) bulkOptT {
 		apikeyMaxParallel: defaultAPIKeyMaxParallel,
 		blockQueueSz:      defaultBlockQueueSz,
 		apikeyMaxReqSize:  defaultApikeyMaxReqSize,
+		refreshParam:      defaultRefreshParam,
 	}
 
 	for _, f := range opts {
@@ -165,5 +173,6 @@ func BulkOptsFromCfg(cfg *config.Config) []BulkOpt {
 		WithMaxPending(bulkCfg.FlushMaxPending),
 		WithAPIKeyMaxParallel(maxKeyParallel),
 		WithAPIKeyMaxRequestSize(cfg.Output.Elasticsearch.MaxContentLength),
+		WithRefreshParam(bulkCfg.Refresh),
 	}
 }

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -119,9 +119,9 @@ func WithAPIKeyMaxRequestSize(maxBytes int) BulkOpt {
 	}
 }
 
-func WithRefreshParam(refresh config.Refresh) BulkOpt {
+func WithRefreshParam(refresh string) BulkOpt {
 	return func(opt *bulkOptT) {
-		opt.refreshParam = string(refresh)
+		opt.refreshParam = refresh
 	}
 }
 

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -19,6 +19,8 @@ const kDefaultInternalHost = "localhost"
 const kDefaultInternalPort = 8221
 const fleetInputType = "fleet-server"
 
+var ErrBulkerRefresh = fmt.Errorf("bulker.refresh setting is invalid")
+
 // Policy is the configuration policy to use.
 type Policy struct {
 	ID string `config:"id"`
@@ -42,9 +44,6 @@ type ServerTLS struct {
 	Cert string `config:"cert"`
 }
 
-// Refresh represents the refresh parameter used in Elasticsearch requests
-type Refresh string
-
 // Possible values of the refresh param as defined by [Elasticsearch Docs].
 // Note that not all operations support all values.
 // For example mget requests still define the refresh param as a boolean.
@@ -61,7 +60,7 @@ type ServerBulk struct {
 	FlushThresholdCount int           `config:"flush_threshold_cnt"`
 	FlushThresholdSize  int           `config:"flush_threshold_size"`
 	FlushMaxPending     int           `config:"flush_max_pending"`
-	Refresh             Refresh       `config:"refresh"`
+	Refresh             string        `config:"refresh"`
 }
 
 func (c *ServerBulk) InitDefaults() {
@@ -70,6 +69,15 @@ func (c *ServerBulk) InitDefaults() {
 	c.FlushThresholdSize = 1024 * 1024
 	c.FlushMaxPending = 8
 	c.Refresh = RefreshTrue
+}
+
+func (c *ServerBulk) Validate() error {
+	switch c.Refresh {
+	case RefreshTrue, RefreshFalse, RefreshWaitFor:
+	default:
+		return fmt.Errorf("%w: value=%s", ErrBulkerRefresh, c.Refresh)
+	}
+	return nil
 }
 
 // Server is the configuration for the server

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -42,11 +42,26 @@ type ServerTLS struct {
 	Cert string `config:"cert"`
 }
 
+// Refresh represents the refresh parameter used in Elasticsearch requests
+type Refresh string
+
+// Possible values of the refresh param as defined by [Elasticsearch Docs].
+// Note that not all operations support all values.
+// For example mget requests still define the refresh param as a boolean.
+//
+// [Elasticsearch Docs]: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html
+const (
+	RefreshTrue    = "true"
+	RefreshFalse   = "false"
+	RefreshWaitFor = "wait_for"
+)
+
 type ServerBulk struct {
 	FlushInterval       time.Duration `config:"flush_interval"`
 	FlushThresholdCount int           `config:"flush_threshold_cnt"`
 	FlushThresholdSize  int           `config:"flush_threshold_size"`
 	FlushMaxPending     int           `config:"flush_max_pending"`
+	Refresh             Refresh       `config:"refresh"`
 }
 
 func (c *ServerBulk) InitDefaults() {
@@ -54,6 +69,7 @@ func (c *ServerBulk) InitDefaults() {
 	c.FlushThresholdCount = 2048
 	c.FlushThresholdSize = 1024 * 1024
 	c.FlushMaxPending = 8
+	c.Refresh = RefreshTrue
 }
 
 // Server is the configuration for the server

--- a/internal/pkg/config/input_test.go
+++ b/internal/pkg/config/input_test.go
@@ -7,12 +7,16 @@
 package config
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	testlog "github.com/elastic/fleet-server/v7/internal/pkg/testing/log"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBindAddress(t *testing.T) {
@@ -46,6 +50,53 @@ func TestBindAddress(t *testing.T) {
 					t.Errorf("%s mismatch (-want +got):\n%s", name, diff)
 				}
 			}
+		})
+	}
+}
+
+func TestRefresh(t *testing.T) {
+	tests := []struct {
+		name string
+		err  string
+	}{{
+		name: "true",
+		err:  "",
+	}, {
+		name: "false",
+		err:  "",
+	}, {
+		name: "wait_for",
+		err:  "",
+	}, {
+		name: "error",
+		err:  ErrBulkerRefresh.Error(),
+	}}
+	fTemplate := `
+inputs:
+  - type: fleet-server
+    server:
+      bulk:
+        refresh: "%s"
+`
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yml")
+			f, err := os.Create(path)
+			require.NoError(t, err)
+			_, err = fmt.Fprintf(f, fTemplate, tt.name)
+			require.NoError(t, err)
+			f.Close()
+
+			cfg, err := LoadFile(path)
+			if tt.err == "" {
+				require.NoError(t, err)
+				require.Equal(t, tt.name, cfg.Inputs[0].Server.Bulk.Refresh)
+			} else {
+				// Using ErrorContains here instead of ErrorIs as go-ucfg does not wrap errors correctly
+				require.ErrorContains(t, err, tt.err)
+			}
+
 		})
 	}
 }

--- a/internal/pkg/dl/migration.go
+++ b/internal/pkg/dl/migration.go
@@ -95,6 +95,7 @@ func applyMigration(ctx context.Context, name string, index string, bulker bulk.
 	opts := []func(*esapi.UpdateByQueryRequest){
 		client.UpdateByQuery.WithBody(reader),
 		client.UpdateByQuery.WithContext(ctx),
+		client.UpdateByQuery.WithRefresh(true), // FIXME change to wait_for once the API supports it.
 		client.UpdateByQuery.WithConflicts("proceed"),
 	}
 

--- a/internal/pkg/dl/migration.go
+++ b/internal/pkg/dl/migration.go
@@ -95,7 +95,6 @@ func applyMigration(ctx context.Context, name string, index string, bulker bulk.
 	opts := []func(*esapi.UpdateByQueryRequest){
 		client.UpdateByQuery.WithBody(reader),
 		client.UpdateByQuery.WithContext(ctx),
-		client.UpdateByQuery.WithRefresh(true),
 		client.UpdateByQuery.WithConflicts("proceed"),
 	}
 

--- a/internal/pkg/file/uploader/es.go
+++ b/internal/pkg/file/uploader/es.go
@@ -123,7 +123,7 @@ func IndexChunk(ctx context.Context, client *elasticsearch.Client, body *cbor.Ch
 		}
 		req.Header.Set("Content-Type", "application/cbor")
 		req.Header.Set("Accept", "application/json")
-		req.Refresh = "true"
+		req.Refresh = "wait_for"
 	})
 	if err != nil {
 		return err

--- a/internal/pkg/file/uploader/es.go
+++ b/internal/pkg/file/uploader/es.go
@@ -114,7 +114,7 @@ func UpdateFileDoc(ctx context.Context, bulker bulk.Bulk, source string, fileID 
 	Chunk Operations
 */
 
-func IndexChunk(ctx context.Context, client *elasticsearch.Client, body *cbor.ChunkEncoder, source string, fileID string, chunkNum int) error {
+func IndexChunk(ctx context.Context, client *elasticsearch.Client, body *cbor.ChunkEncoder, source string, fileID string, chunkNum int, refreshParam string) error {
 	chunkDocID := fmt.Sprintf("%s.%d", fileID, chunkNum)
 	resp, err := client.Create(fmt.Sprintf(UploadDataIndexPattern, source), chunkDocID, body, func(req *esapi.CreateRequest) {
 		req.DocumentID = chunkDocID
@@ -123,7 +123,7 @@ func IndexChunk(ctx context.Context, client *elasticsearch.Client, body *cbor.Ch
 		}
 		req.Header.Set("Content-Type", "application/cbor")
 		req.Header.Set("Accept", "application/json")
-		req.Refresh = "wait_for"
+		req.Refresh = refreshParam
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## What is the problem this PR solves?

Fleet-server should not force ES to refresh with all of it's requests.

## How does this PR solve the problem?

Add a config option that allows us to define the refresh parameter value instead of using `refresh=true` for all requests. 
Parameter is used for bulk operations and creating chunks while uploading a file.
Parameter is not used (and `true` is used) for [mget search](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html#docs-multi-get-api-query-params) requests and the [update by query](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html#docs-update-by-query-api-query-params) requests as refresh is still defined as a bool param.

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Closes #2581 