### PR TITLE
Update linter

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -38,7 +38,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.51.2
+          version: v1.55.2
 
           # Give the job more time to execute.
           # Regarding `--whole-files`, the linter is supposed to support linting of changed a patch only but,

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ check-headers:  ## - Check copyright headers
 
 .PHONY: check-go
 check-go: ## - Run golangci-lint
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/d58dbde584c801091e74a00940e11ff18c6c68bd/install.sh | sh -s v1.51.1
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/d58dbde584c801091e74a00940e11ff18c6c68bd/install.sh | sh -s v1.55.2
 	@./bin/golangci-lint run -v
 
 .PHONY: notice

--- a/internal/pkg/action/dispatcher.go
+++ b/internal/pkg/action/dispatcher.go
@@ -57,11 +57,11 @@ func NewDispatcher(am monitor.SimpleMonitor, throttle time.Duration, i int) *Dis
 // Run starts the Dispatcher.
 // After the Dispatcher is started subscriptions may receive actions.
 // Subscribe may be called before or after Run.
-func (d *Dispatcher) Run(ctx context.Context) (err error) {
+func (d *Dispatcher) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		case hits := <-d.am.Output():
 			d.process(ctx, hits)
 		}

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -638,6 +638,8 @@ func filterActions(zlog zerolog.Logger, agentID string, actions []model.Action) 
 // raw is first parsed into the action-specific data struct then passed into Action_Data in order to remove any undefined keys.
 //
 // TODO: There is a lot of repitition in this method we should try to clean up.
+//
+//nolint:nakedret // FIXME try to refactor this in the future
 func convertActionData(aType ActionType, raw json.RawMessage) (ad Action_Data, err error) {
 	switch aType {
 	case CANCEL:
@@ -687,6 +689,7 @@ func convertActionData(aType ActionType, raw json.RawMessage) (ad Action_Data, e
 	}
 }
 
+//nolint:gosec // memory aliasing is used to convert from pointers to values and the other way
 func convertActions(zlog zerolog.Logger, agentID string, actions []model.Action) ([]Action, string) {
 	var ackToken string
 	sz := len(actions)

--- a/internal/pkg/api/openapi_spec_test.go
+++ b/internal/pkg/api/openapi_spec_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//nolint:dupl // don't care about repitition for tests
+//nolint:dupl,goconst // don't care about repitition for tests
 package api
 
 // Test json encoding/decoding for all req/resp items
@@ -227,6 +227,7 @@ func Test_UpgradeDetailsMetadata_Downloading(t *testing.T) {
 	}}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			meta, err := tc.md.AsUpgradeMetadataDownloading()
 			if tc.err == nil {
@@ -281,6 +282,7 @@ func Test_UpgradeDetailsMetadata_Failed(t *testing.T) {
 	}}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			meta, err := tc.md.AsUpgradeMetadataFailed()
 			if tc.err == nil {
@@ -336,6 +338,7 @@ func Test_UpgradeDetailsMetadata_Scheduled(t *testing.T) {
 	}}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			meta, err := tc.md.AsUpgradeMetadataScheduled()
 			if tc.err == nil {
@@ -378,6 +381,7 @@ func TestUpgradeDetailsSerialization(t *testing.T) {
 		TargetVersion: "1.2.3",
 	}}
 	for _, d := range details {
+		d := d
 		t.Run(string(d.State), func(t *testing.T) {
 			p, err := json.Marshal(d)
 			require.NoError(t, err)

--- a/internal/pkg/bulk/bulk_test.go
+++ b/internal/pkg/bulk/bulk_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"sync"
@@ -101,7 +101,7 @@ func (m *mockBulkTransport) Perform(req *http.Request) (*http.Response, error) {
 		Proto:      "HTTP/1.1",
 		ProtoMajor: 1,
 		ProtoMinor: 1,
-		Body:       ioutil.NopCloser(&body),
+		Body:       io.NopCloser(&body),
 	}
 
 	return resp, nil

--- a/internal/pkg/bulk/helpers.go
+++ b/internal/pkg/bulk/helpers.go
@@ -6,7 +6,7 @@ package bulk
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/es"
 	"github.com/elastic/go-elasticsearch/v8/esapi"
@@ -41,7 +41,7 @@ func parseError(res *esapi.Response, log *zerolog.Logger) error {
 
 	if err := decoder.Decode(&e); err != nil {
 		log.Error().Err(err).Msg("Cannot decode Elasticsearch error body")
-		bodyBytes, readErr := ioutil.ReadAll(res.Body)
+		bodyBytes, readErr := io.ReadAll(res.Body)
 		if readErr != nil {
 			log.Debug().Err(readErr).Msg("Error reading error response body from Elasticsearch")
 		} else {

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -3,6 +3,8 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // Package cache implements an in-memory cache used to track API keys, actions, and artifacts.
+
+//nolint:goconst // easier to read scoped keys if no constants are used
 package cache
 
 import (

--- a/internal/pkg/dl/enrollment_api_key.go
+++ b/internal/pkg/dl/enrollment_api_key.go
@@ -51,10 +51,11 @@ func FindEnrollmentAPIKey(ctx context.Context, bulker bulk.Bulk, tmpl *dsl.Tmpl,
 	return findEnrollmentAPIKey(ctx, bulker, FleetEnrollmentAPIKeys, tmpl, field, id)
 }
 
-func findEnrollmentAPIKey(ctx context.Context, bulker bulk.Bulk, index string, tmpl *dsl.Tmpl, field string, id string) (rec model.EnrollmentAPIKey, err error) {
+func findEnrollmentAPIKey(ctx context.Context, bulker bulk.Bulk, index string, tmpl *dsl.Tmpl, field string, id string) (model.EnrollmentAPIKey, error) {
+	var rec model.EnrollmentAPIKey
 	res, err := SearchWithOneParam(ctx, bulker, tmpl, index, field, id)
 	if err != nil {
-		return
+		return rec, err
 	}
 
 	sz := len(res.Hits)

--- a/internal/pkg/dl/enrollment_api_key_integration_test.go
+++ b/internal/pkg/dl/enrollment_api_key_integration_test.go
@@ -38,16 +38,16 @@ func createRandomEnrollmentAPIKey(policyID string, active bool) model.Enrollment
 
 }
 
-func storeRandomEnrollmentAPIKey(ctx context.Context, bulker bulk.Bulk, index string, policyID string, active bool) (rec model.EnrollmentAPIKey, err error) {
-	rec = createRandomEnrollmentAPIKey(policyID, active)
+func storeRandomEnrollmentAPIKey(ctx context.Context, bulker bulk.Bulk, index string, policyID string, active bool) (model.EnrollmentAPIKey, error) {
+	rec := createRandomEnrollmentAPIKey(policyID, active)
 
 	body, err := json.Marshal(rec)
 	if err != nil {
-		return
+		return rec, err
 	}
 	_, err = bulker.Create(ctx, index, rec.Id, body, bulk.WithRefresh())
 	if err != nil {
-		return
+		return rec, err
 	}
 	return rec, err
 }

--- a/internal/pkg/dl/migration_integration_test.go
+++ b/internal/pkg/dl/migration_integration_test.go
@@ -4,6 +4,7 @@
 
 //go:build integration
 
+//nolint:goconst // disable duplicate checking
 package dl
 
 import (

--- a/internal/pkg/dl/policies_leader.go
+++ b/internal/pkg/dl/policies_leader.go
@@ -36,6 +36,8 @@ func prepareSearchPolicyLeaders() (*dsl.Tmpl, error) {
 }
 
 // SearchPolicyLeaders returns all the leaders for the provided policies
+//
+//nolint:nakedret // leader election is going to be removed
 func SearchPolicyLeaders(ctx context.Context, bulker bulk.Bulk, ids []string, opt ...Option) (leaders map[string]model.PolicyLeader, err error) {
 	initSearchPolicyLeadersOnce.Do(func() {
 		tmplSearchPolicyLeaders, err = prepareSearchPolicyLeaders()

--- a/internal/pkg/es/info.go
+++ b/internal/pkg/es/info.go
@@ -21,13 +21,13 @@ type infoResponse struct {
 	Error   json.RawMessage `json:"error,omitempty"`
 }
 
-func FetchESVersion(ctx context.Context, esCli *elasticsearch.Client) (version string, err error) {
+func FetchESVersion(ctx context.Context, esCli *elasticsearch.Client) (string, error) {
 	res, err := esCli.Info(
 		esCli.Info.WithContext(ctx),
 	)
 
 	if err != nil {
-		return
+		return "", err
 	}
 	defer res.Body.Close()
 
@@ -35,13 +35,13 @@ func FetchESVersion(ctx context.Context, esCli *elasticsearch.Client) (version s
 
 	err = json.NewDecoder(res.Body).Decode(&sres)
 	if err != nil {
-		return
+		return "", err
 	}
 
 	// Check error
 	err = TranslateError(res.StatusCode, sres.Error)
 	if err != nil {
-		return
+		return "", err
 	}
 
 	verStr := strings.TrimSpace(strings.TrimSuffix(strings.ToLower(sres.Version.Number), "-snapshot"))

--- a/internal/pkg/file/delivery/delivery_test.go
+++ b/internal/pkg/file/delivery/delivery_test.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -285,7 +284,7 @@ func sendBodyBytes(body []byte) *http.Response  { return sendBody(bytes.NewReade
 func sendBody(body io.Reader) *http.Response {
 	return &http.Response{
 		StatusCode: http.StatusOK,
-		Body:       ioutil.NopCloser(body),
+		Body:       io.NopCloser(body),
 		Header: http.Header{
 			"X-Elastic-Product": []string{"Elasticsearch"},
 			"Content-Type":      []string{"application/cbor"},

--- a/internal/pkg/file/uploader/upload_test.go
+++ b/internal/pkg/file/uploader/upload_test.go
@@ -2,6 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//nolint:goconst // disable contstants checks for tests
 package uploader
 
 import (

--- a/internal/pkg/gcheckpt/checkpoint.go
+++ b/internal/pkg/gcheckpt/checkpoint.go
@@ -4,6 +4,8 @@
 
 // Package gcheckpt handles the fleet API's global_checkpoints operations
 // checkpoints are used to track which actions, agetnc (docs in general) have been read based on the seqno received.
+
+//nolint:nakedret // FIXME refactor without naked returns at a later date
 package gcheckpt
 
 import (

--- a/internal/pkg/policy/policy_output_integration_test.go
+++ b/internal/pkg/policy/policy_output_integration_test.go
@@ -4,6 +4,7 @@
 
 //go:build integration
 
+//nolint:goconst // disable constants checks for tests
 package policy
 
 import (

--- a/internal/pkg/server/fleet.go
+++ b/internal/pkg/server/fleet.go
@@ -394,6 +394,7 @@ func (f *Fleet) runServer(ctx context.Context, cfg *config.Config) (err error) {
 	// the bulker exits.  If the bulker exits before the error group,
 	// this will tear down the error group and g.Wait() will return.
 	// Otherwise it will be a noop.
+	//nolint:nakedret // small function is easy to track
 	g.Go(func() (err error) {
 		select {
 		case err = <-errCh:

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -4,7 +4,7 @@
 
 //go:build integration
 
-//nolint:dupl // don't care about repeating code
+//nolint:dupl,goconst // don't care about repeating code
 package server
 
 import (
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"path"
@@ -428,7 +427,7 @@ func TestServerUnauthorized(t *testing.T) {
 			defer res.Body.Close()
 			require.Equal(t, http.StatusUnauthorized, res.StatusCode)
 
-			raw, _ := ioutil.ReadAll(res.Body)
+			raw, _ := io.ReadAll(res.Body)
 			var resp api.HTTPErrResp
 			err = json.Unmarshal(raw, &resp)
 			if err != nil {
@@ -457,7 +456,7 @@ func TestServerUnauthorized(t *testing.T) {
 
 			require.Equal(t, http.StatusUnauthorized, res.StatusCode)
 
-			raw, _ := ioutil.ReadAll(res.Body)
+			raw, _ := io.ReadAll(res.Body)
 			var resp api.HTTPErrResp
 			err = json.Unmarshal(raw, &resp)
 			if err != nil {

--- a/internal/pkg/testing/esutil/client.go
+++ b/internal/pkg/testing/esutil/client.go
@@ -6,7 +6,6 @@ package esutil
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -48,7 +47,7 @@ func sendBodyString(body string) *http.Response {
 func sendBody(body io.Reader) *http.Response {
 	return &http.Response{
 		StatusCode: http.StatusOK,
-		Body:       ioutil.NopCloser(body),
+		Body:       io.NopCloser(body),
 		Header: http.Header{
 			"X-Elastic-Product": []string{"Elasticsearch"},
 			"Content-Type":      []string{"application/cbor"},

--- a/internal/pkg/testing/esutil/esutil.go
+++ b/internal/pkg/testing/esutil/esutil.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -85,7 +85,7 @@ func parseResponseError(res *esapi.Response) (*errorResponse, error) {
 		// Read the original body content, in case if it was a error from the cloud response
 		// {"ok":false,"message":"Unknown deployment."}
 		// So we can log it
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			return nil, &ClientError{
 				StatusCode: res.StatusCode,


### PR DESCRIPTION
Update golangci-lint to v1.55.2 and fix or disable new linter warnings.