### PR TITLE
[Fleet] Fix quality gates to use correct docker image

### DIFF
--- a/.buildkite/pipeline.tests-qa.yaml
+++ b/.buildkite/pipeline.tests-qa.yaml
@@ -22,10 +22,10 @@ steps:
         CHECK_API_REQUEST_METRICS: true
         SERVICE_TYPE_FIELD: service.name
         SERVICE_VERSION: ${SERVICE_VERSION:0:12}
+        SERVICE_REPOSITORY: docker.elastic.co/observability-ci/fleet-server
   - label: ":rocket: Run Smoke tests"
     trigger: "fleet-smoke-tests"
     build:
       message: "${BUILDKITE_MESSAGE}"
       env:
         ENVIRONMENT: ${ENVIRONMENT}
-

--- a/.buildkite/pipeline.tests-staging.yaml
+++ b/.buildkite/pipeline.tests-staging.yaml
@@ -22,3 +22,4 @@ steps:
         CHECK_API_REQUEST_METRICS: true
         SERVICE_TYPE_FIELD: service.name
         SERVICE_VERSION: ${SERVICE_VERSION:0:12}
+        SERVICE_REPOSITORY: docker.elastic.co/observability-ci/fleet-server


### PR DESCRIPTION
## Description

PR https://github.com/elastic/fleet-server/pull/2978 introduce filtering on service version but for this to work correctly we need to configure `SERVICE_REPOSITORY` to use the correct docker image for fleet server
