### PR TITLE
Fix bulker error attributes to be ECS complient

### DIFF
--- a/changelog/fragments/1697136150-Fix-bulker-error-message-attribute.yaml
+++ b/changelog/fragments/1697136150-Fix-bulker-error-message-attribute.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix bulker error message attribute to be ECS complient
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 3033

--- a/internal/pkg/bulk/opApiKey.go
+++ b/internal/pkg/bulk/opApiKey.go
@@ -176,7 +176,7 @@ func (b *Bulker) flushUpdateAPIKey(ctx context.Context, queue queueT) error {
 		idsPerBatch := b.getIDsCountPerBatch(len(role), maxKeySize)
 		ids := idsPerRole[hash]
 		if idsPerBatch <= 0 {
-			log.Error().Str("err", "request too large").Msg("No API Key ID could fit request size for bulk update")
+			log.Error().Str("error.message", "request too large").Msg("No API Key ID could fit request size for bulk update")
 			log.Debug().
 				RawJSON("role", role).
 				Strs("ids", ids).
@@ -224,7 +224,7 @@ func (b *Bulker) flushUpdateAPIKey(ctx context.Context, queue queueT) error {
 				defer res.Body.Close()
 			}
 			if res.IsError() {
-				log.Error().Str("err", res.String()).Msg("Error in bulk API Key update result to Elasticsearch")
+				log.Error().Str("error.message", res.String()).Msg("Error in bulk API Key update result to Elasticsearch")
 				return parseError(res)
 			}
 

--- a/internal/pkg/bulk/opBulk.go
+++ b/internal/pkg/bulk/opBulk.go
@@ -218,7 +218,7 @@ func (b *Bulker) flushBulk(ctx context.Context, queue queueT) error {
 	}
 
 	if res.IsError() {
-		log.Error().Str("mod", kModBulk).Str("err", res.String()).Msg("Fail BulkRequest result")
+		log.Error().Str("mod", kModBulk).Str("error.message", res.String()).Msg("Fail BulkRequest result")
 		return parseError(res)
 	}
 

--- a/internal/pkg/bulk/opRead.go
+++ b/internal/pkg/bulk/opRead.go
@@ -110,7 +110,7 @@ func (b *Bulker) flushRead(ctx context.Context, queue queueT) error {
 	}
 
 	if res.IsError() {
-		log.Warn().Str("mod", kModBulk).Str("err", res.String()).Msg("bulker.flushRead: Error in mget request result to Elasticsearch")
+		log.Warn().Str("mod", kModBulk).Str("error.message", res.String()).Msg("bulker.flushRead: Error in mget request result to Elasticsearch")
 		return parseError(res)
 	}
 

--- a/internal/pkg/bulk/opSearch.go
+++ b/internal/pkg/bulk/opSearch.go
@@ -169,7 +169,7 @@ func (b *Bulker) flushSearch(ctx context.Context, queue queueT) error {
 	}
 
 	if res.IsError() {
-		log.Warn().Str("mod", kModBulk).Str("err", res.String()).Msg("bulker.flushSearch: Fail writeMsearchBody")
+		log.Warn().Str("mod", kModBulk).Str("error.message", res.String()).Msg("bulker.flushSearch: Fail writeMsearchBody")
 		return parseError(res)
 	}
 


### PR DESCRIPTION
## What is the problem this PR solves?

Some error logs produced specifically by the bulker are not ECS complient

## How does this PR solve the problem?

Rename the "err" attribute to "error.message"

## Checklist

- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Closes #3033 