### PR TITLE
Deprecate fleet.agent.logging.level attribute

### DIFF
--- a/changelog/fragments/1703700493-deprecate-fleet.agent.logging.level.yaml
+++ b/changelog/fragments/1703700493-deprecate-fleet.agent.logging.level.yaml
@@ -1,0 +1,35 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: deprecate fleet.agent.logging.level
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  Deprecate the fleet.agent.logging.level attribute and rely only on the
+  top level logging.* attributes to control fleet-server logging. Add a
+  unit test to ensure logging flags are parsed correctly.
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 3126

--- a/cmd/fleet/flag_test.go
+++ b/cmd/fleet/flag_test.go
@@ -1,0 +1,59 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package fleet
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/build"
+	"github.com/elastic/fleet-server/v7/internal/pkg/config"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentModeFlag(t *testing.T) {
+	tests := []struct {
+		name   string
+		flags  []string
+		expect func() *config.Config
+	}{{
+		name:  "no flags",
+		flags: []string{},
+		expect: func() *config.Config {
+			cfg := &config.Config{}
+			cfg.InitDefaults()
+			cfg.Output.Elasticsearch.InitDefaults() // NOTE this is implicitly called when ucfg parses the top level cfg object, but we need to explicitly call it for testing.
+			return cfg
+		},
+	}, {
+		name:  "debug log flag",
+		flags: []string{"E logging.level=debug"}, // flag is the k:v separated by a space, key does not have the "-" prefix
+		expect: func() *config.Config {
+			cfg := &config.Config{}
+			cfg.InitDefaults()
+			cfg.Output.Elasticsearch.InitDefaults()
+			cfg.Logging.Level = "debug"
+			return cfg
+		},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := NewCommand(build.Info{})
+			for _, flag := range tc.flags {
+				arr := strings.Split(flag, " ")
+				err := cmd.Flags().Set(arr[0], arr[1])
+				require.NoError(t, err)
+			}
+
+			cfgObj := cmd.Flags().Lookup("E").Value.(*config.Flag) //nolint:errcheck // same as in main
+			cfgCLI := cfgObj.Config()
+			cfg, err := config.FromConfig(cfgCLI)
+			require.NoError(t, err)
+			require.Equal(t, tc.expect(), cfg)
+		})
+	}
+}

--- a/fleet-server.reference.yml
+++ b/fleet-server.reference.yml
@@ -50,7 +50,8 @@ fleet:
     id: fleet-server-agent-idv
 #    # version is the version of the elastic-agent instance
 #    version:
-#    # agent logging level may also be specified in top level logging config
+#    # specify logging level
+#    # deprecated: Use the top level logging.* attributes instead.
 #    logging.level: info
 #  host:
 #    id:

--- a/internal/pkg/config/fleet.go
+++ b/internal/pkg/config/fleet.go
@@ -11,9 +11,8 @@ import (
 	"github.com/rs/zerolog"
 )
 
-const defaultLevel = "info"
-
 // AgentLogging is the log level set on the Agent.
+// deprectated: Use top level `logging.*` attributes instead.
 type AgentLogging struct {
 	Level string `config:"level"`
 }

--- a/internal/pkg/config/logging.go
+++ b/internal/pkg/config/logging.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rs/zerolog"
 )
 
+const defaultLevel = "info"
+
 // LoggingFiles configuration for the logging file output.
 type LoggingFiles struct {
 	Path            string        `config:"path"`

--- a/internal/pkg/logger/logger.go
+++ b/internal/pkg/logger/logger.go
@@ -101,16 +101,10 @@ func Init(cfg *config.Config, svcName string) (*Logger, error) {
 }
 
 func levelChanged(cfg *config.Config) bool {
-	if cfg.Fleet.Agent.Logging.LogLevel() != zerolog.GlobalLevel() {
-		return true
-	}
 	return level(cfg) != zerolog.GlobalLevel()
 }
 
 func level(cfg *config.Config) zerolog.Level {
-	if cfg.Fleet.Agent.Logging.Level != "" {
-		return cfg.Fleet.Agent.Logging.LogLevel()
-	}
 	return cfg.Logging.LogLevel()
 }
 

--- a/internal/pkg/server/agent.go
+++ b/internal/pkg/server/agent.go
@@ -404,9 +404,6 @@ func (a *Agent) configFromUnits() (*config.Config, error) {
 			"agent": map[string]interface{}{
 				"id":      agentID,
 				"version": agentVersion,
-				"logging": map[string]interface{}{
-					"level": logLevel.String(),
-				},
 			},
 		},
 		"output": map[string]interface{}{


### PR DESCRIPTION
## What is the problem this PR solves?

command line flag passed by agent is being ignored by fleet-server.

## How does this PR solve the problem?

Deprecate the fleet.agent.logging.level attribute and rely on the top level logging.* attributes instead. Add a unit test to make sure that command line overrides are respected.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Closes #3126 
