### PR TITLE
[Buildkite] Allow failures to triggering package-registry job

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -144,9 +144,6 @@ steps:
       meta_data:
         DOCKER_TAG: "${BUILDKITE_TAG}"
     if: "build.env('BUILDKITE_TAG') != ''"
-    depends_on:
-      - step: "release-test"
-        allow_failure: true
 
   - trigger: "fleet-server-package-mbp"
     label: ":esbuild: Downstream - Package"
@@ -156,5 +153,5 @@ steps:
     build:
       branch: "${BUILDKITE_BRANCH}"
     depends_on:
-      - step: "release-package-registry"
+      - step: "release-test"
         allow_failure: false

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -138,6 +138,7 @@ steps:
   - label: ":jenkins: Release - Package Registry Distribution"
     key: "release-package-registry"
     trigger: "package-registry-release-package-registry-distribution"
+    async: true
     build:
       branch: "main"
       meta_data:
@@ -145,11 +146,12 @@ steps:
     if: "build.env('BUILDKITE_TAG') != ''"
     depends_on:
       - step: "release-test"
-        allow_failure: false
+        allow_failure: true
 
   - trigger: "fleet-server-package-mbp"
     label: ":esbuild: Downstream - Package"
     key: "downstream-package"
+    async: true
     if: "build.env('BUILDKITE_PULL_REQUEST') == 'false' && build.env('BUILDKITE_TAG') == '' && build.env('BUILDKITE_BRANCH') != ''"
     build:
       branch: "${BUILDKITE_BRANCH}"


### PR DESCRIPTION
## What is the problem this PR solves?

// Please do not just reference an issue. Explain WHAT the problem this PR solves here.
Package-Registry pipeline is not triggered if other steps are failing

Example of build where this step was not triggered: https://buildkite.com/elastic/fleet-server/builds/2186

## How does this PR solve the problem?

Allow to be executed the trigger of package-registry pipeline without any dependencies on other steps.

// Explain HOW you solved the problem in your code. It is possible that during PR reviews this changes and then this section should be updated.

As part of this PR, checking how it was configured Jenkins, it has been updated trigger steps to be asynchronous:
- https://github.com/elastic/fleet-server/blob/396d745bc1081190ff5912dcf0b05a266fe56f6a/.ci/Jenkinsfile#L215
-https://github.com/elastic/fleet-server/blob/396d745bc1081190ff5912dcf0b05a266fe56f6a/.ci/Jenkinsfile#L228

