### PR TITLE
Add ActionLimit and a gzip writer pool to handle checkin responses

### DIFF
--- a/changelog/fragments/1696358866-Add-action-dispatcher-rate-limiter.yaml
+++ b/changelog/fragments/1696358866-Add-action-dispatcher-rate-limiter.yaml
@@ -1,0 +1,35 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add action-dispatcher rate limiter
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  Add a sync.Pool to share gzip writers among all resquests in order to avoid new gzip.Writer allocations.
+  Each writer allocation is around 1.2MB and is a limiting factor of hitting larger scales.
+  Add a rate limiter to the action-dispatcher used by checkins (disabled by default) to control how responses are written.
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 2994
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/fleet-server.reference.yml
+++ b/fleet-server.reference.yml
@@ -141,15 +141,18 @@ fleet:
 #       max_agents: 0
 #       # policy_throttle is the duration that the fleet-server will wait in between attempts to dispatch policy updates to polling agents # TODO verify this
 #       policy_throttle: 5ms # 1ms min is forced
-#       # action_throttle is added as a delay before the in checkin requests to help space response writes
-#       # This is done in order to be able to reuse gzip writers if gzip is requested as allocating new writers is expensive
-#       # should never me more then 2m to prevent edge cases with assumptions around poll-times and server writes from becoming invalid
-#       # a 0 value disables the throttle (default behavior)
-#       action_throttle: 0
 #       # max_header_byte_size is the request header size limit
 #       max_header_byte_size: 8192 # 8Kib
 #       # max_connections is the maximum number of connnections per API endpoint
 #       max_connections: 0
+#
+#       # action_limit is a limiter for the action dispatcher, it is added to control how fast the checkin endpoint reponds when an action effecting multiple agents is detected.
+#       # This is done in order to be able to reuse gzip writers if gzip is requested as allocating new writers is expensive
+#       # If the value is too high it may effect the server/request write times (generally 2m higher then checkin poll times).
+#       # a 0 value disables the limiter by using an infinite value instead (default behavior)
+#       action_limit:
+#         interval: 0
+#         burst: 10
 #
 #       # endpoint specific limits below
 #       checkin_limit:

--- a/fleet-server.reference.yml
+++ b/fleet-server.reference.yml
@@ -120,10 +120,6 @@ fleet:
 #       # checkin_jitter time may be subtracted from the long_poll time.
 #       # a 0 value disables jitter
 #       checkin_jitter: 30s
-#       # checkin_response_jitter is added as a random delay before the checkin method starts writing a response to a checkin
-#       # should never me more then 2m to prevent edge cases with assumptions around poll-times and server writes from becoming invalid
-#       # a 0 value disables jitter
-#       checkin_response_jitter: 100ms
 #       # checkin_max_poll is the maximum long_poll value a client can request.
 #       checkin_max_poll: 1h
 #
@@ -145,6 +141,11 @@ fleet:
 #       max_agents: 0
 #       # policy_throttle is the duration that the fleet-server will wait in between attempts to dispatch policy updates to polling agents # TODO verify this
 #       policy_throttle: 5ms # 1ms min is forced
+#       # action_throttle is added as a delay before the in checkin requests to help space response writes
+#       # This is done in order to be able to reuse gzip writers if gzip is requested as allocating new writers is expensive
+#       # should never me more then 2m to prevent edge cases with assumptions around poll-times and server writes from becoming invalid
+#       # a 0 value disables the throttle (default behavior)
+#       action_throttle: 0
 #       # max_header_byte_size is the request header size limit
 #       max_header_byte_size: 8192 # 8Kib
 #       # max_connections is the maximum number of connnections per API endpoint

--- a/fleet-server.reference.yml
+++ b/fleet-server.reference.yml
@@ -120,6 +120,10 @@ fleet:
 #       # checkin_jitter time may be subtracted from the long_poll time.
 #       # a 0 value disables jitter
 #       checkin_jitter: 30s
+#       # checkin_response_jitter is added as a random delay before the checkin method starts writing a response to a checkin
+#       # should never me more then 2m to prevent edge cases with assumptions around poll-times and server writes from becoming invalid
+#       # a 0 value disables jitter
+#       checkin_response_jitter: 100ms
 #       # checkin_max_poll is the maximum long_poll value a client can request.
 #       checkin_max_poll: 1h
 #

--- a/fleet-server.reference.yml
+++ b/fleet-server.reference.yml
@@ -146,13 +146,14 @@ fleet:
 #       # max_connections is the maximum number of connnections per API endpoint
 #       max_connections: 0
 #
-#       # action_limit is a limiter for the action dispatcher, it is added to control how fast the checkin endpoint reponds when an action effecting multiple agents is detected.
-#       # This is done in order to be able to reuse gzip writers if gzip is requested as allocating new writers is expensive
-#       # If the value is too high it may effect the server/request write times (generally 2m higher then checkin poll times).
-#       # a 0 value disables the limiter by using an infinite value instead (default behavior)
+#       # action_limit is a limiter for the action dispatcher, it is added to control how fast the checkin endpoint writes responses when an action effecting multiple agents is detected.
+#       # This is done in order to be able to reuse gzip writers if gzip is requested as allocating new writers is expensive (around 1.2MB for a new allocation).
+#       # If the interval is too high it may negativly effect assumtions around server write timeouts and poll poll durations, if used we expect the value to be around 5ms.
+#       # An interval value of 0 disables the limiter by using an infinite rate limit (default behavior).
+#       # Burst controls concurrency and has a larger influence on the gzip writer pool size (default 5).
 #       action_limit:
 #         interval: 0
-#         burst: 10
+#         burst: 5
 #
 #       # endpoint specific limits below
 #       checkin_limit:

--- a/internal/pkg/action/dispatcher_test.go
+++ b/internal/pkg/action/dispatcher_test.go
@@ -271,6 +271,7 @@ func Test_Dispatcher_Run(t *testing.T) {
 			select {
 			case actions := <-d.subs["agent1"].Ch():
 				compareActions(t, tt.expect["agent1"], actions)
+				// NOTE: agent1 is not rate limited if the action limmiter is enabled for these tests.
 			case <-ticker.C:
 				t.Fatal("timeout waiting for subscription on agent1")
 			}
@@ -281,7 +282,7 @@ func Test_Dispatcher_Run(t *testing.T) {
 				case actions := <-d.subs["agent2"].Ch():
 					compareActions(t, expect, actions)
 					if tt.throttle != 0 {
-						assert.Greater(t, time.Now(), now.Add(1*tt.throttle))
+						assert.GreaterOrEqual(t, time.Now(), now.Add(1*tt.throttle))
 					}
 				case <-ticker.C:
 					t.Fatal("timeout waiting for subscription on agent2")
@@ -294,7 +295,7 @@ func Test_Dispatcher_Run(t *testing.T) {
 				case actions := <-d.subs["agent3"].Ch():
 					compareActions(t, expect, actions)
 					if tt.throttle != 0 {
-						assert.Greater(t, time.Now(), now.Add(2*tt.throttle))
+						assert.GreaterOrEqual(t, time.Now(), now.Add(2*tt.throttle))
 					}
 				case <-ticker.C:
 					t.Fatal("timeout waiting for subscription on agent3")

--- a/internal/pkg/action/dispatcher_test.go
+++ b/internal/pkg/action/dispatcher_test.go
@@ -129,7 +129,7 @@ func Test_Dispatcher_Run(t *testing.T) {
 		},
 	}, {
 		name:     "three agent action with throttle",
-		throttle: time.Duration(1 * time.Second),
+		throttle: 1 * time.Second,
 		getMock: func() *mockMonitor {
 			m := &mockMonitor{}
 			ch := make(chan []es.HitT)

--- a/internal/pkg/action/dispatcher_test.go
+++ b/internal/pkg/action/dispatcher_test.go
@@ -38,7 +38,7 @@ func (m *mockMonitor) GetCheckpoint() sqn.SeqNo {
 
 func TestNewDispatcher(t *testing.T) {
 	m := &mockMonitor{}
-	d := NewDispatcher(m)
+	d := NewDispatcher(m, 0)
 
 	assert.NotNil(t, d.am)
 	assert.NotNil(t, d.subs)

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -519,8 +519,8 @@ func (ct *CheckinT) writeResponse(zlog zerolog.Logger, w http.ResponseWriter, r 
 			return fmt.Errorf("writeResponse gzip write: %w", err)
 		}
 
-		if err = zipper.Close(); err != nil {
-			err = fmt.Errorf("writeResponse gzip close: %w", err)
+		if err = zipper.Flush(); err != nil {
+			err = fmt.Errorf("writeResponse gzip flush: %w", err)
 		}
 
 		cntCheckin.bodyOut.Add(wrCounter.Count())

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -499,6 +499,16 @@ func (ct *CheckinT) writeResponse(zlog zerolog.Logger, w http.ResponseWriter, r 
 	rSpan, _ := apm.StartSpan(ctx, "response", "write")
 	defer rSpan.End()
 
+	// use CheckinResponseJitter to randomly delay writes
+	if ct.cfg.Timeouts.CheckinResponseJitter > 0 {
+		jitter := time.Duration(rand.Int63n(int64(ct.cfg.Limits.CheckinJitter)))
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(jitter):
+		}
+	}
+
 	payload, err := json.Marshal(&resp)
 	if err != nil {
 		return fmt.Errorf("writeResponse marshal: %w", err)

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -62,6 +62,10 @@ type CheckinT struct {
 	gcp    monitor.GlobalCheckpointProvider
 	ad     *action.Dispatcher
 	tr     *action.TokenResolver
+
+	// gwPool is a gzip.Writer pool intended to lower the amount of writers created when responding to checkin requests.
+	// gzip.Writer allocations are expensive (~1.2MB each) and can exhaust an instance's memory if a lot of concurrent responses are sent (this occurs when a mass-action such as an upgrade is detected).
+	// effectiveness of the pool is controlled by rate limiter configured through the limit.action_limit attribute.
 	gwPool sync.Pool
 	bulker bulk.Bulk
 }

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -510,7 +510,8 @@ func (ct *CheckinT) writeResponse(zlog zerolog.Logger, w http.ResponseWriter, r 
 	if len(payload) > compressThreshold && compressionLevel != flate.NoCompression && acceptsEncoding(r, kEncodingGzip) {
 		wrCounter := datacounter.NewWriterCounter(w)
 
-		zipper := ct.gwPool.Get().(*gzip.Writer)
+		zipper, _ := ct.gwPool.Get().(*gzip.Writer)
+
 		defer ct.gwPool.Put(zipper)
 		zipper.Reset(wrCounter)
 

--- a/internal/pkg/config/env_defaults.go
+++ b/internal/pkg/config/env_defaults.go
@@ -27,7 +27,7 @@ const (
 	defaultPolicyThrottle = time.Millisecond * 5
 
 	defaultActionInterval = 0 // no throttle
-	defaultActionBurst    = 10
+	defaultActionBurst    = 5
 
 	defaultCheckinInterval = time.Millisecond
 	defaultCheckinBurst    = 1000

--- a/internal/pkg/config/env_defaults.go
+++ b/internal/pkg/config/env_defaults.go
@@ -25,6 +25,7 @@ const (
 
 	defaultMaxConnections = 0 // no limit
 	defaultPolicyThrottle = time.Millisecond * 5
+	defaultActionThrottle = 0 // no throttle
 
 	defaultCheckinInterval = time.Millisecond
 	defaultCheckinBurst    = 1000
@@ -120,6 +121,7 @@ type limit struct {
 
 type serverLimitDefaults struct {
 	PolicyThrottle time.Duration `config:"policy_throttle"`
+	ActionThrottle time.Duration `config:"action_throttle"`
 	MaxConnections int           `config:"max_connections"`
 
 	CheckinLimit     limit `config:"checkin_limit"`
@@ -137,6 +139,7 @@ type serverLimitDefaults struct {
 func defaultserverLimitDefaults() *serverLimitDefaults {
 	return &serverLimitDefaults{
 		PolicyThrottle: defaultPolicyThrottle,
+		ActionThrottle: defaultActionThrottle,
 		MaxConnections: defaultMaxConnections,
 
 		CheckinLimit: limit{

--- a/internal/pkg/config/env_defaults.go
+++ b/internal/pkg/config/env_defaults.go
@@ -25,7 +25,9 @@ const (
 
 	defaultMaxConnections = 0 // no limit
 	defaultPolicyThrottle = time.Millisecond * 5
-	defaultActionThrottle = 0 // no throttle
+
+	defaultActionInterval = 0 // no throttle
+	defaultActionBurst    = 10
 
 	defaultCheckinInterval = time.Millisecond
 	defaultCheckinBurst    = 1000
@@ -121,9 +123,9 @@ type limit struct {
 
 type serverLimitDefaults struct {
 	PolicyThrottle time.Duration `config:"policy_throttle"`
-	ActionThrottle time.Duration `config:"action_throttle"`
 	MaxConnections int           `config:"max_connections"`
 
+	ActionLimit      limit `config:"action_limit"`
 	CheckinLimit     limit `config:"checkin_limit"`
 	ArtifactLimit    limit `config:"artifact_limit"`
 	EnrollLimit      limit `config:"enroll_limit"`
@@ -139,9 +141,12 @@ type serverLimitDefaults struct {
 func defaultserverLimitDefaults() *serverLimitDefaults {
 	return &serverLimitDefaults{
 		PolicyThrottle: defaultPolicyThrottle,
-		ActionThrottle: defaultActionThrottle,
 		MaxConnections: defaultMaxConnections,
 
+		ActionLimit: limit{
+			Interval: defaultActionInterval,
+			Burst:    defaultActionBurst,
+		},
 		CheckinLimit: limit{
 			Interval: defaultCheckinInterval,
 			Burst:    defaultCheckinBurst,

--- a/internal/pkg/config/limits.go
+++ b/internal/pkg/config/limits.go
@@ -18,10 +18,10 @@ type Limit struct {
 type ServerLimits struct {
 	MaxAgents         int           `config:"max_agents"`
 	PolicyThrottle    time.Duration `config:"policy_throttle"`
-	ActionThrottle    time.Duration `config:"action_throttle"`
 	MaxHeaderByteSize int           `config:"max_header_byte_size"`
 	MaxConnections    int           `config:"max_connections"`
 
+	ActionLimit      Limit `config:"action_limit"`
 	CheckinLimit     Limit `config:"checkin_limit"`
 	ArtifactLimit    Limit `config:"artifact_limit"`
 	EnrollLimit      Limit `config:"enroll_limit"`
@@ -52,10 +52,7 @@ func (c *ServerLimits) LoadLimits(limits *envLimits) {
 		c.PolicyThrottle = l.PolicyThrottle
 	}
 
-	if c.ActionThrottle == 0 {
-		c.ActionThrottle = l.ActionThrottle
-	}
-
+	c.ActionLimit = mergeEnvLimit(c.ActionLimit, l.ActionLimit)
 	c.CheckinLimit = mergeEnvLimit(c.CheckinLimit, l.CheckinLimit)
 	c.ArtifactLimit = mergeEnvLimit(c.ArtifactLimit, l.ArtifactLimit)
 	c.EnrollLimit = mergeEnvLimit(c.EnrollLimit, l.EnrollLimit)

--- a/internal/pkg/config/limits.go
+++ b/internal/pkg/config/limits.go
@@ -18,6 +18,7 @@ type Limit struct {
 type ServerLimits struct {
 	MaxAgents         int           `config:"max_agents"`
 	PolicyThrottle    time.Duration `config:"policy_throttle"`
+	ActionThrottle    time.Duration `config:"action_throttle"`
 	MaxHeaderByteSize int           `config:"max_header_byte_size"`
 	MaxConnections    int           `config:"max_connections"`
 
@@ -49,6 +50,10 @@ func (c *ServerLimits) LoadLimits(limits *envLimits) {
 	}
 	if c.PolicyThrottle == 0 {
 		c.PolicyThrottle = l.PolicyThrottle
+	}
+
+	if c.ActionThrottle == 0 {
+		c.ActionThrottle = l.ActionThrottle
 	}
 
 	c.CheckinLimit = mergeEnvLimit(c.CheckinLimit, l.CheckinLimit)

--- a/internal/pkg/config/timeouts.go
+++ b/internal/pkg/config/timeouts.go
@@ -10,15 +10,14 @@ import (
 
 // ServerTimeouts is the configuration for the server timeouts
 type ServerTimeouts struct {
-	Read                  time.Duration `config:"read"`
-	Write                 time.Duration `config:"write"`
-	Idle                  time.Duration `config:"idle"`
-	ReadHeader            time.Duration `config:"read_header"`
-	CheckinTimestamp      time.Duration `config:"checkin_timestamp"`
-	CheckinLongPoll       time.Duration `config:"checkin_long_poll"`
-	CheckinJitter         time.Duration `config:"checkin_jitter"`
-	CheckinResponseJitter time.Duration `config:"checkin_response_jitter"`
-	CheckinMaxPoll        time.Duration `config:"checkin_max_poll"`
+	Read             time.Duration `config:"read"`
+	Write            time.Duration `config:"write"`
+	Idle             time.Duration `config:"idle"`
+	ReadHeader       time.Duration `config:"read_header"`
+	CheckinTimestamp time.Duration `config:"checkin_timestamp"`
+	CheckinLongPoll  time.Duration `config:"checkin_long_poll"`
+	CheckinJitter    time.Duration `config:"checkin_jitter"`
+	CheckinMaxPoll   time.Duration `config:"checkin_max_poll"`
 }
 
 // InitDefaults initializes the defaults for the configuration.
@@ -60,9 +59,6 @@ func (c *ServerTimeouts) InitDefaults() {
 
 	// Jitter subtracted from c.CheckinLongPoll. Disabled if zero.
 	c.CheckinJitter = 30 * time.Second
-
-	// Jitter added as a random delay before checkin responses are written. Disabled if zero.
-	c.CheckinResponseJitter = 100 * time.Millisecond
 
 	// MaxPoll is the maximum allowed value for a long poll when the client specified poll_timeout value is used.
 	// The long poll value is poll_timeout-2m, and the request's write timeout is set to poll_timeout-1m

--- a/internal/pkg/config/timeouts.go
+++ b/internal/pkg/config/timeouts.go
@@ -10,14 +10,15 @@ import (
 
 // ServerTimeouts is the configuration for the server timeouts
 type ServerTimeouts struct {
-	Read             time.Duration `config:"read"`
-	Write            time.Duration `config:"write"`
-	Idle             time.Duration `config:"idle"`
-	ReadHeader       time.Duration `config:"read_header"`
-	CheckinTimestamp time.Duration `config:"checkin_timestamp"`
-	CheckinLongPoll  time.Duration `config:"checkin_long_poll"`
-	CheckinJitter    time.Duration `config:"checkin_jitter"`
-	CheckinMaxPoll   time.Duration `config:"checkin_max_poll"`
+	Read                  time.Duration `config:"read"`
+	Write                 time.Duration `config:"write"`
+	Idle                  time.Duration `config:"idle"`
+	ReadHeader            time.Duration `config:"read_header"`
+	CheckinTimestamp      time.Duration `config:"checkin_timestamp"`
+	CheckinLongPoll       time.Duration `config:"checkin_long_poll"`
+	CheckinJitter         time.Duration `config:"checkin_jitter"`
+	CheckinResponseJitter time.Duration `config:"checkin_response_jitter"`
+	CheckinMaxPoll        time.Duration `config:"checkin_max_poll"`
 }
 
 // InitDefaults initializes the defaults for the configuration.
@@ -57,8 +58,11 @@ func (c *ServerTimeouts) InitDefaults() {
 	// Long poll timeout, will be short-circuited on policy change
 	c.CheckinLongPoll = 5 * time.Minute
 
-	// Jitter subtracted from c.CheckinLongPoll.  Disabled if zero.
+	// Jitter subtracted from c.CheckinLongPoll. Disabled if zero.
 	c.CheckinJitter = 30 * time.Second
+
+	// Jitter added as a random delay before checkin responses are written. Disabled if zero.
+	c.CheckinResponseJitter = 100 * time.Millisecond
 
 	// MaxPoll is the maximum allowed value for a long poll when the client specified poll_timeout value is used.
 	// The long poll value is poll_timeout-2m, and the request's write timeout is set to poll_timeout-1m

--- a/internal/pkg/server/fleet.go
+++ b/internal/pkg/server/fleet.go
@@ -505,7 +505,7 @@ func (f *Fleet) runSubsystems(ctx context.Context, cfg *config.Config, g *errgro
 	}
 	g.Go(loggedRunFunc(ctx, "Revision monitor", am.Run))
 
-	ad = action.NewDispatcher(am, cfg.Inputs[0].Server.Limits.ActionThrottle)
+	ad = action.NewDispatcher(am, cfg.Inputs[0].Server.Limits.ActionLimit.Interval, cfg.Inputs[0].Server.Limits.ActionLimit.Burst)
 	g.Go(loggedRunFunc(ctx, "Revision dispatcher", ad.Run))
 	tr, err = action.NewTokenResolver(bulker)
 	if err != nil {

--- a/internal/pkg/server/fleet.go
+++ b/internal/pkg/server/fleet.go
@@ -505,7 +505,7 @@ func (f *Fleet) runSubsystems(ctx context.Context, cfg *config.Config, g *errgro
 	}
 	g.Go(loggedRunFunc(ctx, "Revision monitor", am.Run))
 
-	ad = action.NewDispatcher(am)
+	ad = action.NewDispatcher(am, cfg.Inputs[0].Server.Limits.ActionThrottle)
 	g.Go(loggedRunFunc(ctx, "Revision dispatcher", ad.Run))
 	tr, err = action.NewTokenResolver(bulker)
 	if err != nil {


### PR DESCRIPTION
## What is the problem this PR solves?

Small containers OOM when issuing updates to many clients, this could be mitigated by adding a rate limiter and using a pool for the gzip writter.

## How does this PR solve the problem?

Add a sync.Pool to share gzip writers among all resquests in order to avoid new gzip.Writer allocations. Each writer allocation is around 1.2MB and is a limiting factor of hitting larger scales. Add action dispatch limiter to control how quickly the checkin endpoint writes responses in order to make better use of the writer pool.

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~ 10k test for serverless complete
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)