### PR TITLE
Fix flaky instrumentation test

### DIFF
--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -501,7 +501,7 @@ func TestServerInstrumentation(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Start test server with instrumentation diabled
+	// Start test server with instrumentation disabled
 	srv, err := startTestServer(t, ctx, WithAPM(server.URL, false))
 	require.NoError(t, err)
 


### PR DESCRIPTION
## What is the problem this PR solves?

Fix flaky instrumentation test.

## How does this PR solve the problem?

Fix flaky instrumentation test by changing the order of what is tested. Start with APM disabled, then test that traces are sent once it's enabled.
With the new monitor and coordinator transactions the fleet-server will start sending APM data almost immediately, these traces appear to be batched/streamed by the APM agent making it very dependent on timing to detect when the agent is disabled in the previous test case. By changing the order it should now run reliably.

## How to test this PR locally

`make test-int`

## Related issues

- Closes #2953 
