### PR TITLE
[buildkite] Update condition for downstream package step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -132,7 +132,7 @@ steps:
   - trigger: "fleet-server-package-mbp"
     label: ":esbuild: Downstream - Package"
     key: "downstream-package"
-    if: "build.env('BUILDKITE_PULL_REQUEST') == 'false'"
+    if: "build.env('BUILDKITE_PULL_REQUEST') == 'false' && build.env('BUILDKITE_TAG') == '' && build.env('BUILDKITE_BRANCH') != ''"
     depends_on:
       - step: "release-package-registry"
         allow_failure: false


### PR DESCRIPTION
Update condition to execute Downstream package step, so it runs when a branch is updated.
It should not be executed in the context of Pull Requests nor tags.

Branches executed are filtered/configured at: https://github.com/elastic/fleet-server/blob/d2faa28c5ee3be5e333dcced708c936745296cb4/catalog-info.yaml#L44C1-L44C1
