### PR TITLE
Add branch setting to pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -133,6 +133,8 @@ steps:
     label: ":esbuild: Downstream - Package"
     key: "downstream-package"
     if: "build.env('BUILDKITE_PULL_REQUEST') == 'false' && build.env('BUILDKITE_TAG') == '' && build.env('BUILDKITE_BRANCH') != ''"
+    build:
+      branch: "${BUILDKITE_BRANCH}"
     depends_on:
       - step: "release-package-registry"
         allow_failure: false


### PR DESCRIPTION
Adding this branch setting to the buildkite pipeline will allow us to run the DRA scripts that are part of the same branch.
