### PR TITLE
[Buildkite] Add dependabot as a user to run builds in Pull Requests

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -4,7 +4,7 @@
         "pipeline_slug": "fleet-server",
         "allow_org_users": true,
         "allowed_repo_permissions": ["admin", "write"],
-        "allowed_list": ["mergify[bot]"],
+        "allowed_list": ["dependabot[bot]", "mergify[bot]"],
         "set_commit_status": true,
         "build_on_commit": true,
         "build_on_comment": true,
@@ -17,13 +17,12 @@
         "pipeline_slug": "fleet-server-package-mbp",
         "allow_org_users": true,
         "allowed_repo_permissions": ["admin", "write"],
-        "allowed_list": ["mergify[bot]"],
+        "allowed_list": ["dependabot[bot]", "mergify[bot]"],
         "set_commit_status": false,
         "build_on_commit": false,
         "build_on_comment": true,
         "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:package)\\W+(?:this|it))|^/package$",
         "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:package)\\W+(?:this|it))|^/package$",
-
         "fail_on_not_mergeable": true
       }]
 }


### PR DESCRIPTION
## What is the problem this PR solves?

Pull Requests created by dependabot do not trigger builds in Buildkite.

## How does this PR solve the problem?

Added `dependabot[bot]` user into the allowed users to run builds in Pull Requests.