### PR TITLE
[Fleet] Improve error handling for invalid base64 token

### DIFF
--- a/internal/pkg/apikey/apikey.go
+++ b/internal/pkg/apikey/apikey.go
@@ -103,7 +103,7 @@ type APIKey struct {
 func NewAPIKeyFromToken(token string) (*APIKey, error) {
 	d, err := base64.StdEncoding.DecodeString(token)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrInvalidToken, err)
 	}
 	if !utf8.Valid(d) {
 		return nil, ErrInvalidToken

--- a/internal/pkg/apikey/apikey_test.go
+++ b/internal/pkg/apikey/apikey_test.go
@@ -21,3 +21,42 @@ func TestMonitorLeadership(t *testing.T) {
 	assert.Equal(t, *apiKey, APIKey{" foo", "bar"})
 	assert.Equal(t, token, apiKey.Token())
 }
+
+func TestNewAPIKeyFromToken(t *testing.T) {
+	tests := []struct {
+		name        string
+		apiKey      string
+		expectError error
+	}{{
+		name:        "Invalid base64",
+		apiKey:      "invalidbase64",
+		expectError: ErrInvalidToken,
+	},
+		{
+			name:        "malformed token",
+			apiKey:      "dGVzdA==",
+			expectError: ErrMalformedToken,
+		},
+		{
+			name:        "Invalid utf8",
+			apiKey:      "dGVzdMlA",
+			expectError: ErrInvalidToken,
+		},
+		{
+			name:        "Valid api key",
+			apiKey:      "bURmODBZb0JrTU82QzJJaVVET1A6bmVRUnBsWEJRbmVTVFIwV3FtaVVFZw==",
+			expectError: nil,
+		}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewAPIKeyFromToken(tc.apiKey)
+			if tc.expectError != nil {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, tc.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description 

Resolve #3046  

Improve error handling when enrollemnt token or api key during checkin is not a valid base64 token, and return a 400 instead of a 500.

This is covered by a new unit test