### PR TITLE
[Fleet] Fix updating upgrade details during checkin

### DIFF
--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -442,13 +442,8 @@ func (ct *CheckinT) processUpgradeDetails(ctx context.Context, agent *model.Agen
 	}
 	vSpan.End()
 
-	// marshal and update agent doc with details
-	p, err := json.Marshal(details)
-	if err != nil {
-		return err
-	}
 	doc := bulk.UpdateFields{
-		dl.FieldUpgradeDetails: p,
+		dl.FieldUpgradeDetails: details,
 	}
 	body, err := doc.Marshal()
 	if err != nil {


### PR DESCRIPTION
## Description 

In https://github.com/elastic/fleet-server/pull/2901 we introduced upgrade details, it seems that field is not correctly saved as we try to save it as string, that PR fix it by saving is as an object.

## How to tests

with the API
1. enroll an agent
2. upgrade it
3. provide the upgrade_details during checkin

You should not get that error and `upgrade_details` should be persisted
```
failed to update upgrade_details: elastic fail 400: document_parsing_exception: [1:3732] object mapping for [upgrade_details] tried to parse field [upgrade_details] as object, but found a concrete value
```
