### PR TITLE
Relax version checks for snapshot builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ list-platforms: ## - Show the possible PLATFORMS
 .PHONY: local
 local: ## - Build local binary for local environment (bin/fleet-server)
 	@printf "${CMD_COLOR_ON} Build binaries using local go installation\n${CMD_COLOR_OFF}"
-	go build $(if $(DEV),-tags="dev",) -gcflags="${GCFLAGS}" -ldflags="${LDFLAGS}" -o ./bin/fleet-server .
+	go build $(if $(SNAPSHOT),-tags="snapshot",) -gcflags="${GCFLAGS}" -ldflags="${LDFLAGS}" -o ./bin/fleet-server .
 	@printf "${CMD_COLOR_ON} Binaries in ./bin/\n${CMD_COLOR_OFF}"
 
 .PHONY: $(COVER_TARGETS)
@@ -84,7 +84,7 @@ $(COVER_TARGETS): cover-%: ## - Build a binary with the -cover flag for integrat
 	$(eval $@_GO_ARCH := $(lastword $(subst /, ,$(lastword $(subst cover-, ,$@)))))
 	$(eval $@_ARCH := $(TARGET_ARCH_$($@_GO_ARCH)))
 	$(eval $@_BUILDMODE:= $(BUILDMODE_$($@_OS)_$($@_GO_ARCH)))
-	GOOS=$($@_OS) GOARCH=$($@_GO_ARCH) go build $(if $(DEV),-tags="dev",) -cover -coverpkg=./... -gcflags="${GCFLAGS}" -ldflags="${LDFLAGS}" $($@_BUILDMODE) -o build/cover/fleet-server-$(VERSION)-$($@_OS)-$($@_ARCH)/fleet-server$(if $(filter windows,$($@_OS)),.exe,) .
+	GOOS=$($@_OS) GOARCH=$($@_GO_ARCH) go build $(if $(SNAPSHOT),-tags="snapshot",) -cover -coverpkg=./... -gcflags="${GCFLAGS}" -ldflags="${LDFLAGS}" $($@_BUILDMODE) -o build/cover/fleet-server-$(VERSION)-$($@_OS)-$($@_ARCH)/fleet-server$(if $(filter windows,$($@_OS)),.exe,) .
 
 .PHONY: clean
 clean: ## - Clean up build artifacts
@@ -198,7 +198,7 @@ $(PLATFORM_TARGETS): release-%:
 	$(eval $@_GO_ARCH := $(lastword $(subst /, ,$(lastword $(subst release-, ,$@)))))
 	$(eval $@_ARCH := $(TARGET_ARCH_$($@_GO_ARCH)))
 	$(eval $@_BUILDMODE:= $(BUILDMODE_$($@_OS)_$($@_GO_ARCH)))
-	GOOS=$($@_OS) GOARCH=$($@_GO_ARCH) go build $(if $(DEV),-tags="dev",) -gcflags="${GCFLAGS}" -ldflags="${LDFLAGS}" $($@_BUILDMODE) -o build/binaries/fleet-server-$(VERSION)-$($@_OS)-$($@_ARCH)/fleet-server .
+	GOOS=$($@_OS) GOARCH=$($@_GO_ARCH) go build $(if $(SNAPSHOT),-tags="snapshot",) -gcflags="${GCFLAGS}" -ldflags="${LDFLAGS}" $($@_BUILDMODE) -o build/binaries/fleet-server-$(VERSION)-$($@_OS)-$($@_ARCH)/fleet-server .
 	@$(MAKE) OS=$($@_OS) ARCH=$($@_ARCH) package-target
 
 .PHONY: build-docker
@@ -208,6 +208,7 @@ build-docker:
 		--build-arg=GCFLAGS="${GCFLAGS}" \
 		--build-arg=LDFLAGS="${LDFLAGS}" \
 		--build-arg=DEV="$(DEV)" \
+		--build-arg=SNAPSHOT="$(SNAPSHOT)" \
 		--build-arg=VERSION="$(VERSION)" \
 		-t $(DOCKER_IMAGE):$(DOCKER_IMAGE_TAG)$(if $(DEV),-dev,) .
 
@@ -220,6 +221,7 @@ build-and-push-docker:
 		--build-arg=GCFLAGS="${GCFLAGS}" \
 		--build-arg=LDFLAGS="${LDFLAGS}" \
 		--build-arg=DEV="$(DEV)" \
+		--build-arg=SNAPSHOT="$(SNAPSHOT)" \
 		--build-arg=VERSION="$(VERSION)" \
 		-t $(DOCKER_IMAGE):$(DOCKER_IMAGE_TAG)$(if $(DEV),-dev,) .
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ GOOS=darwin GOARCH=amd64 go build -tags="dev" -gcflags="all=-N -l" -ldflags="-X 
 Change `release-darwin/amd64` to `release-YOUR_OS/platform`.
 Run `make list-platforms` to check out the possible values.
 
-The `SNAPSHOT` flag sets the snapshot version flag.
+The `SNAPSHOT` flag sets the snapshot version flag and relaxes client version checks.
+When `SNAPSHOT` is set we allow clients of the next version to communicate with fleet-server.
+For example, if fleet-server is running version `8.11.0` on a `SNAPSHOT` build, clients can communiate with versions up to `8.12.0`.
 
 ### Docker build
 

--- a/changelog/fragments/1697230491-Relax-version-checks-in-snapshot-builds.yaml
+++ b/changelog/fragments/1697230491-Relax-version-checks-in-snapshot-builds.yaml
@@ -1,0 +1,36 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Relax version checks in snapshot builds
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  Relax version checking fleet-server does to client communication when built with SNAPSHOT=true.
+  Versions allowed will be <=X.Y+1.Z, that is to say snapshots will allow the next minor version to communicate.
+  This is done to avoid the chicken and egg prpoblem we face in automated testing when releasing new minor versions.
+
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 2960

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -28,6 +28,7 @@ import (
 	testcache "github.com/elastic/fleet-server/v7/internal/pkg/testing/cache"
 	testlog "github.com/elastic/fleet-server/v7/internal/pkg/testing/log"
 
+	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -577,4 +578,12 @@ func BenchmarkParallel_CheckinT_writeResponse(b *testing.B) {
 			require.NoError(b, err)
 		}
 	})
+}
+
+func mustBuildConstraints(verStr string) version.Constraints {
+	con, err := BuildVersionConstraint(verStr)
+	if err != nil {
+		panic(err)
+	}
+	return con
 }

--- a/internal/pkg/api/userAgent.go
+++ b/internal/pkg/api/userAgent.go
@@ -7,7 +7,6 @@ package api
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -28,17 +27,6 @@ var (
 	ErrInvalidUserAgent   = errors.New("user-agent is invalid")
 	ErrUnsupportedVersion = errors.New("version is not supported")
 )
-
-// BuildVersionConstraint turns the version into a constraint to ensure that the connecting Elastic Agent's are
-// a supported version.
-func BuildVersionConstraint(verStr string) (version.Constraints, error) {
-	ver, err := version.NewVersion(verStr)
-	if err != nil {
-		return nil, err
-	}
-	verStr = maximizePatch(ver)
-	return version.NewConstraint(fmt.Sprintf(">= %s, <= %s", MinVersion, verStr))
-}
 
 // maximizePatch turns the version into a string that has the patch value set to the maximum integer.
 //

--- a/internal/pkg/api/userAgent_test.go
+++ b/internal/pkg/api/userAgent_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build !integration
+//go:build !integration && !snapshot
 
 package api
 
@@ -120,12 +120,4 @@ func TestValidateUserAgent(t *testing.T) {
 			}
 		})
 	}
-}
-
-func mustBuildConstraints(verStr string) version.Constraints {
-	con, err := BuildVersionConstraint(verStr)
-	if err != nil {
-		panic(err)
-	}
-	return con
 }

--- a/internal/pkg/api/verConst.go
+++ b/internal/pkg/api/verConst.go
@@ -1,0 +1,24 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !snapshot
+
+package api
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-version"
+)
+
+// BuildVersionConstraint turns the version into a constraint to ensure that the connecting Elastic Agent's are
+// a supported version.
+func BuildVersionConstraint(verStr string) (version.Constraints, error) {
+	ver, err := version.NewVersion(verStr)
+	if err != nil {
+		return nil, err
+	}
+	verStr = maximizePatch(ver)
+	return version.NewConstraint(fmt.Sprintf(">= %s, <= %s", MinVersion, verStr))
+}

--- a/internal/pkg/api/verConst_snapshot.go
+++ b/internal/pkg/api/verConst_snapshot.go
@@ -1,0 +1,41 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build snapshot
+
+package api
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-version"
+)
+
+// BuildVersionConstraint turns the version into a constraint to ensure that the connecting Elastic Agent's are
+// a supported version.
+// For snapshot builds we allow the minor version to be newer in order to allow automated testing to proceed.
+func BuildVersionConstraint(verStr string) (version.Constraints, error) {
+	ver, err := version.NewVersion(verStr)
+	if err != nil {
+		return nil, err
+	}
+	verStr = bumpMinor(ver)
+	return version.NewConstraint(fmt.Sprintf(">= %s, <= %s", MinVersion, verStr))
+}
+
+// bumpMinor returns a version string where 1 is added to the minor version
+func bumpMinor(ver *version.Version) string {
+	segments := ver.Segments()
+	if len(segments) < 2 {
+		return ver.String()
+	}
+	segments[1] += 1
+	strs := make([]string, 0, len(segments))
+	for _, seg := range segments {
+		strs = append(strs, strconv.Itoa(seg))
+	}
+	return strings.Join(strs, ".")
+}

--- a/internal/pkg/api/verConst_snapshot_test.go
+++ b/internal/pkg/api/verConst_snapshot_test.go
@@ -1,0 +1,41 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !integration && snapshot
+
+package api
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionConstraint(t *testing.T) {
+	tests := []struct {
+		version string
+		succeed bool
+	}{{
+		version: "8.0.0",
+		succeed: true,
+	}, {
+		version: "8.1.0",
+		succeed: true,
+	}, {
+		version: "8.2.0",
+		succeed: false,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.version, func(t *testing.T) {
+			vc, err := BuildVersionConstraint("8.0.0")
+			require.NoError(t, err)
+			ver, err := version.NewVersion(tc.version)
+			require.NoError(t, err)
+
+			require.Equalf(t, tc.succeed, vc.Check(ver), "vc is %s", vc.String())
+		})
+	}
+}


### PR DESCRIPTION
## What is the problem this PR solves?

Automated testing stalls for a few days when we release a new minor version.

## How does this PR solve the problem?

Relax version checking when a SNAPSHOT binary of the fleet-server is built.
Version checking is relaxed to allow the minor version to be ahead by one.
If the fleet-server is running `X.Y.Z`, it allows clients of `X.Y+1.Z` to communicate.

## How to test this PR locally

`go test -v -tags=snapshot ./...`

Example output:
```
--- PASS: TestVersionConstraint (0.00s)
    --- PASS: TestVersionConstraint/8.0.0 (0.00s)
    --- PASS: TestVersionConstraint/8.1.0 (0.00s)
    --- PASS: TestVersionConstraint/8.2.0 (0.00s)
PASS
```

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Closes #2960 