### PR TITLE
fix the GCP credentials variable name

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -11,13 +11,13 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server" ]]; then
 fi
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server" && "$BUILDKITE_STEP_KEY" == "release-test" ]]; then
-    unset GOOGLE_APPLICATIONS_CREDENTIALS
+    unset GOOGLE_APPLICATION_CREDENTIALS
     cleanup
 fi
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server-package-mbp" ]]; then
   if [[ "$BUILDKITE_STEP_KEY" == "package-x86-64" || "$BUILDKITE_STEP_KEY" == "package-arm" || "$BUILDKITE_STEP_KEY" == "dra-snapshot" && "$BUILDKITE_STEP_KEY" == "dra-staging" ]]; then
-    unset GOOGLE_APPLICATIONS_CREDENTIALS
+    unset GOOGLE_APPLICATION_CREDENTIALS
     unset VAULT_ROLE_ID_SECRET
     unset VAULT_ADDR_SECRET
     unset VAULT_SECRET_ID_SECRET

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -99,7 +99,7 @@ google_cloud_auth() {
     local secretFileLocation=$(mktemp -d -p "${WORKSPACE}" -t "${TMP_FOLDER_TEMPLATE_BASE}.XXXXXXXXX")/google-cloud-credentials.json
     echo "${PRIVATE_CI_GCS_CREDENTIALS_SECRET}" > ${secretFileLocation}
     gcloud auth activate-service-account --key-file ${secretFileLocation} 2> /dev/null
-    export GOOGLE_APPLICATIONS_CREDENTIALS=${secretFileLocation}
+    export GOOGLE_APPLICATION_CREDENTIALS=${secretFileLocation}
 }
 
 upload_packages_to_gcp_bucket() {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

Fix the GCP credentials variable name according to the doc: https://cloud.google.com/docs/authentication/application-default-credentials#GAC


## How does this PR solve the problem?

remove the extra "S" symbol

## How to test this PR locally

It tested in the other repository

## Related issues

Related to the issue: https://github.com/elastic/fleet-server/issues/2517

