### PR TITLE
Add Elastic-Api-Version and X-Request-Id headers in openapi spec

### DIFF
--- a/changelog/fragments/1697650203-Add-missing-headers-to-openapi-spec.yaml
+++ b/changelog/fragments/1697650203-Add-missing-headers-to-openapi-spec.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: other
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add missing headers to openapi spec
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: Add missing Elastic-Api-Version and X-Request-Id headers across all req/resp in the openapi spec and generated clients.
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/api/api.go
+++ b/internal/pkg/api/api.go
@@ -130,7 +130,7 @@ func (a *apiServer) UploadChunk(w http.ResponseWriter, r *http.Request, id strin
 	}
 }
 
-func (a *apiServer) GetFile(w http.ResponseWriter, r *http.Request, id string) {
+func (a *apiServer) GetFile(w http.ResponseWriter, r *http.Request, id string, params GetFileParams) {
 	zlog := hlog.FromRequest(r).With().Logger()
 	if err := a.ft.handleSendFile(zlog, w, r, id); err != nil {
 		cntFileDeliv.IncError(err)
@@ -139,7 +139,7 @@ func (a *apiServer) GetFile(w http.ResponseWriter, r *http.Request, id string) {
 	}
 }
 
-func (a *apiServer) GetPGPKey(w http.ResponseWriter, r *http.Request, major, minor, patch int) {
+func (a *apiServer) GetPGPKey(w http.ResponseWriter, r *http.Request, major, minor, patch int, params GetPGPKeyParams) {
 	zlog := hlog.FromRequest(r).With().Logger()
 	if err := a.pt.handlePGPKey(zlog, w, r, major, minor, patch); err != nil {
 		cntGetPGP.IncError(err)

--- a/internal/pkg/api/apiVersion.go
+++ b/internal/pkg/api/apiVersion.go
@@ -62,6 +62,7 @@ func (a *apiVersion) middleware(next http.Handler) http.Handler {
 		if headerValue != "" {
 			err := a.validateVersionFormat(headerValue)
 			if err != nil {
+				w.Header().Add(ElasticAPIVersionHeader, a.defaultVersion)
 				ErrorResp(w, r, err)
 				return
 			}

--- a/internal/pkg/api/openapi.gen.go
+++ b/internal/pkg/api/openapi.gen.go
@@ -612,6 +612,15 @@ type Throttle = Error
 // Unavailable Error processing request.
 type Unavailable = Error
 
+// GetPGPKeyParams defines parameters for GetPGPKey.
+type GetPGPKeyParams struct {
+	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
+	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
+
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
+}
+
 // AgentEnrollParams defines parameters for AgentEnroll.
 type AgentEnrollParams struct {
 	// UserAgent The user-agent header that is sent.
@@ -619,8 +628,8 @@ type AgentEnrollParams struct {
 	// The agent version must not be greater than the version of the fleet-server.
 	UserAgent UserAgent `json:"User-Agent"`
 
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
 	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
@@ -628,8 +637,8 @@ type AgentEnrollParams struct {
 
 // AgentAcksParams defines parameters for AgentAcks.
 type AgentAcksParams struct {
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
 	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
@@ -647,8 +656,8 @@ type AgentCheckinParams struct {
 	// The agent version must not be greater than the version of the fleet-server.
 	UserAgent UserAgent `json:"User-Agent"`
 
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
 	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
@@ -656,17 +665,26 @@ type AgentCheckinParams struct {
 
 // ArtifactParams defines parameters for Artifact.
 type ArtifactParams struct {
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
 	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
 }
 
+// GetFileParams defines parameters for GetFile.
+type GetFileParams struct {
+	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
+	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
+
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
+}
+
 // UploadBeginParams defines parameters for UploadBegin.
 type UploadBeginParams struct {
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
 	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
@@ -674,8 +692,8 @@ type UploadBeginParams struct {
 
 // UploadCompleteParams defines parameters for UploadComplete.
 type UploadCompleteParams struct {
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
 	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
@@ -686,8 +704,8 @@ type UploadChunkParams struct {
 	// XChunkSHA2 the SHA256 hash of the body contents for this request
 	XChunkSHA2 string `json:"X-Chunk-SHA2"`
 
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
 	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
@@ -695,8 +713,8 @@ type UploadChunkParams struct {
 
 // StatusParams defines parameters for Status.
 type StatusParams struct {
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
 	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
@@ -1036,7 +1054,7 @@ func (t *UpgradeDetails_Metadata) UnmarshalJSON(b []byte) error {
 type ServerInterface interface {
 	// retrieve a PGP key from the fleet-server's local storage.
 	// (GET /api/agents/upgrades/{major}.{minor}.{patch}/pgp-public-key)
-	GetPGPKey(w http.ResponseWriter, r *http.Request, major int, minor int, patch int)
+	GetPGPKey(w http.ResponseWriter, r *http.Request, major int, minor int, patch int, params GetPGPKeyParams)
 
 	// (POST /api/fleet/agents/enroll)
 	AgentEnroll(w http.ResponseWriter, r *http.Request, params AgentEnrollParams)
@@ -1051,7 +1069,7 @@ type ServerInterface interface {
 	Artifact(w http.ResponseWriter, r *http.Request, id string, sha2 string, params ArtifactParams)
 	// retrieve stored file for integration
 	// (GET /api/fleet/file/{id})
-	GetFile(w http.ResponseWriter, r *http.Request, id string)
+	GetFile(w http.ResponseWriter, r *http.Request, id string, params GetFileParams)
 	// Initiate a file upload process
 	// (POST /api/fleet/uploads)
 	UploadBegin(w http.ResponseWriter, r *http.Request, params UploadBeginParams)
@@ -1072,7 +1090,7 @@ type Unimplemented struct{}
 
 // retrieve a PGP key from the fleet-server's local storage.
 // (GET /api/agents/upgrades/{major}.{minor}.{patch}/pgp-public-key)
-func (_ Unimplemented) GetPGPKey(w http.ResponseWriter, r *http.Request, major int, minor int, patch int) {
+func (_ Unimplemented) GetPGPKey(w http.ResponseWriter, r *http.Request, major int, minor int, patch int, params GetPGPKeyParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1098,7 +1116,7 @@ func (_ Unimplemented) Artifact(w http.ResponseWriter, r *http.Request, id strin
 
 // retrieve stored file for integration
 // (GET /api/fleet/file/{id})
-func (_ Unimplemented) GetFile(w http.ResponseWriter, r *http.Request, id string) {
+func (_ Unimplemented) GetFile(w http.ResponseWriter, r *http.Request, id string, params GetFileParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1169,8 +1187,51 @@ func (siw *ServerInterfaceWrapper) GetPGPKey(w http.ResponseWriter, r *http.Requ
 
 	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetPGPKeyParams
+
+	headers := r.Header
+
+	// ------------- Optional header parameter "elastic-api-version" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("elastic-api-version")]; found {
+		var ElasticApiVersion ApiVersion
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "elastic-api-version", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithLocation("simple", false, "elastic-api-version", runtime.ParamLocationHeader, valueList[0], &ElasticApiVersion)
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "elastic-api-version", Err: err})
+			return
+		}
+
+		params.ElasticApiVersion = &ElasticApiVersion
+
+	}
+
+	// ------------- Optional header parameter "X-Request-Id" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Request-Id")]; found {
+		var XRequestId RequestId
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Request-Id", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, valueList[0], &XRequestId)
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Request-Id", Err: err})
+			return
+		}
+
+		params.XRequestId = &XRequestId
+
+	}
+
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetPGPKey(w, r, major, minor, patch)
+		siw.Handler.GetPGPKey(w, r, major, minor, patch, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1216,22 +1277,22 @@ func (siw *ServerInterfaceWrapper) AgentEnroll(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// ------------- Optional header parameter "X-Request-ID" -------------
-	if valueList, found := headers[http.CanonicalHeaderKey("X-Request-ID")]; found {
-		var XRequestID RequestId
+	// ------------- Optional header parameter "X-Request-Id" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Request-Id")]; found {
+		var XRequestId RequestId
 		n := len(valueList)
 		if n != 1 {
-			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Request-ID", Count: n})
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Request-Id", Count: n})
 			return
 		}
 
-		err = runtime.BindStyledParameterWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, valueList[0], &XRequestID)
+		err = runtime.BindStyledParameterWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, valueList[0], &XRequestId)
 		if err != nil {
-			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Request-ID", Err: err})
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Request-Id", Err: err})
 			return
 		}
 
-		params.XRequestID = &XRequestID
+		params.XRequestId = &XRequestId
 
 	}
 
@@ -1287,22 +1348,22 @@ func (siw *ServerInterfaceWrapper) AgentAcks(w http.ResponseWriter, r *http.Requ
 
 	headers := r.Header
 
-	// ------------- Optional header parameter "X-Request-ID" -------------
-	if valueList, found := headers[http.CanonicalHeaderKey("X-Request-ID")]; found {
-		var XRequestID RequestId
+	// ------------- Optional header parameter "X-Request-Id" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Request-Id")]; found {
+		var XRequestId RequestId
 		n := len(valueList)
 		if n != 1 {
-			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Request-ID", Count: n})
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Request-Id", Count: n})
 			return
 		}
 
-		err = runtime.BindStyledParameterWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, valueList[0], &XRequestID)
+		err = runtime.BindStyledParameterWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, valueList[0], &XRequestId)
 		if err != nil {
-			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Request-ID", Err: err})
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Request-Id", Err: err})
 			return
 		}
 
-		params.XRequestID = &XRequestID
+		params.XRequestId = &XRequestId
 
 	}
 
@@ -1400,22 +1461,22 @@ func (siw *ServerInterfaceWrapper) AgentCheckin(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	// ------------- Optional header parameter "X-Request-ID" -------------
-	if valueList, found := headers[http.CanonicalHeaderKey("X-Request-ID")]; found {
-		var XRequestID RequestId
+	// ------------- Optional header parameter "X-Request-Id" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Request-Id")]; found {
+		var XRequestId RequestId
 		n := len(valueList)
 		if n != 1 {
-			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Request-ID", Count: n})
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Request-Id", Count: n})
 			return
 		}
 
-		err = runtime.BindStyledParameterWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, valueList[0], &XRequestID)
+		err = runtime.BindStyledParameterWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, valueList[0], &XRequestId)
 		if err != nil {
-			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Request-ID", Err: err})
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Request-Id", Err: err})
 			return
 		}
 
-		params.XRequestID = &XRequestID
+		params.XRequestId = &XRequestId
 
 	}
 
@@ -1480,22 +1541,22 @@ func (siw *ServerInterfaceWrapper) Artifact(w http.ResponseWriter, r *http.Reque
 
 	headers := r.Header
 
-	// ------------- Optional header parameter "X-Request-ID" -------------
-	if valueList, found := headers[http.CanonicalHeaderKey("X-Request-ID")]; found {
-		var XRequestID RequestId
+	// ------------- Optional header parameter "X-Request-Id" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Request-Id")]; found {
+		var XRequestId RequestId
 		n := len(valueList)
 		if n != 1 {
-			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Request-ID", Count: n})
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Request-Id", Count: n})
 			return
 		}
 
-		err = runtime.BindStyledParameterWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, valueList[0], &XRequestID)
+		err = runtime.BindStyledParameterWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, valueList[0], &XRequestId)
 		if err != nil {
-			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Request-ID", Err: err})
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Request-Id", Err: err})
 			return
 		}
 
-		params.XRequestID = &XRequestID
+		params.XRequestId = &XRequestId
 
 	}
 
@@ -1546,8 +1607,51 @@ func (siw *ServerInterfaceWrapper) GetFile(w http.ResponseWriter, r *http.Reques
 
 	ctx = context.WithValue(ctx, AgentApiKeyScopes, []string{})
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetFileParams
+
+	headers := r.Header
+
+	// ------------- Optional header parameter "elastic-api-version" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("elastic-api-version")]; found {
+		var ElasticApiVersion ApiVersion
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "elastic-api-version", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithLocation("simple", false, "elastic-api-version", runtime.ParamLocationHeader, valueList[0], &ElasticApiVersion)
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "elastic-api-version", Err: err})
+			return
+		}
+
+		params.ElasticApiVersion = &ElasticApiVersion
+
+	}
+
+	// ------------- Optional header parameter "X-Request-Id" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Request-Id")]; found {
+		var XRequestId RequestId
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Request-Id", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, valueList[0], &XRequestId)
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Request-Id", Err: err})
+			return
+		}
+
+		params.XRequestId = &XRequestId
+
+	}
+
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetFile(w, r, id)
+		siw.Handler.GetFile(w, r, id, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1570,22 +1674,22 @@ func (siw *ServerInterfaceWrapper) UploadBegin(w http.ResponseWriter, r *http.Re
 
 	headers := r.Header
 
-	// ------------- Optional header parameter "X-Request-ID" -------------
-	if valueList, found := headers[http.CanonicalHeaderKey("X-Request-ID")]; found {
-		var XRequestID RequestId
+	// ------------- Optional header parameter "X-Request-Id" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Request-Id")]; found {
+		var XRequestId RequestId
 		n := len(valueList)
 		if n != 1 {
-			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Request-ID", Count: n})
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Request-Id", Count: n})
 			return
 		}
 
-		err = runtime.BindStyledParameterWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, valueList[0], &XRequestID)
+		err = runtime.BindStyledParameterWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, valueList[0], &XRequestId)
 		if err != nil {
-			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Request-ID", Err: err})
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Request-Id", Err: err})
 			return
 		}
 
-		params.XRequestID = &XRequestID
+		params.XRequestId = &XRequestId
 
 	}
 
@@ -1641,22 +1745,22 @@ func (siw *ServerInterfaceWrapper) UploadComplete(w http.ResponseWriter, r *http
 
 	headers := r.Header
 
-	// ------------- Optional header parameter "X-Request-ID" -------------
-	if valueList, found := headers[http.CanonicalHeaderKey("X-Request-ID")]; found {
-		var XRequestID RequestId
+	// ------------- Optional header parameter "X-Request-Id" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Request-Id")]; found {
+		var XRequestId RequestId
 		n := len(valueList)
 		if n != 1 {
-			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Request-ID", Count: n})
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Request-Id", Count: n})
 			return
 		}
 
-		err = runtime.BindStyledParameterWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, valueList[0], &XRequestID)
+		err = runtime.BindStyledParameterWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, valueList[0], &XRequestId)
 		if err != nil {
-			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Request-ID", Err: err})
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Request-Id", Err: err})
 			return
 		}
 
-		params.XRequestID = &XRequestID
+		params.XRequestId = &XRequestId
 
 	}
 
@@ -1744,22 +1848,22 @@ func (siw *ServerInterfaceWrapper) UploadChunk(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// ------------- Optional header parameter "X-Request-ID" -------------
-	if valueList, found := headers[http.CanonicalHeaderKey("X-Request-ID")]; found {
-		var XRequestID RequestId
+	// ------------- Optional header parameter "X-Request-Id" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Request-Id")]; found {
+		var XRequestId RequestId
 		n := len(valueList)
 		if n != 1 {
-			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Request-ID", Count: n})
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Request-Id", Count: n})
 			return
 		}
 
-		err = runtime.BindStyledParameterWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, valueList[0], &XRequestID)
+		err = runtime.BindStyledParameterWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, valueList[0], &XRequestId)
 		if err != nil {
-			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Request-ID", Err: err})
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Request-Id", Err: err})
 			return
 		}
 
-		params.XRequestID = &XRequestID
+		params.XRequestId = &XRequestId
 
 	}
 
@@ -1806,22 +1910,22 @@ func (siw *ServerInterfaceWrapper) Status(w http.ResponseWriter, r *http.Request
 
 	headers := r.Header
 
-	// ------------- Optional header parameter "X-Request-ID" -------------
-	if valueList, found := headers[http.CanonicalHeaderKey("X-Request-ID")]; found {
-		var XRequestID RequestId
+	// ------------- Optional header parameter "X-Request-Id" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Request-Id")]; found {
+		var XRequestId RequestId
 		n := len(valueList)
 		if n != 1 {
-			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Request-ID", Count: n})
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Request-Id", Count: n})
 			return
 		}
 
-		err = runtime.BindStyledParameterWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, valueList[0], &XRequestID)
+		err = runtime.BindStyledParameterWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, valueList[0], &XRequestId)
 		if err != nil {
-			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Request-ID", Err: err})
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Request-Id", Err: err})
 			return
 		}
 
-		params.XRequestID = &XRequestID
+		params.XRequestId = &XRequestId
 
 	}
 

--- a/pkg/api/client.gen.go
+++ b/pkg/api/client.gen.go
@@ -94,7 +94,7 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 // The interface specification for the client above.
 type ClientInterface interface {
 	// GetPGPKey request
-	GetPGPKey(ctx context.Context, major int, minor int, patch int, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetPGPKey(ctx context.Context, major int, minor int, patch int, params *GetPGPKeyParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// AgentEnrollWithBody request with any body
 	AgentEnrollWithBody(ctx context.Context, params *AgentEnrollParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -115,7 +115,7 @@ type ClientInterface interface {
 	Artifact(ctx context.Context, id string, sha2 string, params *ArtifactParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetFile request
-	GetFile(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetFile(ctx context.Context, id string, params *GetFileParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UploadBeginWithBody request with any body
 	UploadBeginWithBody(ctx context.Context, params *UploadBeginParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -134,8 +134,8 @@ type ClientInterface interface {
 	Status(ctx context.Context, params *StatusParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
-func (c *Client) GetPGPKey(ctx context.Context, major int, minor int, patch int, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetPGPKeyRequest(c.Server, major, minor, patch)
+func (c *Client) GetPGPKey(ctx context.Context, major int, minor int, patch int, params *GetPGPKeyParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPGPKeyRequest(c.Server, major, minor, patch, params)
 	if err != nil {
 		return nil, err
 	}
@@ -230,8 +230,8 @@ func (c *Client) Artifact(ctx context.Context, id string, sha2 string, params *A
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetFile(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetFileRequest(c.Server, id)
+func (c *Client) GetFile(ctx context.Context, id string, params *GetFileParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetFileRequest(c.Server, id, params)
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +315,7 @@ func (c *Client) Status(ctx context.Context, params *StatusParams, reqEditors ..
 }
 
 // NewGetPGPKeyRequest generates requests for GetPGPKey
-func NewGetPGPKeyRequest(server string, major int, minor int, patch int) (*http.Request, error) {
+func NewGetPGPKeyRequest(server string, major int, minor int, patch int, params *GetPGPKeyParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -357,6 +357,32 @@ func NewGetPGPKeyRequest(server string, major int, minor int, patch int) (*http.
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+
+		if params.ElasticApiVersion != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "elastic-api-version", runtime.ParamLocationHeader, *params.ElasticApiVersion)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("elastic-api-version", headerParam0)
+		}
+
+		if params.XRequestId != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, *params.XRequestId)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Request-Id", headerParam1)
+		}
+
 	}
 
 	return req, nil
@@ -410,15 +436,15 @@ func NewAgentEnrollRequestWithBody(server string, params *AgentEnrollParams, con
 
 		req.Header.Set("User-Agent", headerParam0)
 
-		if params.XRequestID != nil {
+		if params.XRequestId != nil {
 			var headerParam1 string
 
-			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, *params.XRequestID)
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, *params.XRequestId)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("X-Request-ID", headerParam1)
+			req.Header.Set("X-Request-Id", headerParam1)
 		}
 
 		if params.ElasticApiVersion != nil {
@@ -483,15 +509,15 @@ func NewAgentAcksRequestWithBody(server string, id string, params *AgentAcksPara
 
 	if params != nil {
 
-		if params.XRequestID != nil {
+		if params.XRequestId != nil {
 			var headerParam0 string
 
-			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, *params.XRequestID)
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, *params.XRequestId)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("X-Request-ID", headerParam0)
+			req.Header.Set("X-Request-Id", headerParam0)
 		}
 
 		if params.ElasticApiVersion != nil {
@@ -576,15 +602,15 @@ func NewAgentCheckinRequestWithBody(server string, id string, params *AgentCheck
 
 		req.Header.Set("User-Agent", headerParam1)
 
-		if params.XRequestID != nil {
+		if params.XRequestId != nil {
 			var headerParam2 string
 
-			headerParam2, err = runtime.StyleParamWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, *params.XRequestID)
+			headerParam2, err = runtime.StyleParamWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, *params.XRequestId)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("X-Request-ID", headerParam2)
+			req.Header.Set("X-Request-Id", headerParam2)
 		}
 
 		if params.ElasticApiVersion != nil {
@@ -643,15 +669,15 @@ func NewArtifactRequest(server string, id string, sha2 string, params *ArtifactP
 
 	if params != nil {
 
-		if params.XRequestID != nil {
+		if params.XRequestId != nil {
 			var headerParam0 string
 
-			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, *params.XRequestID)
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, *params.XRequestId)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("X-Request-ID", headerParam0)
+			req.Header.Set("X-Request-Id", headerParam0)
 		}
 
 		if params.ElasticApiVersion != nil {
@@ -671,7 +697,7 @@ func NewArtifactRequest(server string, id string, sha2 string, params *ArtifactP
 }
 
 // NewGetFileRequest generates requests for GetFile
-func NewGetFileRequest(server string, id string) (*http.Request, error) {
+func NewGetFileRequest(server string, id string, params *GetFileParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -699,6 +725,32 @@ func NewGetFileRequest(server string, id string) (*http.Request, error) {
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+
+		if params.ElasticApiVersion != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "elastic-api-version", runtime.ParamLocationHeader, *params.ElasticApiVersion)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("elastic-api-version", headerParam0)
+		}
+
+		if params.XRequestId != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, *params.XRequestId)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Request-Id", headerParam1)
+		}
+
 	}
 
 	return req, nil
@@ -743,15 +795,15 @@ func NewUploadBeginRequestWithBody(server string, params *UploadBeginParams, con
 
 	if params != nil {
 
-		if params.XRequestID != nil {
+		if params.XRequestId != nil {
 			var headerParam0 string
 
-			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, *params.XRequestID)
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, *params.XRequestId)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("X-Request-ID", headerParam0)
+			req.Header.Set("X-Request-Id", headerParam0)
 		}
 
 		if params.ElasticApiVersion != nil {
@@ -816,15 +868,15 @@ func NewUploadCompleteRequestWithBody(server string, id string, params *UploadCo
 
 	if params != nil {
 
-		if params.XRequestID != nil {
+		if params.XRequestId != nil {
 			var headerParam0 string
 
-			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, *params.XRequestID)
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, *params.XRequestId)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("X-Request-ID", headerParam0)
+			req.Header.Set("X-Request-Id", headerParam0)
 		}
 
 		if params.ElasticApiVersion != nil {
@@ -894,15 +946,15 @@ func NewUploadChunkRequestWithBody(server string, id string, chunkNum int, param
 
 		req.Header.Set("X-Chunk-SHA2", headerParam0)
 
-		if params.XRequestID != nil {
+		if params.XRequestId != nil {
 			var headerParam1 string
 
-			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, *params.XRequestID)
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, *params.XRequestId)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("X-Request-ID", headerParam1)
+			req.Header.Set("X-Request-Id", headerParam1)
 		}
 
 		if params.ElasticApiVersion != nil {
@@ -947,15 +999,15 @@ func NewStatusRequest(server string, params *StatusParams) (*http.Request, error
 
 	if params != nil {
 
-		if params.XRequestID != nil {
+		if params.XRequestId != nil {
 			var headerParam0 string
 
-			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, *params.XRequestID)
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, *params.XRequestId)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("X-Request-ID", headerParam0)
+			req.Header.Set("X-Request-Id", headerParam0)
 		}
 
 		if params.ElasticApiVersion != nil {
@@ -1018,7 +1070,7 @@ func WithBaseURL(baseURL string) ClientOption {
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
 	// GetPGPKeyWithResponse request
-	GetPGPKeyWithResponse(ctx context.Context, major int, minor int, patch int, reqEditors ...RequestEditorFn) (*GetPGPKeyResponse, error)
+	GetPGPKeyWithResponse(ctx context.Context, major int, minor int, patch int, params *GetPGPKeyParams, reqEditors ...RequestEditorFn) (*GetPGPKeyResponse, error)
 
 	// AgentEnrollWithBodyWithResponse request with any body
 	AgentEnrollWithBodyWithResponse(ctx context.Context, params *AgentEnrollParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AgentEnrollResponse, error)
@@ -1039,7 +1091,7 @@ type ClientWithResponsesInterface interface {
 	ArtifactWithResponse(ctx context.Context, id string, sha2 string, params *ArtifactParams, reqEditors ...RequestEditorFn) (*ArtifactResponse, error)
 
 	// GetFileWithResponse request
-	GetFileWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetFileResponse, error)
+	GetFileWithResponse(ctx context.Context, id string, params *GetFileParams, reqEditors ...RequestEditorFn) (*GetFileResponse, error)
 
 	// UploadBeginWithBodyWithResponse request with any body
 	UploadBeginWithBodyWithResponse(ctx context.Context, params *UploadBeginParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UploadBeginResponse, error)
@@ -1325,8 +1377,8 @@ func (r StatusResponse) StatusCode() int {
 }
 
 // GetPGPKeyWithResponse request returning *GetPGPKeyResponse
-func (c *ClientWithResponses) GetPGPKeyWithResponse(ctx context.Context, major int, minor int, patch int, reqEditors ...RequestEditorFn) (*GetPGPKeyResponse, error) {
-	rsp, err := c.GetPGPKey(ctx, major, minor, patch, reqEditors...)
+func (c *ClientWithResponses) GetPGPKeyWithResponse(ctx context.Context, major int, minor int, patch int, params *GetPGPKeyParams, reqEditors ...RequestEditorFn) (*GetPGPKeyResponse, error) {
+	rsp, err := c.GetPGPKey(ctx, major, minor, patch, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -1394,8 +1446,8 @@ func (c *ClientWithResponses) ArtifactWithResponse(ctx context.Context, id strin
 }
 
 // GetFileWithResponse request returning *GetFileResponse
-func (c *ClientWithResponses) GetFileWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetFileResponse, error) {
-	rsp, err := c.GetFile(ctx, id, reqEditors...)
+func (c *ClientWithResponses) GetFileWithResponse(ctx context.Context, id string, params *GetFileParams, reqEditors ...RequestEditorFn) (*GetFileResponse, error) {
+	rsp, err := c.GetFile(ctx, id, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/doc.go
+++ b/pkg/api/doc.go
@@ -1,0 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// Package api contains the client implementation for the master branch of fleet-server.
+// Code is generated from ../model/openapi.yml
+package api

--- a/pkg/api/types.gen.go
+++ b/pkg/api/types.gen.go
@@ -609,6 +609,15 @@ type Throttle = Error
 // Unavailable Error processing request.
 type Unavailable = Error
 
+// GetPGPKeyParams defines parameters for GetPGPKey.
+type GetPGPKeyParams struct {
+	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
+	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
+
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
+}
+
 // AgentEnrollParams defines parameters for AgentEnroll.
 type AgentEnrollParams struct {
 	// UserAgent The user-agent header that is sent.
@@ -616,8 +625,8 @@ type AgentEnrollParams struct {
 	// The agent version must not be greater than the version of the fleet-server.
 	UserAgent UserAgent `json:"User-Agent"`
 
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
 	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
@@ -625,8 +634,8 @@ type AgentEnrollParams struct {
 
 // AgentAcksParams defines parameters for AgentAcks.
 type AgentAcksParams struct {
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
 	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
@@ -644,8 +653,8 @@ type AgentCheckinParams struct {
 	// The agent version must not be greater than the version of the fleet-server.
 	UserAgent UserAgent `json:"User-Agent"`
 
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
 	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
@@ -653,17 +662,26 @@ type AgentCheckinParams struct {
 
 // ArtifactParams defines parameters for Artifact.
 type ArtifactParams struct {
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
 	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
 }
 
+// GetFileParams defines parameters for GetFile.
+type GetFileParams struct {
+	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
+	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
+
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
+}
+
 // UploadBeginParams defines parameters for UploadBegin.
 type UploadBeginParams struct {
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
 	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
@@ -671,8 +689,8 @@ type UploadBeginParams struct {
 
 // UploadCompleteParams defines parameters for UploadComplete.
 type UploadCompleteParams struct {
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
 	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
@@ -683,8 +701,8 @@ type UploadChunkParams struct {
 	// XChunkSHA2 the SHA256 hash of the body contents for this request
 	XChunkSHA2 string `json:"X-Chunk-SHA2"`
 
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
 	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
@@ -692,8 +710,8 @@ type UploadChunkParams struct {
 
 // StatusParams defines parameters for Status.
 type StatusParams struct {
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
 	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`

--- a/pkg/api/versions/2023_06_01/api/client.gen.go
+++ b/pkg/api/versions/2023_06_01/api/client.gen.go
@@ -112,7 +112,7 @@ type ClientInterface interface {
 	Artifact(ctx context.Context, id string, sha2 string, params *ArtifactParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetFile request
-	GetFile(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetFile(ctx context.Context, id string, params *GetFileParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UploadBeginWithBody request with any body
 	UploadBeginWithBody(ctx context.Context, params *UploadBeginParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -215,8 +215,8 @@ func (c *Client) Artifact(ctx context.Context, id string, sha2 string, params *A
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetFile(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetFileRequest(c.Server, id)
+func (c *Client) GetFile(ctx context.Context, id string, params *GetFileParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetFileRequest(c.Server, id, params)
 	if err != nil {
 		return nil, err
 	}
@@ -347,26 +347,26 @@ func NewAgentEnrollRequestWithBody(server string, params *AgentEnrollParams, con
 
 		req.Header.Set("User-Agent", headerParam0)
 
-		if params.XRequestID != nil {
+		if params.XRequestId != nil {
 			var headerParam1 string
 
-			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, *params.XRequestID)
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, *params.XRequestId)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("X-Request-ID", headerParam1)
+			req.Header.Set("X-Request-Id", headerParam1)
 		}
 
 		if params.ElasticApiVersion != nil {
 			var headerParam2 string
 
-			headerParam2, err = runtime.StyleParamWithLocation("simple", false, "elastic-api-version", runtime.ParamLocationHeader, *params.ElasticApiVersion)
+			headerParam2, err = runtime.StyleParamWithLocation("simple", false, "Elastic-Api-Version", runtime.ParamLocationHeader, *params.ElasticApiVersion)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("elastic-api-version", headerParam2)
+			req.Header.Set("Elastic-Api-Version", headerParam2)
 		}
 
 	}
@@ -420,26 +420,26 @@ func NewAgentAcksRequestWithBody(server string, id string, params *AgentAcksPara
 
 	if params != nil {
 
-		if params.XRequestID != nil {
+		if params.XRequestId != nil {
 			var headerParam0 string
 
-			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, *params.XRequestID)
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, *params.XRequestId)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("X-Request-ID", headerParam0)
+			req.Header.Set("X-Request-Id", headerParam0)
 		}
 
 		if params.ElasticApiVersion != nil {
 			var headerParam1 string
 
-			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "elastic-api-version", runtime.ParamLocationHeader, *params.ElasticApiVersion)
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "Elastic-Api-Version", runtime.ParamLocationHeader, *params.ElasticApiVersion)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("elastic-api-version", headerParam1)
+			req.Header.Set("Elastic-Api-Version", headerParam1)
 		}
 
 	}
@@ -513,26 +513,26 @@ func NewAgentCheckinRequestWithBody(server string, id string, params *AgentCheck
 
 		req.Header.Set("User-Agent", headerParam1)
 
-		if params.XRequestID != nil {
+		if params.XRequestId != nil {
 			var headerParam2 string
 
-			headerParam2, err = runtime.StyleParamWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, *params.XRequestID)
+			headerParam2, err = runtime.StyleParamWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, *params.XRequestId)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("X-Request-ID", headerParam2)
+			req.Header.Set("X-Request-Id", headerParam2)
 		}
 
 		if params.ElasticApiVersion != nil {
 			var headerParam3 string
 
-			headerParam3, err = runtime.StyleParamWithLocation("simple", false, "elastic-api-version", runtime.ParamLocationHeader, *params.ElasticApiVersion)
+			headerParam3, err = runtime.StyleParamWithLocation("simple", false, "Elastic-Api-Version", runtime.ParamLocationHeader, *params.ElasticApiVersion)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("elastic-api-version", headerParam3)
+			req.Header.Set("Elastic-Api-Version", headerParam3)
 		}
 
 	}
@@ -580,26 +580,26 @@ func NewArtifactRequest(server string, id string, sha2 string, params *ArtifactP
 
 	if params != nil {
 
-		if params.XRequestID != nil {
+		if params.XRequestId != nil {
 			var headerParam0 string
 
-			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, *params.XRequestID)
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, *params.XRequestId)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("X-Request-ID", headerParam0)
+			req.Header.Set("X-Request-Id", headerParam0)
 		}
 
 		if params.ElasticApiVersion != nil {
 			var headerParam1 string
 
-			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "elastic-api-version", runtime.ParamLocationHeader, *params.ElasticApiVersion)
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "Elastic-Api-Version", runtime.ParamLocationHeader, *params.ElasticApiVersion)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("elastic-api-version", headerParam1)
+			req.Header.Set("Elastic-Api-Version", headerParam1)
 		}
 
 	}
@@ -608,7 +608,7 @@ func NewArtifactRequest(server string, id string, sha2 string, params *ArtifactP
 }
 
 // NewGetFileRequest generates requests for GetFile
-func NewGetFileRequest(server string, id string) (*http.Request, error) {
+func NewGetFileRequest(server string, id string, params *GetFileParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -636,6 +636,32 @@ func NewGetFileRequest(server string, id string) (*http.Request, error) {
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+
+		if params.XRequestId != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, *params.XRequestId)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Request-Id", headerParam0)
+		}
+
+		if params.ElasticApiVersion != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "Elastic-Api-Version", runtime.ParamLocationHeader, *params.ElasticApiVersion)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("Elastic-Api-Version", headerParam1)
+		}
+
 	}
 
 	return req, nil
@@ -680,26 +706,26 @@ func NewUploadBeginRequestWithBody(server string, params *UploadBeginParams, con
 
 	if params != nil {
 
-		if params.XRequestID != nil {
+		if params.XRequestId != nil {
 			var headerParam0 string
 
-			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, *params.XRequestID)
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, *params.XRequestId)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("X-Request-ID", headerParam0)
+			req.Header.Set("X-Request-Id", headerParam0)
 		}
 
 		if params.ElasticApiVersion != nil {
 			var headerParam1 string
 
-			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "elastic-api-version", runtime.ParamLocationHeader, *params.ElasticApiVersion)
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "Elastic-Api-Version", runtime.ParamLocationHeader, *params.ElasticApiVersion)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("elastic-api-version", headerParam1)
+			req.Header.Set("Elastic-Api-Version", headerParam1)
 		}
 
 	}
@@ -753,26 +779,26 @@ func NewUploadCompleteRequestWithBody(server string, id string, params *UploadCo
 
 	if params != nil {
 
-		if params.XRequestID != nil {
+		if params.XRequestId != nil {
 			var headerParam0 string
 
-			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, *params.XRequestID)
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, *params.XRequestId)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("X-Request-ID", headerParam0)
+			req.Header.Set("X-Request-Id", headerParam0)
 		}
 
 		if params.ElasticApiVersion != nil {
 			var headerParam1 string
 
-			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "elastic-api-version", runtime.ParamLocationHeader, *params.ElasticApiVersion)
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "Elastic-Api-Version", runtime.ParamLocationHeader, *params.ElasticApiVersion)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("elastic-api-version", headerParam1)
+			req.Header.Set("Elastic-Api-Version", headerParam1)
 		}
 
 	}
@@ -831,26 +857,26 @@ func NewUploadChunkRequestWithBody(server string, id string, chunkNum int, param
 
 		req.Header.Set("X-Chunk-SHA2", headerParam0)
 
-		if params.XRequestID != nil {
+		if params.XRequestId != nil {
 			var headerParam1 string
 
-			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, *params.XRequestID)
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, *params.XRequestId)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("X-Request-ID", headerParam1)
+			req.Header.Set("X-Request-Id", headerParam1)
 		}
 
 		if params.ElasticApiVersion != nil {
 			var headerParam2 string
 
-			headerParam2, err = runtime.StyleParamWithLocation("simple", false, "elastic-api-version", runtime.ParamLocationHeader, *params.ElasticApiVersion)
+			headerParam2, err = runtime.StyleParamWithLocation("simple", false, "Elastic-Api-Version", runtime.ParamLocationHeader, *params.ElasticApiVersion)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("elastic-api-version", headerParam2)
+			req.Header.Set("Elastic-Api-Version", headerParam2)
 		}
 
 	}
@@ -884,26 +910,26 @@ func NewStatusRequest(server string, params *StatusParams) (*http.Request, error
 
 	if params != nil {
 
-		if params.XRequestID != nil {
+		if params.XRequestId != nil {
 			var headerParam0 string
 
-			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-ID", runtime.ParamLocationHeader, *params.XRequestID)
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Request-Id", runtime.ParamLocationHeader, *params.XRequestId)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("X-Request-ID", headerParam0)
+			req.Header.Set("X-Request-Id", headerParam0)
 		}
 
 		if params.ElasticApiVersion != nil {
 			var headerParam1 string
 
-			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "elastic-api-version", runtime.ParamLocationHeader, *params.ElasticApiVersion)
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "Elastic-Api-Version", runtime.ParamLocationHeader, *params.ElasticApiVersion)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("elastic-api-version", headerParam1)
+			req.Header.Set("Elastic-Api-Version", headerParam1)
 		}
 
 	}
@@ -973,7 +999,7 @@ type ClientWithResponsesInterface interface {
 	ArtifactWithResponse(ctx context.Context, id string, sha2 string, params *ArtifactParams, reqEditors ...RequestEditorFn) (*ArtifactResponse, error)
 
 	// GetFileWithResponse request
-	GetFileWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetFileResponse, error)
+	GetFileWithResponse(ctx context.Context, id string, params *GetFileParams, reqEditors ...RequestEditorFn) (*GetFileResponse, error)
 
 	// UploadBeginWithBodyWithResponse request with any body
 	UploadBeginWithBodyWithResponse(ctx context.Context, params *UploadBeginParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UploadBeginResponse, error)
@@ -1296,8 +1322,8 @@ func (c *ClientWithResponses) ArtifactWithResponse(ctx context.Context, id strin
 }
 
 // GetFileWithResponse request returning *GetFileResponse
-func (c *ClientWithResponses) GetFileWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetFileResponse, error) {
-	rsp, err := c.GetFile(ctx, id, reqEditors...)
+func (c *ClientWithResponses) GetFileWithResponse(ctx context.Context, id string, params *GetFileParams, reqEditors ...RequestEditorFn) (*GetFileResponse, error) {
+	rsp, err := c.GetFile(ctx, id, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/versions/2023_06_01/api/doc.go
+++ b/pkg/api/versions/2023_06_01/api/doc.go
@@ -1,0 +1,10 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:generate oapi-codegen -generate types -package api -o types.gen.go  openapi.yml
+//go:generate oapi-codegen -generate client -package api -o client.gen.go  openapi.yml
+
+// Package api contains the 2023-06-01 client of the fleet-server API.
+// Client code is generated from ./openapi.yml
+package api

--- a/pkg/api/versions/2023_06_01/api/openapi.yml
+++ b/pkg/api/versions/2023_06_01/api/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: fleet-server API
-  version: 0000-00-00
+  version: 2023-06-01
   license:
     name: Elastic License 2.0
     url: https://www.elastic.co/licensing/elastic-license
@@ -137,6 +137,7 @@ components:
       type: object
       required:
         - type
+        - shared_id
         - metadata
       properties:
         type:
@@ -147,12 +148,6 @@ components:
           type: string
           enum:
             - PERMANENT
-        enrollment_id:
-          type: string
-          description: |
-            The enrollment ID of the agent.
-            To replace an agent on enroll fail.
-            The existing agent with a matching enrollment_id will be deleted if it never checked in. The new agent will be enrolled with the enrollment_id.
         shared_id:
           deprecated: true
           type: string
@@ -264,79 +259,6 @@ components:
           type: string
         item:
           $ref: "#/components/schemas/enrollResponseItem"
-    upgrade_metadata_scheduled:
-      description: Upgrade metadata for an upgrade that has been scheduled.
-      type: object
-      required:
-        - scheduled_at
-      properties:
-        scheduled_at:
-          description: The RFC3339 timestamp the upgrade is scheduled to start at.
-          type: string
-          format: date-time
-    upgrade_metadata_downloading:
-      description: Upgrade metadata for an upgrade that is downloading.
-      required:
-        - download_percent
-      properties:
-        download_percent:
-          description: The artifact download progress as a percentage.
-          type: number
-          format: double
-    upgrade_metadata_failed:
-      description: Upgrade metadata for an upgrade that has failed.
-      required:
-        - failed_state
-        - error_msg
-      properties:
-        failed_state:
-          description: The state where the upgrade failed.
-          type: string
-          enum:
-            - UPG_REQUESTED
-            - UPG_SCHEDULED
-            - UPG_DOWNLOADING
-            - UPG_EXTRACTING
-            - UPG_REPLACING
-            - UPG_RESTARTING
-            - UPG_WATCHING
-        error_msg:
-          description: The error message associated with a failed state.
-          type: string
-    upgrade_details:
-      description: |
-        Additional details describing the status of an UPGRADE action delivered by the client (agent) on checkin.
-      type: object
-      required:
-        - target_version
-        - action_id
-        - state
-      properties:
-        target_version:
-          description: The version the agent should upgrade to.
-          type: string
-        action_id:
-          description: The upgrade action ID the details are associated with.
-          type: string
-        state:
-          description: The upgrade state.
-          type: string
-          enum:
-            - UPG_REQUESTED
-            - UPG_SCHEDULED
-            - UPG_DOWNLOADING
-            - UPG_EXTRACTING
-            - UPG_REPLACING
-            - UPG_RESTARTING
-            - UPG_WATCHING
-            - UPG_ROLLBACK
-            - UPG_FAILED
-        metadata:
-          description: Upgrade status metadata. Determined by state.
-          oneOf:
-            - $ref: "#/components/schemas/upgrade_metadata_scheduled"
-            - $ref: "#/components/schemas/upgrade_metadata_downloading"
-            - $ref: "#/components/schemas/upgrade_metadata_failed"
     checkinRequest:
       type: object
       required:
@@ -384,8 +306,6 @@ components:
             If specified fleet-server will set its poll timeout to `max(1m, poll_timeout-2m)` and its write timeout to `max(2m, poll_timout-1m)`.
           type: string
           format: duration
-        upgrade_details:
-          $ref: "#/components/schemas/upgrade_details"
     actionSignature:
       description: Optional action signing data.
       type: object
@@ -666,11 +586,13 @@ components:
         errors:
           description: A flag to indicate if one or more errors occured when proccessing events.
           type: boolean
+          nullable: false
           x-oapi-codegen-extra-tags:
             json: "errors,omitempty"
         items:
           description: The in-order list of results from processing events.
           type: array
+          nullable: false
           items:
             $ref: "#/components/schemas/ackResponseItem"
           x-oapi-codegen-extra-tags:
@@ -692,8 +614,7 @@ components:
             Compression:
               description: "The algorithm used to compress the file. Valid values: br,gzip,deflate,none"
               type: string
-              examples:
-                - deflate
+              example: deflate
             hash:
               title: Hash
               description: Checksums on the file contents
@@ -702,24 +623,20 @@ components:
                 sha256:
                   description: SHA256 of the contents
                   type: string
-                  examples:
-                    - 04f81394bababa0fb31e6ad2d703c875eb46dc254527e39ff316564c0dc339e2
+                  example: 04f81394bababa0fb31e6ad2d703c875eb46dc254527e39ff316564c0dc339e2
             name:
               description: Name of the file including the extension, without the directory
               type: string
-              examples:
-                - yankees-stats.zip
+              example: yankees-stats.zip
             mime_type:
               description: MIME type of the file
               type: string
-              examples:
-                - application/zip
+              example: application/zip
             size:
               description: Size of the file contents, in bytes
               type: integer
               format: int64
-              examples:
-                - 8276748
+              example: 8276748
           required:
             - name
             - size
@@ -727,13 +644,11 @@ components:
         action_id:
           description: ID of the action that requested this file
           type: string
-          examples:
-            - 2f440d31-2ea4-42f8-b0f2-4b6e98e8dc5e
+          example: 2f440d31-2ea4-42f8-b0f2-4b6e98e8dc5e
         agent_id:
           description: Identifier of the agent uploading. Matches the ID usually found in agent.id
           type: string
-          examples:
-            - 9347e918-5e00-48b0-b302-a09f9258a46d
+          example: 9347e918-5e00-48b0-b302-a09f9258a46d
         src:
           description: The source integration sending this file
           type: string
@@ -751,14 +666,12 @@ components:
         upload_id:
           description: A unique identifier for the ensuing upload operation
           type: string
-          examples:
-            - fbc8e23c-055d-461e-87f7-b0d1b57f14b4
+          example: fbc8e23c-055d-461e-87f7-b0d1b57f14b4
         chunk_size:
           description: The required size (in bytes) that the file must be segmented into for each chunk
           type: integer
           format: int64
-          examples:
-            - 4194304
+          example: 4194304
     uploadCompleteRequest:
       description: Request to verify and finish an uploaded file
       type: object
@@ -774,8 +687,7 @@ components:
             sha256:
               description: SHA256 hash
               type: string
-              examples:
-                - 83810fdc61c44290778c212d7829d0c3f0232e81bd551d3943998a920025d14f
+              example: 83810fdc61c44290778c212d7829d0c3f0232e81bd551d3943998a920025d14f
   parameters:
     requestId:
       name: X-Request-Id
@@ -784,7 +696,7 @@ components:
       schema:
         type: string
     apiVersion:
-      name: elastic-api-version
+      name: Elastic-Api-Version
       description: The API version to use, format should be "YYYY-MM-DD"
       in: header
       schema:
@@ -829,8 +741,7 @@ components:
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: "#/components/schemas/error"
+            $ref: "#/components/schemas/error"
           examples:
             badRequest:
               description: Generic bad request response.
@@ -848,8 +759,7 @@ components:
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: "#/components/schemas/error"
+            $ref: "#/components/schemas/error"
           examples:
             internalServerError:
               description: Generic internal server error response.
@@ -866,8 +776,7 @@ components:
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: "#/components/schemas/error"
+            $ref: "#/components/schemas/error"
           examples:
             unauthorized:
               description: The ApiKey is not enabled
@@ -885,8 +794,7 @@ components:
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: "#/components/schemas/error"
+            $ref: "#/components/schemas/error"
           examples:
             agentNotFound:
               description: The agent is not found.
@@ -904,8 +812,7 @@ components:
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: "#/components/schemas/error"
+            $ref: "#/components/schemas/error"
           examples:
             requestTimeout:
               description: Deadline exceeded.
@@ -914,7 +821,7 @@ components:
                 error: RequestTimeout
                 message: timeout on request
     throttle:
-      description: 428 rate limiting request.
+      description: 428 rate limiting request. Only returned by artifacts endpoint.
       headers:
         # throttle is checked before api version header is validated
         X-Request-Id:
@@ -922,8 +829,7 @@ components:
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: "#/components/schemas/error"
+            $ref: "#/components/schemas/error"
           examples:
             rateLimit:
               description: Too many requests - rate limit reached.
@@ -944,8 +850,7 @@ components:
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: "#/components/schemas/error"
+            $ref: "#/components/schemas/error"
           examples:
             unavailable:
               description: Service unavailable
@@ -967,8 +872,6 @@ paths:
       description: |
         Return the fleet-server status.
         The status code will either be 200 if healthy, or 503 if not.
-        Service is considered healthy if it has access to Elasticsearch, but the policies index
-        does not exist. This is equivalent to a deployment without any policy.
         Authentication for this endpoint is optional, if not provided a shorter response body is returned.
       responses:
         "200":
@@ -1149,18 +1052,6 @@ paths:
                   status: online
                   message: ""
                   ack_token: previous-token
-              withCheckinDetails:
-                description: A checking request from an elastic-agent that is downloading a new version.
-                value:
-                  status: online
-                  message: ""
-                  ack_token: previous-token
-                  upgrade_details:
-                    action_id: upgrade-action-id
-                    target_version: X.Y.Z
-                    state: UPG_DOWNLOADING
-                    metadata:
-                      download_percent: 12.3
       responses:
         "200":
           description: Agent checkin successful. May include actions.
@@ -1213,9 +1104,6 @@ paths:
         The endpoint that an agent uses to acknowledge (and inform fleet-server) of events that it has recieved/executed.
         A single action may have multiple different events associated with it.
         Also an action may not have any acks associated with it.
-
-        Note that using this endpoint for an `UPGRADE` action is deprecated behaviour.
-        `UPGRADE` status should use the `upgrade_details` attribute of the checkin request body.
       parameters:
         - name: id
           in: path
@@ -1367,7 +1255,7 @@ paths:
     put:
       operationId: uploadChunk
       summary: Upload a section of file data
-      description: "Upload portions of the intended file in a piecewise fashion. Chunks may be uploaded in any order, and may be uploaded in parallel. The body is the raw contents of the file at the given position matching the chunk number. The body must be the exact chunk size returned from the upload initiation response. All chunks must be this size except for the final one, which is naturally the file remainder."
+      description: "Upload portions of the intended file in a piecewise fashion. This route is idempotent in that any successive calls will overwrite previous ones for the same URL parameters. Chunks may be uploaded in any order, and may be uploaded in parallel. The body is the raw contents of the file at the given position matching the chunk number. The body must be the exact chunk size returned from the upload initiation response. All chunks must be this size except for the final one, which is naturally the file remainder."
       security:
         - agentApiKey: []
       parameters:
@@ -1377,24 +1265,21 @@ paths:
           required: true
           schema:
             type: string
-            examples:
-              - ecb30383-6dd1-4b1d-bed0-2386b4e5df51
+            example: ecb30383-6dd1-4b1d-bed0-2386b4e5df51
         - name: chunkNum
           in: path
           description: the positional index of the chunk within the file. The first chunk is 0, the next 1, etc.
           required: true
           schema:
             type: integer
-            examples:
-              - 3
+            example: 3
         - name: X-Chunk-SHA2
           in: header
           required: true
           description: the SHA256 hash of the body contents for this request
           schema:
             type: string
-            examples:
-              - 0c4a81b85a6b7ff00bde6c32e1e8be33b4b793b3b7b5cb03db93f77f7c9374d1
+            example: 0c4a81b85a6b7ff00bde6c32e1e8be33b4b793b3b7b5cb03db93f77f7c9374d1
         - $ref: "#/components/parameters/requestId"
         - $ref: "#/components/parameters/apiVersion"
       requestBody:
@@ -1443,8 +1328,7 @@ paths:
           required: true
           schema:
             type: string
-            examples:
-              - ecb30383-6dd1-4b1d-bed0-2386b4e5df51
+            example: ecb30383-6dd1-4b1d-bed0-2386b4e5df51
         - $ref: "#/components/parameters/requestId"
         - $ref: "#/components/parameters/apiVersion"
       responses:
@@ -1462,8 +1346,7 @@ paths:
                 properties:
                   status:
                     type: string
-                    examples:
-                      - "ok"
+                    example: "ok"
         "400":
           $ref: "#/components/responses/badRequest"
         "401":
@@ -1488,10 +1371,9 @@ paths:
           required: true
           schema:
             type: string
-            examples:
-              - ecb30383-6dd1-4b1d-bed0-2386b4e5df51
-        - $ref: "#/components/parameters/apiVersion"
+            example: ecb30383-6dd1-4b1d-bed0-2386b4e5df51
         - $ref: "#/components/parameters/requestId"
+        - $ref: "#/components/parameters/apiVersion"
       responses:
         "200":
           description: File Contents.
@@ -1500,8 +1382,7 @@ paths:
               description: SHA256 digest of the file contents. Only sent when the uploaded file contains a file.hash.sha256 value.
               schema:
                 type: string
-                examples:
-                  - 0c4a81b85a6b7ff00bde6c32e1e8be33b4b793b3b7b5cb03db93f77f7c9374d1
+                example: 0c4a81b85a6b7ff00bde6c32e1e8be33b4b793b3b7b5cb03db93f77f7c9374d1
             Elastic-Api-Version:
               $ref: "#/components/headers/apiVersion"
             X-Request-Id:
@@ -1544,62 +1425,3 @@ paths:
           $ref: "#/components/responses/internalServerError"
         "503":
           $ref: "#/components/responses/unavailable"
-  /api/agents/upgrades/{major}.{minor}.{patch}/pgp-public-key:
-    get:
-      operationId: getPGPKey
-      summary: retrieve a PGP key from the fleet-server's local storage.
-      description: "Get a PGP key that can be used to verify agent upgrades. Key is stored on (fleet-server's) disk."
-      security:
-        - apiKey: []
-      parameters:
-        - name: major
-          in: path
-          description: The major version number.
-          required: true
-          schema:
-            type: integer
-        - name: minor
-          in: path
-          description: The minor version number.
-          required: true
-          schema:
-            type: integer
-        - name: patch
-          in: path
-          description: The patch version number.
-          required: true
-          schema:
-            type: integer
-        - $ref: "#/components/parameters/apiVersion"
-        - $ref: "#/components/parameters/requestId"
-      responses:
-        "200":
-          description: The PGP key bytes.
-          headers:
-            Elastic-Api-Version:
-              $ref: "#/components/headers/apiVersion"
-            X-Request-Id:
-              $ref: "#/components/headers/requestID"
-          content:
-            "application/octet-stream":
-              schema:
-                type: string
-                format: binary
-        "400":
-          $ref: "#/components/responses/badRequest"
-        "401":
-          $ref: "#/components/responses/keyNotEnabled"
-        "500":
-          description: The server has an error retrieving or reading the local key.
-          headers:
-            Elastic-Api-Version:
-              $ref: "#/components/headers/apiVersion"
-            X-Request-Id:
-              $ref: "#/components/headers/requestID"
-        "501":
-          description: The server will not serve the request without a TLS connection.
-          headers:
-            Elastic-Api-Version:
-              $ref: "#/components/headers/apiVersion"
-            X-Request-Id:
-              $ref: "#/components/headers/requestID"

--- a/pkg/api/versions/2023_06_01/api/types.gen.go
+++ b/pkg/api/versions/2023_06_01/api/types.gen.go
@@ -534,20 +534,20 @@ type AgentEnrollParams struct {
 	// The agent version must not be greater than the version of the fleet-server.
 	UserAgent UserAgent `json:"User-Agent"`
 
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
-	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
+	ElasticApiVersion *ApiVersion `json:"Elastic-Api-Version,omitempty"`
 }
 
 // AgentAcksParams defines parameters for AgentAcks.
 type AgentAcksParams struct {
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
-	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
+	ElasticApiVersion *ApiVersion `json:"Elastic-Api-Version,omitempty"`
 }
 
 // AgentCheckinParams defines parameters for AgentCheckin.
@@ -562,38 +562,47 @@ type AgentCheckinParams struct {
 	// The agent version must not be greater than the version of the fleet-server.
 	UserAgent UserAgent `json:"User-Agent"`
 
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
-	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
+	ElasticApiVersion *ApiVersion `json:"Elastic-Api-Version,omitempty"`
 }
 
 // ArtifactParams defines parameters for Artifact.
 type ArtifactParams struct {
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
-	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
+	ElasticApiVersion *ApiVersion `json:"Elastic-Api-Version,omitempty"`
+}
+
+// GetFileParams defines parameters for GetFile.
+type GetFileParams struct {
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
+
+	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
+	ElasticApiVersion *ApiVersion `json:"Elastic-Api-Version,omitempty"`
 }
 
 // UploadBeginParams defines parameters for UploadBegin.
 type UploadBeginParams struct {
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
-	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
+	ElasticApiVersion *ApiVersion `json:"Elastic-Api-Version,omitempty"`
 }
 
 // UploadCompleteParams defines parameters for UploadComplete.
 type UploadCompleteParams struct {
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
-	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
+	ElasticApiVersion *ApiVersion `json:"Elastic-Api-Version,omitempty"`
 }
 
 // UploadChunkParams defines parameters for UploadChunk.
@@ -601,20 +610,20 @@ type UploadChunkParams struct {
 	// XChunkSHA2 the SHA256 hash of the body contents for this request
 	XChunkSHA2 string `json:"X-Chunk-SHA2"`
 
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
-	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
+	ElasticApiVersion *ApiVersion `json:"Elastic-Api-Version,omitempty"`
 }
 
 // StatusParams defines parameters for Status.
 type StatusParams struct {
-	// XRequestID The request tracking ID for APM.
-	XRequestID *RequestId `json:"X-Request-ID,omitempty"`
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
 
 	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
-	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
+	ElasticApiVersion *ApiVersion `json:"Elastic-Api-Version,omitempty"`
 }
 
 // AgentEnrollJSONRequestBody defines body for AgentEnroll for application/json ContentType.

--- a/testing/e2e/api_version/client_api_2023_06_01.go
+++ b/testing/e2e/api_version/client_api_2023_06_01.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/elastic/fleet-server/testing/e2e/scaffold"
-	"github.com/elastic/fleet-server/v7/pkg/api/versions/2022_06_01/api"
+	"github.com/elastic/fleet-server/v7/pkg/api/versions/2023_06_01/api"
 
 	"github.com/elastic/fleet-server/v7/version"
 )

--- a/testing/e2e/api_version/client_api_current.go
+++ b/testing/e2e/api_version/client_api_current.go
@@ -249,7 +249,7 @@ func (tester *ClientAPITester) GetPGPKey(ctx context.Context, apiKey string) []b
 	}))
 	tester.Require().NoError(err)
 
-	resp, err := client.GetPGPKeyWithResponse(ctx, 1, 2, 3)
+	resp, err := client.GetPGPKeyWithResponse(ctx, 1, 2, 3, nil)
 	tester.Require().NoError(err)
 	if strings.HasPrefix(tester.endpoint, "https") {
 		tester.Require().Equal(http.StatusOK, resp.StatusCode())


### PR DESCRIPTION
## What is the problem this PR solves?

`Elastic-Api-Version` and `X-Request-Id` headers are not defined as part of responses for fleet-server

## How does this PR solve the problem?

Add doc.go files for minimal information on generated client apis (what they are generated from).
Add missing headers to all req/resp in the openapi spec for the current implementation in `model/openapi.yml`.
Add an `openapi.yml` spec file for the `2023-06-01` based off commit 1d28f4ca4ec62f940771e5eb72b77699d256525f with the missing headers (and version defined in the spec). Correct the directory name for the versioned client.