### PR TITLE
add path to release-manager script

### DIFF
--- a/.buildkite/scripts/dra_release.sh
+++ b/.buildkite/scripts/dra_release.sh
@@ -41,9 +41,7 @@ mkdir -p ${BASE_DIR}/reports
 ./dev-tools/dependencies-report --csv ${BASE_DIR}/reports/dependencies-${VERSION}.csv
 cd ${BASE_DIR}/reports && shasum -a 512 dependencies-${VERSION}.csv > dependencies-${VERSION}.csv.sha512
 
-cd ${WORKSPACE}
+cd $(dirname ${WORKSPACE})
 export FOLDER="${FOLDER_PATH}"
 export OUTPUT_FILE="${DRA_OUTPUT}"
-echo "$(pwd)"
-ls -la
 ./.buildkite/scripts/release-manager.sh          #TODO use "echo" for rollback

--- a/.buildkite/scripts/release-manager.sh
+++ b/.buildkite/scripts/release-manager.sh
@@ -21,8 +21,9 @@ readonly TYPE=${TYPE:-snapshot}
 readonly OUTPUT_FILE=${OUTPUT_FILE:-release-manager-report.out}
 
 # set required permissions on artifacts and directory
-chmod -R a+r "${WORKSPACE}"/"$FOLDER"/*
-chmod -R a+w "${WORKSPACE}"/"$FOLDER"
+cd ${WORKSPACE}
+chmod -R a+r "$FOLDER"/*
+chmod -R a+w "$FOLDER"
 
 # ensure the latest image has been pulled
 IMAGE=docker.elastic.co/infra/release-manager:latest

--- a/.buildkite/scripts/release-manager.sh
+++ b/.buildkite/scripts/release-manager.sh
@@ -21,8 +21,8 @@ readonly TYPE=${TYPE:-snapshot}
 readonly OUTPUT_FILE=${OUTPUT_FILE:-release-manager-report.out}
 
 # set required permissions on artifacts and directory
-chmod -R a+r "$FOLDER"/*
-chmod -R a+w "$FOLDER"
+chmod -R a+r "${WORKSPACE}"/"$FOLDER"/*
+chmod -R a+w "${WORKSPACE}"/"$FOLDER"
 
 # ensure the latest image has been pulled
 IMAGE=docker.elastic.co/infra/release-manager:latest


### PR DESCRIPTION
## What is the problem this PR solves?

fix the issue: https://buildkite.com/elastic/fleet-server-package-mbp/builds/240#0189966d-f773-4479-be35-7913b0e5f9db

## How does this PR solve the problem?

add `cd ${WORKSPACE}` to the release-manager script

## Related issues

https://github.com/elastic/fleet-server/issues/2517
