### PR TITLE
[Fleet] Fix static enrollment tokens blocking db enrollemnt tokens

### DIFF
--- a/internal/pkg/api/handleEnroll.go
+++ b/internal/pkg/api/handleEnroll.go
@@ -100,7 +100,7 @@ func (et *EnrollerT) handleEnroll(zlog zerolog.Logger, w http.ResponseWriter, r 
 func (et *EnrollerT) processRequest(zlog zerolog.Logger, w http.ResponseWriter, r *http.Request, rb *rollback.Rollback, enrollmentAPIKey *apikey.APIKey, ver string) (*EnrollResponse, error) {
 	// Validate that an enrollment record exists for a key with this id.
 	var enrollAPI *model.EnrollmentAPIKey
-	enrollAPI, err := et.fetchStaticTokenPolicy(r.Context(), zlog, enrollmentAPIKey)
+	enrollAPI, err := et.retrieveStaticTokenEnrollmentToken(r.Context(), zlog, enrollmentAPIKey)
 	if err != nil {
 		return nil, err
 	}
@@ -134,10 +134,10 @@ func (et *EnrollerT) processRequest(zlog zerolog.Logger, w http.ResponseWriter, 
 	return et._enroll(r.Context(), rb, zlog, req, enrollAPI.PolicyID, ver)
 }
 
-// fetchEnrollmentKeyRecord fetches the enrollment key record from the database.
+// retrieveStaticTokenEnrollmentToken fetches the enrollment key record from the config static tokens.
 // If the static policy token feature was not enabled, nothing is returns (nil, nil)
 // otherwise either an error or the enrollment key record is returned.
-func (et *EnrollerT) fetchStaticTokenPolicy(ctx context.Context, zlog zerolog.Logger, enrollmentAPIKey *apikey.APIKey) (*model.EnrollmentAPIKey, error) {
+func (et *EnrollerT) retrieveStaticTokenEnrollmentToken(ctx context.Context, zlog zerolog.Logger, enrollmentAPIKey *apikey.APIKey) (*model.EnrollmentAPIKey, error) {
 	if !et.cfg.StaticPolicyTokens.Enabled {
 		return nil, nil
 	}

--- a/internal/pkg/api/handleEnroll.go
+++ b/internal/pkg/api/handleEnroll.go
@@ -161,7 +161,7 @@ func (et *EnrollerT) fetchStaticTokenPolicy(ctx context.Context, zlog zerolog.Lo
 
 	}
 	// no error, just not found
-	return nil, ErrPolicyNotFound
+	return nil, nil
 }
 
 func (et *EnrollerT) fetchPolicy(ctx context.Context, policyID string) (model.Policy, error) {

--- a/internal/pkg/api/handleEnroll_test.go
+++ b/internal/pkg/api/handleEnroll_test.go
@@ -96,7 +96,7 @@ func TestEnroll(t *testing.T) {
 	}
 }
 
-func TestEnrollerT_fetchStaticTokenPolicy(t *testing.T) {
+func TestEnrollerT_retrieveStaticTokenEnrollmentToken(t *testing.T) {
 	bulkerBuilder := func(policies ...model.Policy) func() bulk.Bulk {
 		return func() bulk.Bulk {
 			bulker := ftesting.NewMockBulk()
@@ -237,7 +237,7 @@ func TestEnrollerT_fetchStaticTokenPolicy(t *testing.T) {
 				},
 				bulker: tt.fields.bulker(),
 			}
-			got, err := et.fetchStaticTokenPolicy(context.Background(), zerolog.Logger{}, tt.args.enrollmentAPIKey)
+			got, err := et.retrieveStaticTokenEnrollmentToken(context.Background(), zerolog.Logger{}, tt.args.enrollmentAPIKey)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/internal/pkg/api/handleEnroll_test.go
+++ b/internal/pkg/api/handleEnroll_test.go
@@ -96,6 +96,55 @@ func TestEnroll(t *testing.T) {
 	}
 }
 
+func TestEnrollWithStaticPolicyTokensConfigured(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rb := &rollback.Rollback{}
+	zlog := zerolog.Logger{}
+	enrollmentID := "1234"
+	req := &EnrollRequest{
+		Type:         "PERMANENT",
+		EnrollmentId: &enrollmentID,
+		Metadata: EnrollMetadata{
+			UserProvided: []byte("{}"),
+			Local:        []byte("{}"),
+		},
+	}
+	verCon := mustBuildConstraints("8.9.0")
+	cfg := &config.Server{
+		StaticPolicyTokens: config.StaticPolicyTokens{
+			Enabled: true,
+			PolicyTokens: []config.PolicyToken{
+				{
+					TokenKey: "abcdefg",
+					PolicyID: "dummy-policy",
+				},
+			},
+		},
+	}
+	c, _ := cache.New(config.Cache{NumCounters: 100, MaxCost: 100000})
+	bulker := ftesting.NewMockBulk()
+	et, _ := NewEnrollerT(verCon, cfg, bulker, c)
+
+	bulker.On("Search", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&es.ResultT{
+		HitsT: es.HitsT{
+			Hits: make([]es.HitT, 0),
+		},
+	}, nil)
+	bulker.On("APIKeyCreate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		&apikey.APIKey{
+			ID:  "1234",
+			Key: "1234",
+		}, nil)
+	bulker.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		"", nil)
+	resp, _ := et._enroll(ctx, rb, zlog, req, "1234", "8.9.0")
+
+	if resp.Action != "created" {
+		t.Fatal("enroll failed")
+	}
+}
+
 func TestEnrollerT_fetchStaticTokenPolicy(t *testing.T) {
 	bulkerBuilder := func(policies ...model.Policy) func() bulk.Bulk {
 		return func() bulk.Bulk {


### PR DESCRIPTION
## Description 

Resolve #2877 

Fix an issue when enabling static enrollement tokens it was disabling support for regular db enrollment tokens.

That PR fix that and add a unit test to cover that scenario.

## Manual tests

* Add some static tokens to your fleet server config
* Create a policy in the fleet UI and check you can enroll agents into that policy.
