### PR TITLE
[8.12] added download_rate to openapi (#3177)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Elastic Beats
-Copyright 2014-2023 Elasticsearch BV
+Copyright 2014-2024 Elasticsearch BV
 
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).

--- a/internal/pkg/api/openapi.gen.go
+++ b/internal/pkg/api/openapi.gen.go
@@ -707,6 +707,15 @@ type UpgradeDetailsState string
 type UpgradeMetadataDownloading struct {
 	// DownloadPercent The artifact download progress as a percentage.
 	DownloadPercent float64 `json:"download_percent"`
+
+	// DownloadRate The artifact download rate as bytes per second.
+	DownloadRate *float64 `json:"download_rate,omitempty"`
+
+	// RetryErrorMsg The error message that is a result of a retryable upgrade download failure.
+	RetryErrorMsg *string `json:"retry_error_msg,omitempty"`
+
+	// RetryUntil The RFC3339 timestamp of the deadline the upgrade download is retried until.
+	RetryUntil *time.Time `json:"retry_until,omitempty"`
 }
 
 // UpgradeMetadataFailed Upgrade metadata for an upgrade that has failed.

--- a/internal/pkg/api/openapi_spec_test.go
+++ b/internal/pkg/api/openapi_spec_test.go
@@ -2,7 +2,6 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//nolint:goconst // don't care about repitition for tests
 package api
 
 // Test json encoding/decoding for all req/resp items

--- a/internal/pkg/api/openapi_spec_test.go
+++ b/internal/pkg/api/openapi_spec_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//nolint:dupl // don't care about repitition for tests
+//nolint:goconst // don't care about repitition for tests
 package api
 
 // Test json encoding/decoding for all req/resp items
@@ -190,6 +190,7 @@ func Test_UpgradeDetailsMetadata_Downloading(t *testing.T) {
 		md   *UpgradeDetails_Metadata
 		err  error
 		pct  float64
+		rate float64
 	}{{
 		name: "empty object",
 		md: &UpgradeDetails_Metadata{
@@ -200,10 +201,11 @@ func Test_UpgradeDetailsMetadata_Downloading(t *testing.T) {
 	}, {
 		name: "valid object",
 		md: &UpgradeDetails_Metadata{
-			union: json.RawMessage(`{"download_percent":1}`),
+			union: json.RawMessage(`{"download_percent":1,"download_rate":1000}`),
 		},
-		err: nil,
-		pct: 1,
+		err:  nil,
+		pct:  1,
+		rate: 1000,
 	}, {
 		name: "invalid object",
 		md: &UpgradeDetails_Metadata{
@@ -231,6 +233,9 @@ func Test_UpgradeDetailsMetadata_Downloading(t *testing.T) {
 			meta, err := tc.md.AsUpgradeMetadataDownloading()
 			if tc.err == nil {
 				assert.Equal(t, tc.pct, meta.DownloadPercent)
+				if meta.DownloadRate != nil {
+					assert.Equal(t, tc.rate, *meta.DownloadRate)
+				}
 			} else {
 				assert.ErrorAsf(t, err, &tc.err, "error is %v", err)
 			}

--- a/model/openapi.yml
+++ b/model/openapi.yml
@@ -283,6 +283,17 @@ components:
           description: The artifact download progress as a percentage.
           type: number
           format: double
+        download_rate:
+          description: The artifact download rate as bytes per second.
+          type: number
+          format: double 
+        retry_error_msg:
+          description: The error message that is a result of a retryable upgrade download failure.
+          type: string 
+        retry_until:
+          description: The RFC3339 timestamp of the deadline the upgrade download is retried until.
+          type: string
+          format: date-time  
     upgrade_metadata_failed:
       description: Upgrade metadata for an upgrade that has failed.
       required:
@@ -1301,6 +1312,7 @@ paths:
                     state: UPG_DOWNLOADING
                     metadata:
                       download_percent: 12.3
+                      download_rate: 1024
       responses:
         "200":
           description: Agent checkin successful. May include actions.

--- a/pkg/api/types.gen.go
+++ b/pkg/api/types.gen.go
@@ -704,6 +704,15 @@ type UpgradeDetailsState string
 type UpgradeMetadataDownloading struct {
 	// DownloadPercent The artifact download progress as a percentage.
 	DownloadPercent float64 `json:"download_percent"`
+
+	// DownloadRate The artifact download rate as bytes per second.
+	DownloadRate *float64 `json:"download_rate,omitempty"`
+
+	// RetryErrorMsg The error message that is a result of a retryable upgrade download failure.
+	RetryErrorMsg *string `json:"retry_error_msg,omitempty"`
+
+	// RetryUntil The RFC3339 timestamp of the deadline the upgrade download is retried until.
+	RetryUntil *time.Time `json:"retry_until,omitempty"`
 }
 
 // UpgradeMetadataFailed Upgrade metadata for an upgrade that has failed.


### PR DESCRIPTION
Backport https://github.com/elastic/fleet-server/pull/3177 to 8.12