### PR TITLE
Use Shutdown to gracefully halt HTTP servers

### DIFF
--- a/changelog/fragments/1702574888-Drain-HTTP-connections-on-shutdown.yaml
+++ b/changelog/fragments/1702574888-Drain-HTTP-connections-on-shutdown.yaml
@@ -1,0 +1,34 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Drain HTTP connections on shutdown
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  Attempt to safely drain HTTP connections on shutdown by using the http server's Shutdown method.
+  Add a new timeout.Drain config attribute that how long the shutdown will wait (default 10s).
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 3165
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 2902

--- a/fleet-server.reference.yml
+++ b/fleet-server.reference.yml
@@ -122,6 +122,8 @@ fleet:
 #       checkin_jitter: 30s
 #       # checkin_max_poll is the maximum long_poll value a client can request.
 #       checkin_max_poll: 1h
+#       # drain is the amount of time fleet-server will wait for HTTP connections to terminate on a shutdown signal before forcing all connections closed
+#       drain: 10s
 #
 #     # profiler will bind Go's pprof endpoints to a new listener if enabled.
 #     profiler:

--- a/internal/pkg/checkin/bulk.go
+++ b/internal/pkg/checkin/bulk.go
@@ -99,6 +99,7 @@ func (bc *Bulk) timestamp() string {
 
 // CheckIn will add the agent (identified by id) to the pending set.
 // The pending agents are sent to elasticsearch as a bulk update at each flush interval.
+// NOTE: If Checkin is called after Run has returned it will just add the entry to the pending map and not do any operations, this may occur when the fleet-server is shutting down.
 // WARNING: Bulk will take ownership of fields, so do not use after passing in.
 func (bc *Bulk) CheckIn(id string, status string, message string, meta []byte, components []byte, seqno sqn.SeqNo, newVer string) error {
 	// Separate out the extra data to minimize

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -119,6 +119,7 @@ func TestConfig(t *testing.T) {
 								CheckinLongPoll:  5 * time.Minute,
 								CheckinJitter:    30 * time.Second,
 								CheckinMaxPoll:   10 * time.Minute,
+								Drain:            10 * time.Second,
 							},
 							Profiler: ServerProfiler{
 								Enabled: false,

--- a/internal/pkg/config/timeouts.go
+++ b/internal/pkg/config/timeouts.go
@@ -18,6 +18,7 @@ type ServerTimeouts struct {
 	CheckinLongPoll  time.Duration `config:"checkin_long_poll"`
 	CheckinJitter    time.Duration `config:"checkin_jitter"`
 	CheckinMaxPoll   time.Duration `config:"checkin_max_poll"`
+	Drain            time.Duration `config:"drain"`
 }
 
 // InitDefaults initializes the defaults for the configuration.
@@ -64,4 +65,9 @@ func (c *ServerTimeouts) InitDefaults() {
 	// The long poll value is poll_timeout-2m, and the request's write timeout is set to poll_timeout-1m
 	// CheckinMaxPoll values of less then 1m are effectively ignored and a 1m limit is used.
 	c.CheckinMaxPoll = time.Hour
+
+	// Drain is the max duration that a server will keep connections open when a shutdown signal is received in order to gracefully handle in progress-requests.
+	// It is used as a context timeout value for server.ShutDown(ctx).
+	// A long-poll checkin connection should immediately return with a 200 status and the same ackToken it was sent, the same as if the long-poll completed with no changes detected.
+	c.Drain = 10 * time.Second
 }

--- a/internal/pkg/profile/profile_test.go
+++ b/internal/pkg/profile/profile_test.go
@@ -1,0 +1,46 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package profile
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunProfiler(t *testing.T) {
+	ln, err := net.Listen("tcp", ":8080")
+	if err != nil {
+		t.Skip("Port 8080 must be free to run this test")
+	}
+	ln.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error)
+
+	go func() {
+		errCh <- RunProfiler(ctx, "localhost:8080")
+	}()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://localhost:8080/debug/pprof", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	default:
+	}
+}

--- a/internal/pkg/profile/profile_test.go
+++ b/internal/pkg/profile/profile_test.go
@@ -35,7 +35,7 @@ func TestRunProfiler(t *testing.T) {
 
 	var resp *http.Response
 	for i := 0; i < 10; i++ {
-		resp, err = http.DefaultClient.Do(req)
+		resp, err = http.DefaultClient.Do(req) //nolint:bodyclose // closed outside the loop
 		if err == nil {
 			break
 		}

--- a/internal/pkg/profile/profile_test.go
+++ b/internal/pkg/profile/profile_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestRunProfiler(t *testing.T) {
-	ln, err := net.Listen("tcp", ":8080")
+	ln, err := net.Listen("tcp", "localhost:8080")
 	if err != nil {
 		t.Skip("Port 8080 must be free to run this test")
 	}

--- a/internal/pkg/server/fleet.go
+++ b/internal/pkg/server/fleet.go
@@ -207,7 +207,7 @@ LOOP:
 
 	// Server is coming down; wait for the server group to exit cleanly.
 	// Timeout if something is locked up.
-	err = safeWait(srvEg, time.Second)
+	err = safeWait(srvEg, curCfg.Inputs[0].Server.Timeouts.Drain)
 
 	// Eat cancel error to minimize confusion in logs
 	if errors.Is(err, context.Canceled) {
@@ -505,10 +505,10 @@ func (f *Fleet) runSubsystems(ctx context.Context, cfg *config.Config, g *errgro
 	if err != nil {
 		return err
 	}
-	g.Go(loggedRunFunc(ctx, "Revision monitor", am.Run))
+	g.Go(loggedRunFunc(ctx, "Action monitor", am.Run))
 
 	ad = action.NewDispatcher(am, cfg.Inputs[0].Server.Limits.ActionLimit.Interval, cfg.Inputs[0].Server.Limits.ActionLimit.Burst)
-	g.Go(loggedRunFunc(ctx, "Revision dispatcher", ad.Run))
+	g.Go(loggedRunFunc(ctx, "Action dispatcher", ad.Run))
 	tr, err = action.NewTokenResolver(bulker)
 	if err != nil {
 		return err


### PR DESCRIPTION
## What is the problem this PR solves?

Checkin API long-poll connections terminate with an error when the server needs to shut down (providing a 5xx to the client).

## How does this PR solve the problem?

Use the Shutdown method with a timeout to try to gracefully shutdown
HTTP connections. If the server times out while attempting to drain the
connections, connections are forced closed. If there is a long-polling
checkin request, the server should send a 200 response with the ack
token used in the request (same behaviour as the poll completing
normally).

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Closes #2902 