### PR TITLE
[Fleet] Fix docker publish step in buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,15 +1,15 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 env:
-  SETUP_GVM_VERSION: 'v0.5.0'
-  DOCKER_COMPOSE_VERSION: '1.25.5'
+  SETUP_GVM_VERSION: "v0.5.0"
+  DOCKER_COMPOSE_VERSION: "1.25.5"
   DOCKER_REGISTRY: "docker.elastic.co"
   DOCKER_IMAGE: "${DOCKER_REGISTRY}/observability-ci/fleet-server" # needs to rename for rollback
   DOCKER_IMAGE_SHA_TAG: "git-${BUILDKITE_COMMIT:0:12}" # needs to rename for rollback, should be "git-${BUILDKITE_COMMIT:0:12}"
   DOCKER_IMAGE_LATEST_TAG: "latest" # needs to rename for rollback
   DOCKER_IMAGE_GIT_TAG: "${BUILDKITE_BRANCH}" # needs to rename for rollback
   GO_AGENT_IMAGE: "golang:${GO_VERSION}"
-  TERRAFORM_VERSION: '1.4.6'
+  TERRAFORM_VERSION: "1.4.6"
 
 steps:
   - group: "Check and build"
@@ -90,7 +90,7 @@ steps:
   - label: ":docker: Publish docker image"
     key: "publish"
     command: ".buildkite/scripts/build_push_docker_image.sh"
-    if: "build.env('BUILDKITE_PULL_REQUEST') == '' && build.env('BUILDKITE_BRANCH') == 'main'"
+    if: "build.env('BUILDKITE_PULL_REQUEST') == 'false' && build.env('BUILDKITE_BRANCH') == 'main'"
     agents:
       provider: "gcp"
     depends_on:
@@ -105,6 +105,8 @@ steps:
       env:
         SERVICE_COMMIT_HASH: ${BUILDKITE_COMMIT:0:12}
         REMOTE_SERVICE_CONFIG: https://raw.githubusercontent.com/elastic/serverless-gitops/main/gen/gpctl/fleet/config.yaml
+    depends_on:
+      - step: "publish"
 
   - label: ":gcloud: Release test"
     key: "release-test"
@@ -130,7 +132,7 @@ steps:
   - trigger: "fleet-server-package-mbp"
     label: ":esbuild: Downstream - Package"
     key: "downstream-package"
-    if:  "build.env('BUILDKITE_BRANCH') != '' && build.env('BUILDKITE_TAG') == '' && build.env('BUILDKITE_PULL_REQUEST') == ''"
+    if: "build.env('BUILDKITE_BRANCH') != '' && build.env('BUILDKITE_TAG') == '' && build.env('BUILDKITE_PULL_REQUEST') == ''"
     depends_on:
       - step: "release-package-registry"
         allow_failure: false


### PR DESCRIPTION
## Description 

Fix docker publish step in buildkite

The if condition to build the docker image was not met 
<img width="1185" alt="Screenshot 2023-07-24 at 1 00 56 PM" src="https://github.com/elastic/fleet-server/assets/1336873/6ae05e37-bfdc-4ae5-b426-3835c4c61d35">


It seems according to buildkite doc that `BUILDKITE_PULL_REQUEST ` should be false if it's not a pull request and not an empty string