### PR TITLE
migrate release manager dependencies

### DIFF
--- a/.buildkite/scripts/dra_release.sh
+++ b/.buildkite/scripts/dra_release.sh
@@ -32,17 +32,14 @@ with_go
 
 with_mage
 
-case "${TYPE}" in
-    "snapshot")
-        make release-manager-dependencies-snapshot
-        ;;
-    "staging")
-        make release-manager-dependencies-release
-        ;;
-    *)
-    echo "The option is unsupported yet"
-    ;;
-esac
+
+if [[ ${TYPE} == "snapshot" ]]; then
+    export SNAPSHOT=true
+fi
+
+mkdir -p ${BASE_DIR}/reports
+./dev-tools/dependencies-report --csv ${BASE_DIR}/reports/dependencies-${VERSION}.csv
+cd ${BASE_DIR}/reports && shasum -a 512 dependencies-${VERSION}.csv > dependencies-${VERSION}.csv.sha512
 
 cd $(dirname ${WORKSPACE})
 export FOLDER="${FOLDER_PATH}"


### PR DESCRIPTION
## What is the problem this PR solves?

fix the issue: https://buildkite.com/elastic/fleet-server-package-mbp/builds/236#018995a5-441f-40a1-9d52-401a2d8ca320

## How does this PR solve the problem?

migrate release manager dependencies from `./dev-tools/run_with_go_ver` to the `dra_release.sh` script because the` ./dev-tools/run_with_go_ver` is still used

## Related issues

https://github.com/elastic/fleet-server/issues/2517
