### PR TITLE
using `service.name` for check error logs

### DIFF
--- a/.buildkite/pipeline.tests-qa.yaml
+++ b/.buildkite/pipeline.tests-qa.yaml
@@ -23,10 +23,4 @@ steps:
       message: "${BUILDKITE_MESSAGE}"
       env:
         ENVIRONMENT: ${ENVIRONMENT}
-  - label: ":rocket: Run Scale tests"
-    trigger: "fleet-scale-tests"
-    build:
-      message: "${BUILDKITE_MESSAGE}"
-      env:
-        ENVIRONMENT: ${ENVIRONMENT}
 

--- a/.buildkite/pipeline.tests-qa.yaml
+++ b/.buildkite/pipeline.tests-qa.yaml
@@ -16,6 +16,7 @@ steps:
         CHECK_CONTAINER_RESTART_COUNT: true
         CONTAINER_NAME: fleet-server
         CHECK_API_REQUEST_METRICS: true
+        SERVICE_TYPE_FIELD: service.name
   - label: ":rocket: Run Smoke tests"
     trigger: "fleet-smoke-tests"
     build:

--- a/.buildkite/pipeline.tests-staging.yaml
+++ b/.buildkite/pipeline.tests-staging.yaml
@@ -16,3 +16,4 @@ steps:
         CHECK_CONTAINER_RESTART_COUNT: true
         CONTAINER_NAME: fleet-server
         CHECK_API_REQUEST_METRICS: true
+        SERVICE_TYPE_FIELD: service.name

--- a/internal/pkg/logger/ecs.go
+++ b/internal/pkg/logger/ecs.go
@@ -54,6 +54,7 @@ const (
 
 	// Service
 	ECSServiceName = "service.name"
+	ECSServiceType = "service.type"
 )
 
 // Non ECS compliant contants used in logging

--- a/internal/pkg/logger/logger.go
+++ b/internal/pkg/logger/logger.go
@@ -150,7 +150,7 @@ func configure(cfg *config.Config, svcName string) (lg zerolog.Logger, wr Writer
 	lg = lg.Level(zerolog.TraceLevel)
 
 	if svcName != "" {
-		lg = lg.With().Str(ECSServiceName, svcName).Logger()
+		lg = lg.With().Str(ECSServiceName, svcName).Str(ECSServiceType, svcName).Logger()
 	}
 
 	return //nolint:nakedret // short function


### PR DESCRIPTION
Found that check error logs qg is failing as it is [using](https://github.com/search?q=repo%3Aelastic%2Fserverless-quality-gates%20SERVICE_TYPE_FIELD&type=code) `service.type` field by default to find fleet-server logs, which is not populated right now.
Using `service.name` instead.

Tested manually here: https://buildkite.com/elastic/serverless-quality-gates/builds/1182#018a603e-930f-4f87-b8d0-95e6524f21b7

```
$ ./observability/check-error-log-percentage.sh
--
  | % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
  | Dload  Upload   Total   Spent    Left  Speed
  | 100  1001  100   296  100   705    279    666  0:00:01  0:00:01 --:--:--   947
  | Calculated error percentage: 1
```