### PR TITLE
add uploading the test-unit.out.xml artifact

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -81,6 +81,7 @@ steps:
           image: "docker.elastic.co/cloud-ci/sonarqube/buildkite-scanner:latest"
         command:
           - "buildkite-agent artifact download build/*coverage.out ."
+          - "buildkite-agent artifact download build/test-unit.out.xml ."
           - "/scan-source-code.sh"
         depends_on:
           - step: "unit-test"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

// Please do not just reference an issue. Explain WHAT the problem this PR solves here.

## How does this PR solve the problem?

Error in the SonarQube step:
`ERROR: Test report can't be loaded, file not found: '/buildkite/builds/bk-agent-prod-k8s-1699483250115927686/elastic/fleet-server/build/test-unit.out.xml', ignoring this file.`

## How to test this PR locally

It's tested in the https://github.com/elastic/integrations/pull/8464

## Related issues

-

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
