### PR TITLE
[Fleet] Better handle policy not found error for static tokens

### DIFF
--- a/internal/pkg/api/error.go
+++ b/internal/pkg/api/error.go
@@ -445,6 +445,15 @@ func NewHTTPErrResp(err error) HTTPErrResp {
 				zerolog.InfoLevel,
 			},
 		},
+		{
+			ErrPolicyNotFound,
+			HTTPErrResp{
+				http.StatusBadRequest,
+				"ErrPolicyNotFound",
+				"ErrPolicyNotFound",
+				zerolog.InfoLevel,
+			},
+		},
 	}
 
 	for _, e := range errTable {
@@ -515,7 +524,7 @@ func ErrorResp(w http.ResponseWriter, r *http.Request, err error) {
 	}
 	e.Msg("HTTP request error")
 
-	if (resp.StatusCode >= 500) {
+	if resp.StatusCode >= 500 {
 		apm.CaptureError(r.Context(), err).Send()
 	}
 


### PR DESCRIPTION
## Description 

Resolve https://github.com/elastic/fleet-server/issues/3068
Better handling of policy not found error for static tokens, return a 400 instead of 500.

as it's a temporary error that could be fixed by a user (or by the preconfiguration) by creating the correct policy.

## Tests

Automated test, the policy not found is already handled and there is a unit test is here, not sure we should add a e2e test for that.







