### PR TITLE
[Fleet] Support output secrets

### DIFF
--- a/changelog/fragments/1698420960-output-secrets.yaml
+++ b/changelog/fragments/1698420960-output-secrets.yaml
@@ -1,0 +1,33 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Support output secrets
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  Add support for outputs secrets, secrets are being stored in a separate index in elasticsearch
+  and replaced when processing the policy in fleet server.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: "fleet-server"
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/elastic/fleet-server/issues/2966

--- a/changelog/fragments/1698420960-output-secrets.yaml
+++ b/changelog/fragments/1698420960-output-secrets.yaml
@@ -26,7 +26,7 @@ component: "fleet-server"
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-#pr: https://github.com/owner/repo/1234
+pr: 3061
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.

--- a/changelog/fragments/1698420960-output-secrets.yaml
+++ b/changelog/fragments/1698420960-output-secrets.yaml
@@ -30,4 +30,4 @@ pr: 3061
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.
-# issue: https://github.com/elastic/fleet-server/issues/2966
+issue: 2966

--- a/internal/pkg/policy/parsed_policy.go
+++ b/internal/pkg/policy/parsed_policy.go
@@ -66,7 +66,6 @@ func NewParsedPolicy(ctx context.Context, bulker bulk.Bulk, p model.Policy) (*Pa
 	}
 	for _, policyOutput := range p.Data.Outputs {
 		err := processOutputSecret(ctx, policyOutput, bulker)
-
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/policy/parsed_policy.go
+++ b/internal/pkg/policy/parsed_policy.go
@@ -65,23 +65,11 @@ func NewParsedPolicy(ctx context.Context, bulker bulk.Bulk, p model.Policy) (*Pa
 		return nil, err
 	}
 	for _, policyOutput := range p.Data.Outputs {
-		outputSecrets, err := getOutputsSecrets(ctx, policyOutput, bulker)
+		err := processOutputSecret(ctx, policyOutput, bulker)
 
-		fmt.Printf("\nOUTPUT AFTER %v+", policyOutput)
 		if err != nil {
 			return nil, err
 		}
-		fmt.Printf("\nTEST %v+", outputSecrets)
-		// fmt.Printf("OUTPUT SECRET %v+ %v+", .SecretsValues, v.Secrets)
-		// for secretName, secretValue := range outputSecrets {
-		// 	fmt.Printf("SET SECRET %v+", secretName)
-		// 	outputMap := outputsMap.GetMap(policyOutput.Name)
-		// 	delete(outputMap, FieldOutputSecrets)
-		// 	err = setMapObj(outputsMap, secretValue, policyOutput.Name, secretName)
-		// 	if err != nil {
-		// 		return nil, err
-		// 	}
-		// }
 	}
 	defaultName, err := findDefaultOutputName(p.Data.Outputs)
 	if err != nil {

--- a/internal/pkg/policy/policy_output.go
+++ b/internal/pkg/policy/policy_output.go
@@ -35,12 +35,9 @@ var (
 )
 
 type Output struct {
-	Name          string
-	Type          string
-	Role          *RoleT
-	Secrets       map[string]model.SecretReferencesItems
-	SecretsValues map[string]string
-	Raw           json.RawMessage
+	Name string
+	Type string
+	Role *RoleT
 }
 
 // Prepare prepares the output p to be sent to the elastic-agent

--- a/internal/pkg/policy/policy_output.go
+++ b/internal/pkg/policy/policy_output.go
@@ -35,9 +35,12 @@ var (
 )
 
 type Output struct {
-	Name string
-	Type string
-	Role *RoleT
+	Name          string
+	Type          string
+	Role          *RoleT
+	Secrets       map[string]SecretReference
+	SecretsValues map[string]string
+	Raw           json.RawMessage
 }
 
 // Prepare prepares the output p to be sent to the elastic-agent

--- a/internal/pkg/policy/secret.go
+++ b/internal/pkg/policy/secret.go
@@ -79,17 +79,72 @@ func getPolicyInputsWithSecrets(ctx context.Context, data *model.PolicyData, bul
 	return result, nil
 }
 
+type OutputSecret struct {
+	Path []string
+	ID   string
+}
+
+func getSecretIDAndPath(secret smap.Map) ([]OutputSecret, error) {
+	outputSecrets := make([]OutputSecret, 0)
+
+	secretID := secret.GetString("id")
+	if secretID != "" {
+		outputSecrets = append(outputSecrets, OutputSecret{
+			Path: make([]string, 0),
+			ID:   secretID,
+		})
+
+		return outputSecrets, nil
+	}
+
+	for secretKey := range secret {
+		newOutputSecrets, err := getSecretIDAndPath(secret.GetMap(secretKey))
+		if err != nil {
+			return nil, err
+		}
+
+		for _, secret := range newOutputSecrets {
+			path := append([]string{secretKey}, secret.Path...)
+			outputSecrets = append(outputSecrets, OutputSecret{
+				Path: path,
+				ID:   secret.ID,
+			})
+		}
+	}
+
+	return outputSecrets, nil
+}
+
+func setSecretPath(output smap.Map, secretValue string, secretPaths []string) error {
+	// Break the recursion
+	if len(secretPaths) == 1 {
+		output[secretPaths[0]] = secretValue
+
+		return nil
+	}
+	path, secretPaths := secretPaths[0], secretPaths[1:]
+
+	if output.GetMap(path) == nil {
+		output[path] = make(map[string]interface{})
+	}
+
+	return setSecretPath(output.GetMap(path), secretValue, secretPaths)
+}
+
 // Read secret from output and mutate output with secret value
 func processOutputSecret(ctx context.Context, output smap.Map, bulker bulk.Bulk) error {
 	secrets := output.GetMap(FieldOutputSecrets)
 
 	delete(output, FieldOutputSecrets)
 	secretReferences := make([]model.SecretReferencesItems, 0)
+	outputSecrets, err := getSecretIDAndPath(secrets)
+	if err != nil {
+		return err
+	}
 
-	for secretKey := range secrets {
-		secretID := secrets.GetMap(secretKey).GetString("id")
+	for _, secret := range outputSecrets {
 		secretReferences = append(secretReferences, model.SecretReferencesItems{
-			ID: secretID,
+			ID: secret.ID,
 		})
 	}
 	if len(secretReferences) == 0 {
@@ -99,10 +154,11 @@ func processOutputSecret(ctx context.Context, output smap.Map, bulker bulk.Bulk)
 	if err != nil {
 		return err
 	}
-	for secretKey := range secrets {
-		secretID := secrets.GetMap(secretKey).GetString("id")
-		secretValue := secretValues[secretID]
-		output[secretKey] = secretValue
+	for _, secret := range outputSecrets {
+		err = setSecretPath(output, secretValues[secret.ID], secret.Path)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/pkg/policy/secret.go
+++ b/internal/pkg/policy/secret.go
@@ -49,7 +49,6 @@ func getPolicyInputsWithSecrets(ctx context.Context, data *model.PolicyData, bul
 	}
 
 	secretValues, err := getSecretValues(ctx, data.SecretReferences, bulker)
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/policy/secret_test.go
+++ b/internal/pkg/policy/secret_test.go
@@ -57,10 +57,9 @@ func TestReplaceSecretRefNotFound(t *testing.T) {
 
 func TestGetSecretValues(t *testing.T) {
 	secretRefsJSON := []SecretReference{{ID: "ref1"}, {ID: "ref2"}}
-	secretRefsRaw, _ := json.Marshal(secretRefsJSON)
 	bulker := ftesting.NewMockBulk()
 
-	secretRefs, _ := getSecretValues(context.TODO(), secretRefsRaw, bulker)
+	secretRefs, _ := getSecretValues(context.TODO(), secretRefsJSON, bulker)
 
 	expectedRefs := map[string]string{
 		"ref1": "ref1_value",


### PR DESCRIPTION
## Description

Resolve #2966 

Add support for output secrets.

Implementation details, if we found anything under `secrets` for an output fleet server will retrieve the associated secret and put it under the same path in the resulting output, this should be future proof and allow us to support new output secrets without any change to fleet server.

Example `secrets: { "password": {"id": "TEST"} }` => `{ "password": "retrieved_password_for_TEST_id"}`



## TODO 

- [x] changelog
- [x] add unit tests
- [x] Support nested secret path `ssl.keyword` for example
