### PR TITLE
Add unit tests for supporting build metadata

### DIFF
--- a/internal/pkg/api/userAgent_test.go
+++ b/internal/pkg/api/userAgent_test.go
@@ -20,6 +20,7 @@ func TestValidateUserAgent(t *testing.T) {
 		userAgent string
 		verCon    version.Constraints
 		err       error
+		repVer   string
 	}{
 		{
 			userAgent: "",
@@ -55,16 +56,19 @@ func TestValidateUserAgent(t *testing.T) {
 			userAgent: "eLaStIc AGeNt v7.13.0",
 			verCon:    mustBuildConstraints("7.13.0"),
 			err:       nil,
+			repVer:    "7.13.0",
 		},
 		{
 			userAgent: "eLaStIc AGeNt v7.13.0",
 			verCon:    mustBuildConstraints("7.13.1"),
 			err:       nil,
+			repVer:    "7.13.0",
 		},
 		{
 			userAgent: "eLaStIc AGeNt v7.13.1",
 			verCon:    mustBuildConstraints("7.13.0"),
 			err:       nil,
+			repVer:    "7.13.1",
 		},
 		{
 			userAgent: "eLaStIc AGeNt v7.14.0",
@@ -80,43 +84,64 @@ func TestValidateUserAgent(t *testing.T) {
 			userAgent: "eLaStIc AGeNt v7.13.0",
 			verCon:    mustBuildConstraints("8.0.0"),
 			err:       nil,
+			repVer:    "7.13.0",
 		},
 		{
 			userAgent: "eLaStIc AGeNt v7.13.0",
 			verCon:    mustBuildConstraints("8.0.0-alpha1"),
 			err:       nil,
+			repVer:    "7.13.0",
 		},
 		{
 			userAgent: "eLaStIc AGeNt v8.0.0-alpha1",
 			verCon:    mustBuildConstraints("8.0.0-alpha1"),
 			err:       nil,
+			repVer:    "8.0.0",
 		},
 		{
 			userAgent: "eLaStIc AGeNt v8.0.0-alpha1",
 			verCon:    mustBuildConstraints("8.0.0"),
 			err:       nil,
+			repVer:    "8.0.0",
 		},
 		{
 			userAgent: "eLaStIc AGeNt v8.0.0-anything",
 			verCon:    mustBuildConstraints("8.0.0"),
 			err:       nil,
+			repVer:    "8.0.0",
 		},
 		{
 			userAgent: "eLaStIc AGeNt v7.15.0-anything",
 			verCon:    mustBuildConstraints("8.0.0"),
 			err:       nil,
+			repVer:    "7.15.0",
 		},
 		{
 			userAgent: "eLaStIc AGeNt v7.15.0-anything",
 			verCon:    mustBuildConstraints("8.0.0-beta1"),
 			err:       nil,
+			repVer:    "7.15.0",
+		},
+		{
+			userAgent: "Elastic Agent v8.10.0+build1234",
+			verCon:    mustBuildConstraints("8.10.0"),
+			err:       nil,
+			repVer:	  "8.10.0+build1234",
+		},
+		{
+			userAgent: "Elastic Agent v8.10.0+build1234",
+			verCon:    mustBuildConstraints("8.9.0"),
+			err:       ErrUnsupportedVersion,
 		},
 	}
 	for _, tr := range tests {
 		t.Run(tr.userAgent, func(t *testing.T) {
-			_, res := validateUserAgent(context.Background(), zerolog.Nop(), tr.userAgent, tr.verCon)
+			repVer, res := validateUserAgent(context.Background(), zerolog.Nop(), tr.userAgent, tr.verCon)
 			if !errors.Is(tr.err, res) {
 				t.Fatalf("err mismatch: %v != %v", tr.err, res)
+			}
+			if tr.repVer != "" && tr.repVer != repVer {
+				t.Fatalf("version mismatch: %v != %v", tr.repVer, repVer)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

This updates our user agent validation and parsing tests to ensure that we accept Agent builds that include the `\+build[0-9]$` metadata suffix. These tests also verify that we will retain the build metadata suffix in the version that we report to the `.fleet-agents` index.

## How does this PR solve the problem?

// Explain HOW you solved the problem in your code. It is possible that during PR reviews this changes and then this section should be updated.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
