### PR TITLE
[Fleet] Fix docker publish

### DIFF
--- a/.buildkite/scripts/build_push_docker_image.sh
+++ b/.buildkite/scripts/build_push_docker_image.sh
@@ -11,11 +11,7 @@ if ! docker pull -q ${DOCKER_IMAGE}:${DOCKER_IMAGE_SHA_TAG} 2> /dev/null; then
 fi
 
 if [ -n "${BUILDKITE_TAG}" ]; then
-    docker tag "${DOCKER_IMAGE}":"${DOCKER_IMAGE_SHA_TAG}" "${DOCKER_IMAGE}":"${DOCKER_IMAGE_GIT_TAG}"
-    DOCKER_IMAGE_TAG="${DOCKER_IMAGE_GIT_TAG}"
-    make build-and-push-docker
+    DOCKER_IMAGE=${DOCKER_IMAGE} DOCKER_IMAGE_TAG="${DOCKER_IMAGE_GIT_TAG}" make build-and-push-docker
 else
-    docker tag "${DOCKER_IMAGE}":"${DOCKER_IMAGE_SHA_TAG}" "${DOCKER_IMAGE}":"${DOCKER_IMAGE_LATEST_TAG}"
-    DOCKER_IMAGE_TAG="${DOCKER_IMAGE_LATEST_TAG}"
-    make build-and-push-docker
+    DOCKER_IMAGE=${DOCKER_IMAGE} DOCKER_IMAGE_TAG="${DOCKER_IMAGE_LATEST_TAG}" make build-and-push-docker
 fi

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,11 @@ build-and-push-docker:
 		--build-arg=VERSION="$(VERSION)" \
 		-t $(DOCKER_IMAGE):$(DOCKER_IMAGE_TAG)$(if $(DEV),-dev,) .
 
+.PHONY: release-docker
+release-docker:
+	docker push \
+		$(DOCKER_IMAGE):$(DOCKER_IMAGE_TAG)$(if $(DEV),-dev,)
+
 .PHONY: package-target
 package-target: build/distributions
 ifeq ($(OS),windows)


### PR DESCRIPTION
## Description 

The docker publish seems to be broken after https://github.com/elastic/fleet-server/pull/2832 

That PR fix docker publish step to remove the `docker tag` command that is not used anymore.