### PR TITLE
Add output type kafka to agent policies

### DIFF
--- a/changelog/fragments/1690563780-Add-kafka-output-type-for-agent-policies.yaml
+++ b/changelog/fragments/1690563780-Add-kafka-output-type-for-agent-policies.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add kafka output type for agent policies
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent-shipper/issues/116

--- a/internal/pkg/policy/policy_output.go
+++ b/internal/pkg/policy/policy_output.go
@@ -25,6 +25,7 @@ import (
 const (
 	OutputTypeElasticsearch = "elasticsearch"
 	OutputTypeLogstash      = "logstash"
+	OutputTypeKafka         = "kafka"
 )
 
 var (
@@ -54,6 +55,9 @@ func (p *Output) Prepare(ctx context.Context, zlog zerolog.Logger, bulker bulk.B
 	case OutputTypeLogstash:
 		zlog.Debug().Msg("preparing logstash output")
 		zlog.Info().Msg("no actions required for logstash output preparation")
+	case OutputTypeKafka:
+		zlog.Debug().Msg("preparing kafka output")
+		zlog.Info().Msg("no actions required for logstash kafka preparation")
 	default:
 		zlog.Error().Msgf("unknown output type: %s; skipping preparation", p.Type)
 		return fmt.Errorf("encountered unexpected output type while preparing outputs: %s", p.Type)

--- a/internal/pkg/policy/policy_output.go
+++ b/internal/pkg/policy/policy_output.go
@@ -57,7 +57,7 @@ func (p *Output) Prepare(ctx context.Context, zlog zerolog.Logger, bulker bulk.B
 		zlog.Info().Msg("no actions required for logstash output preparation")
 	case OutputTypeKafka:
 		zlog.Debug().Msg("preparing kafka output")
-		zlog.Info().Msg("no actions required for logstash kafka preparation")
+		zlog.Info().Msg("no actions required for kafka output preparation")
 	default:
 		zlog.Error().Msgf("unknown output type: %s; skipping preparation", p.Type)
 		return fmt.Errorf("encountered unexpected output type while preparing outputs: %s", p.Type)

--- a/internal/pkg/policy/policy_output_test.go
+++ b/internal/pkg/policy/policy_output_test.go
@@ -69,6 +69,37 @@ func TestPolicyDefaultLogstashOutputPrepare(t *testing.T) {
 	bulker.AssertExpectations(t)
 }
 
+func TestPolicyKafkaOutputPrepare(t *testing.T) {
+	logger := testlog.SetLogger(t)
+	bulker := ftesting.NewMockBulk()
+	po := Output{
+		Type: OutputTypeKafka,
+		Name: "test output",
+		Role: &RoleT{
+			Sha2: "fake sha",
+			Raw:  TestPayload,
+		},
+	}
+
+	err := po.Prepare(context.Background(), logger, bulker, &model.Agent{}, smap.Map{})
+	require.Nil(t, err, "expected prepare to pass")
+	bulker.AssertExpectations(t)
+}
+func TestPolicyKafkaOutputPrepareNoRole(t *testing.T) {
+	logger := testlog.SetLogger(t)
+	bulker := ftesting.NewMockBulk()
+	po := Output{
+		Type: OutputTypeKafka,
+		Name: "test output",
+		Role: nil,
+	}
+
+	err := po.Prepare(context.Background(), logger, bulker, &model.Agent{}, smap.Map{})
+	// No permissions are required by kafka currently
+	require.Nil(t, err, "expected prepare to pass")
+	bulker.AssertExpectations(t)
+}
+
 func TestPolicyESOutputPrepareNoRole(t *testing.T) {
 	logger := testlog.SetLogger(t)
 	bulker := ftesting.NewMockBulk()


### PR DESCRIPTION
## What is the problem this PR solves?

fleet-server gives an error if kafka appears an the output type in an agent policy.

## How does this PR solve the problem?

Add `OutputTypeKafka` to policy output as a nop similar to logstash handling.

## Design Checklist


- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

- Relates https://github.com/elastic/elastic-agent-shipper/issues/116
