### PR TITLE
Add mtls attributes to reference and unit tests

### DIFF
--- a/fleet-server.reference.yml
+++ b/fleet-server.reference.yml
@@ -30,6 +30,8 @@ output:
 #    ssl.enabled: true
 #    ssl.verification_mode: full
 #    ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+#    ssl.certificate: /creds/cert.pem  # optional mTLS keypair used to connect to Elasticsearch
+#    ssl.key: /creds/key.pem           # optional mTLS keypair used to connect to Elasticsearch
 #    ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 #    ssl.cipher_suites: []
 #    ssl.curve_types: []
@@ -93,9 +95,9 @@ fleet:
 #        supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 #        cipher_suites: []
 #        curve_types: []
-#        certificate_authorities: []
+#        certificate_authorities: []  # CA used to verify client certs
 #        ca_sha256: []
-#        client_authentication: none
+#        client_authentication: none # 'none', 'optional', or 'required'
 #        certificate: /creds/cert.pem
 #        key: /creds/key.pem
 #        key_passphrase_path: /creds/key.pem

--- a/internal/pkg/api/server_test.go
+++ b/internal/pkg/api/server_test.go
@@ -8,12 +8,19 @@ package api
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
+	"fmt"
 	"net/http"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/elastic/elastic-agent-client/v7/pkg/client"
+	libsconfig "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
+	"github.com/elastic/go-ucfg/yaml"
 	"github.com/stretchr/testify/require"
 
 	fbuild "github.com/elastic/fleet-server/v7/internal/pkg/build"
@@ -23,6 +30,7 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/monitor/mock"
 	"github.com/elastic/fleet-server/v7/internal/pkg/policy"
 	ftesting "github.com/elastic/fleet-server/v7/internal/pkg/testing"
+	"github.com/elastic/fleet-server/v7/internal/pkg/testing/certs"
 )
 
 func Test_server_Run(t *testing.T) {
@@ -54,7 +62,9 @@ func Test_server_Run(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		err = srv.Run(ctx)
+		if err := srv.Run(ctx); err != nil {
+			errCh <- err
+		}
 		wg.Done()
 	}()
 	var errFromChan error
@@ -70,4 +80,273 @@ func Test_server_Run(t *testing.T) {
 	if !errors.Is(err, http.ErrServerClosed) {
 		require.NoError(t, err)
 	}
+}
+
+var tlsCFGTempl = `
+enabled: true
+certificate_authorities: ["%s"]
+certificate: "%s"
+key: "%s"
+client_authentication: "optional"
+`
+
+func Test_server_ClientCert(t *testing.T) {
+	// prep self monitor mock for status endpoint
+	sm := mock.NewMockMonitor()
+	sm.On("State").Return(client.UnitStateHealthy)
+
+	// prep server tls config
+	ca := certs.GenCA(t)
+	caPath := certs.CertToFile(t, ca, "ca")
+	cert := certs.GenCert(t, ca)
+	certPath := certs.CertToFile(t, cert, "cert")
+	keyPath := certs.KeyToFile(t, cert, "key")
+
+	tlsYML := fmt.Sprintf(tlsCFGTempl,
+		caPath,
+		certPath,
+		keyPath,
+	)
+	ucfg, err := yaml.NewConfig([]byte(tlsYML))
+	require.NoError(t, err)
+	tlsCFG := &tlscommon.ServerConfig{}
+	err = tlsCFG.Unpack(libsconfig.C(*ucfg))
+	require.NoError(t, err)
+
+	t.Run("no client certs", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		port, err := ftesting.FreePort()
+		require.NoError(t, err)
+		cfg := &config.Server{}
+		cfg.InitDefaults()
+		cfg.Host = "localhost"
+		cfg.Port = port
+		addr := cfg.BindEndpoints()[0]
+		cfg.TLS = tlsCFG
+
+		st := NewStatusT(cfg, nil, nil)
+		srv := NewServer(addr, cfg, nil, nil, nil, nil, st, sm, fbuild.Info{}, nil, nil, nil, nil, nil)
+		errCh := make(chan error)
+
+		// make http client with no client certs
+		certPool := x509.NewCertPool()
+		certPool.AddCert(ca.Leaf)
+		httpClient := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs: certPool,
+				},
+			},
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			if err := srv.Run(ctx); err != nil {
+				errCh <- err
+			}
+			wg.Done()
+		}()
+
+		rCtx, rCancel := context.WithTimeout(ctx, time.Second)
+		defer rCancel()
+		req, err := http.NewRequestWithContext(rCtx, "GET", "https://"+addr+"/api/status", nil)
+		require.NoError(t, err)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		select {
+		case err := <-errCh:
+			require.NoError(t, err)
+		default:
+		}
+		cancel()
+		wg.Wait()
+	})
+
+	t.Run("valid client certs", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		port, err := ftesting.FreePort()
+		require.NoError(t, err)
+		cfg := &config.Server{}
+		cfg.InitDefaults()
+		cfg.Host = "localhost"
+		cfg.Port = port
+		addr := cfg.BindEndpoints()[0]
+		cfg.TLS = tlsCFG
+
+		st := NewStatusT(cfg, nil, nil)
+		srv := NewServer(addr, cfg, nil, nil, nil, nil, st, sm, fbuild.Info{}, nil, nil, nil, nil, nil)
+		errCh := make(chan error)
+
+		// make http client with valid client certs
+		clientCert := certs.GenCert(t, ca)
+		certPool := x509.NewCertPool()
+		certPool.AddCert(ca.Leaf)
+		httpClient := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs:      certPool,
+					Certificates: []tls.Certificate{clientCert},
+				},
+			},
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			if err := srv.Run(ctx); err != nil {
+				errCh <- err
+			}
+			wg.Done()
+		}()
+
+		rCtx, rCancel := context.WithTimeout(ctx, time.Second)
+		defer rCancel()
+		req, err := http.NewRequestWithContext(rCtx, "GET", "https://"+addr+"/api/status", nil)
+		require.NoError(t, err)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		select {
+		case err := <-errCh:
+			require.NoError(t, err)
+		default:
+		}
+		cancel()
+		wg.Wait()
+	})
+
+	t.Run("invalid client certs", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		port, err := ftesting.FreePort()
+		require.NoError(t, err)
+		cfg := &config.Server{}
+		cfg.InitDefaults()
+		cfg.Host = "localhost"
+		cfg.Port = port
+		addr := cfg.BindEndpoints()[0]
+		cfg.TLS = tlsCFG
+
+		st := NewStatusT(cfg, nil, nil)
+		srv := NewServer(addr, cfg, nil, nil, nil, nil, st, sm, fbuild.Info{}, nil, nil, nil, nil, nil)
+		errCh := make(chan error)
+
+		// make http client with invalid client certs
+		clientCA := certs.GenCA(t)
+		clientCert := certs.GenCert(t, clientCA)
+		certPool := x509.NewCertPool()
+		certPool.AddCert(ca.Leaf)
+		httpClient := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs:      certPool,
+					Certificates: []tls.Certificate{clientCert},
+				},
+			},
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			if err := srv.Run(ctx); err != nil {
+				errCh <- err
+			}
+			wg.Done()
+		}()
+
+		rCtx, rCancel := context.WithTimeout(ctx, time.Second)
+		defer rCancel()
+		req, err := http.NewRequestWithContext(rCtx, "GET", "https://"+addr+"/api/status", nil)
+		require.NoError(t, err)
+		_, err = httpClient.Do(req)
+		require.Error(t, err)
+
+		select {
+		case err := <-errCh:
+			require.NoError(t, err)
+		default:
+		}
+		cancel()
+		wg.Wait()
+	})
+
+	t.Run("valid client certs no certs requested", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		port, err := ftesting.FreePort()
+		require.NoError(t, err)
+		cfg := &config.Server{}
+		cfg.InitDefaults()
+		cfg.Host = "localhost"
+		cfg.Port = port
+		addr := cfg.BindEndpoints()[0]
+
+		// prep server config without specifing client_authentication
+		tlsYML := fmt.Sprintf(`
+enabled: true
+certificate: "%s"
+key: %s`,
+			certPath, keyPath)
+		ucfg, err := yaml.NewConfig([]byte(tlsYML))
+		require.NoError(t, err)
+		tlsCFG := &tlscommon.ServerConfig{}
+		err = tlsCFG.Unpack(libsconfig.C(*ucfg))
+		require.NoError(t, err)
+		cfg.TLS = tlsCFG
+
+		st := NewStatusT(cfg, nil, nil)
+		srv := NewServer(addr, cfg, nil, nil, nil, nil, st, sm, fbuild.Info{}, nil, nil, nil, nil, nil)
+		errCh := make(chan error)
+
+		// make http client with valid client certs
+		clientCert := certs.GenCert(t, ca)
+		certPool := x509.NewCertPool()
+		certPool.AddCert(ca.Leaf)
+		httpClient := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs:      certPool,
+					Certificates: []tls.Certificate{clientCert},
+				},
+			},
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			if err := srv.Run(ctx); err != nil {
+				errCh <- err
+			}
+			wg.Done()
+		}()
+
+		rCtx, rCancel := context.WithTimeout(ctx, time.Second)
+		defer rCancel()
+		req, err := http.NewRequestWithContext(rCtx, "GET", "https://"+addr+"/api/status", nil)
+		require.NoError(t, err)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		select {
+		case err := <-errCh:
+			require.NoError(t, err)
+		default:
+		}
+		cancel()
+		wg.Wait()
+	})
 }

--- a/internal/pkg/api/server_test.go
+++ b/internal/pkg/api/server_test.go
@@ -141,15 +141,18 @@ func Test_server_ClientCert(t *testing.T) {
 			},
 		}
 
+		started := make(chan struct{}, 1)
 		var wg sync.WaitGroup
 		wg.Add(1)
 		go func() {
+			started <- struct{}{}
 			if err := srv.Run(ctx); err != nil {
 				errCh <- err
 			}
 			wg.Done()
 		}()
 
+		<-started
 		rCtx, rCancel := context.WithTimeout(ctx, time.Second)
 		defer rCancel()
 		req, err := http.NewRequestWithContext(rCtx, "GET", "https://"+addr+"/api/status", nil)
@@ -198,15 +201,18 @@ func Test_server_ClientCert(t *testing.T) {
 			},
 		}
 
+		started := make(chan struct{}, 1)
 		var wg sync.WaitGroup
 		wg.Add(1)
 		go func() {
+			started <- struct{}{}
 			if err := srv.Run(ctx); err != nil {
 				errCh <- err
 			}
 			wg.Done()
 		}()
 
+		<-started
 		rCtx, rCancel := context.WithTimeout(ctx, time.Second)
 		defer rCancel()
 		req, err := http.NewRequestWithContext(rCtx, "GET", "https://"+addr+"/api/status", nil)
@@ -256,15 +262,18 @@ func Test_server_ClientCert(t *testing.T) {
 			},
 		}
 
+		started := make(chan struct{}, 1)
 		var wg sync.WaitGroup
 		wg.Add(1)
 		go func() {
+			started <- struct{}{}
 			if err := srv.Run(ctx); err != nil {
 				errCh <- err
 			}
 			wg.Done()
 		}()
 
+		<-started
 		rCtx, rCancel := context.WithTimeout(ctx, time.Second)
 		defer rCancel()
 		req, err := http.NewRequestWithContext(rCtx, "GET", "https://"+addr+"/api/status", nil)

--- a/internal/pkg/es/client_test.go
+++ b/internal/pkg/es/client_test.go
@@ -1,0 +1,161 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package es
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
+	"github.com/elastic/fleet-server/v7/internal/pkg/config"
+	"github.com/elastic/fleet-server/v7/internal/pkg/testing/certs"
+	"github.com/stretchr/testify/require"
+)
+
+var enabled bool = true
+
+func TestClientCerts(t *testing.T) {
+	t.Run("no certs", func(t *testing.T) {
+		ca := certs.GenCA(t)
+		server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Elastic-Product", "Elasticsearch")
+			fmt.Fprintln(w, "You know, For Search.")
+		}))
+		certPool := x509.NewCertPool()
+		certPool.AddCert(ca.Leaf)
+
+		// test server will verify a client cert if present
+		server.TLS = &tls.Config{
+			Certificates: []tls.Certificate{ca},
+			ClientAuth:   tls.VerifyClientCertIfGiven,
+			ClientCAs:    certPool,
+		}
+		server.StartTLS()
+		defer server.Close()
+
+		// client does not use client certs
+		client, err := NewClient(context.Background(), &config.Config{
+			Output: config.Output{
+				Elasticsearch: config.Elasticsearch{
+					Protocol: "https",
+					Hosts:    []string{server.URL},
+					TLS: &tlscommon.Config{
+						Enabled: &enabled,
+						CAs:     []string{certs.CertToFile(t, ca, "ca")},
+					},
+				},
+			},
+		}, false)
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(context.Background(), "GET", server.URL, nil)
+		require.NoError(t, err)
+
+		resp, err := client.Perform(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("uses certs", func(t *testing.T) {
+		ca := certs.GenCA(t)
+		server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Elastic-Product", "Elasticsearch")
+			fmt.Fprintln(w, "You know, For Search.")
+		}))
+		certPool := x509.NewCertPool()
+		certPool.AddCert(ca.Leaf)
+
+		// test server will verify a client cert if present
+		server.TLS = &tls.Config{
+			Certificates: []tls.Certificate{ca},
+			ClientAuth:   tls.VerifyClientCertIfGiven,
+			ClientCAs:    certPool,
+		}
+		server.StartTLS()
+		defer server.Close()
+
+		cert := certs.GenCert(t, ca)
+
+		// client uses valid, matching certs
+		client, err := NewClient(context.Background(), &config.Config{
+			Output: config.Output{
+				Elasticsearch: config.Elasticsearch{
+					Protocol: "https",
+					Hosts:    []string{server.URL},
+					TLS: &tlscommon.Config{
+						Enabled: &enabled,
+						CAs:     []string{certs.CertToFile(t, ca, "ca")},
+						Certificate: tlscommon.CertificateConfig{
+							Certificate: certs.CertToFile(t, cert, "cert"),
+							Key:         certs.KeyToFile(t, cert, "key"),
+						},
+					},
+				},
+			},
+		}, false)
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(context.Background(), "GET", server.URL, nil)
+		require.NoError(t, err)
+
+		resp, err := client.Perform(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("client cert does not match", func(t *testing.T) {
+		ca := certs.GenCA(t)
+		server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Elastic-Product", "Elasticsearch")
+			fmt.Fprintln(w, "You know, For Search.")
+		}))
+		certPool := x509.NewCertPool()
+		certPool.AddCert(ca.Leaf)
+
+		// test server will verify a client cert if present
+		server.TLS = &tls.Config{
+			Certificates: []tls.Certificate{ca},
+			ClientAuth:   tls.VerifyClientCertIfGiven,
+			ClientCAs:    certPool,
+		}
+		server.StartTLS()
+		defer server.Close()
+
+		certCA := certs.GenCA(t)
+		cert := certs.GenCert(t, certCA)
+
+		// client uses certs that are signed by a different CA
+		client, err := NewClient(context.Background(), &config.Config{
+			Output: config.Output{
+				Elasticsearch: config.Elasticsearch{
+					Protocol: "https",
+					Hosts:    []string{server.URL},
+					TLS: &tlscommon.Config{
+						Enabled: &enabled,
+						CAs:     []string{certs.CertToFile(t, ca, "ca")},
+						Certificate: tlscommon.CertificateConfig{
+							Certificate: certs.CertToFile(t, cert, "cert"),
+							Key:         certs.KeyToFile(t, cert, "key"),
+						},
+					},
+				},
+			},
+		}, false)
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(context.Background(), "GET", server.URL, nil)
+		require.NoError(t, err)
+
+		_, err = client.Perform(req)
+		require.Error(t, err)
+	})
+}

--- a/internal/pkg/es/client_test.go
+++ b/internal/pkg/es/client_test.go
@@ -36,6 +36,7 @@ func TestClientCerts(t *testing.T) {
 			Certificates: []tls.Certificate{ca},
 			ClientAuth:   tls.VerifyClientCertIfGiven,
 			ClientCAs:    certPool,
+			MinVersion:   tls.VersionTLS12,
 		}
 		server.StartTLS()
 		defer server.Close()
@@ -78,6 +79,7 @@ func TestClientCerts(t *testing.T) {
 			Certificates: []tls.Certificate{ca},
 			ClientAuth:   tls.VerifyClientCertIfGiven,
 			ClientCAs:    certPool,
+			MinVersion:   tls.VersionTLS12,
 		}
 		server.StartTLS()
 		defer server.Close()
@@ -126,6 +128,7 @@ func TestClientCerts(t *testing.T) {
 			Certificates: []tls.Certificate{ca},
 			ClientAuth:   tls.VerifyClientCertIfGiven,
 			ClientCAs:    certPool,
+			MinVersion:   tls.VersionTLS12,
 		}
 		server.StartTLS()
 		defer server.Close()
@@ -155,7 +158,7 @@ func TestClientCerts(t *testing.T) {
 		req, err := http.NewRequestWithContext(context.Background(), "GET", server.URL, nil)
 		require.NoError(t, err)
 
-		_, err = client.Perform(req)
+		_, err = client.Perform(req) //nolint:bodyclose // no response is expected
 		require.Error(t, err)
 	})
 }

--- a/internal/pkg/monitor/mock/monitor.go
+++ b/internal/pkg/monitor/mock/monitor.go
@@ -7,6 +7,7 @@ package mock
 import (
 	"context"
 
+	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"github.com/elastic/fleet-server/v7/internal/pkg/es"
 	"github.com/elastic/fleet-server/v7/internal/pkg/monitor"
 	"github.com/elastic/fleet-server/v7/internal/pkg/sqn"
@@ -71,4 +72,9 @@ func (m *MockMonitor) Output() <-chan []es.HitT {
 		return nil
 	}
 	return args.Get(0).(<-chan []es.HitT)
+}
+
+func (m *MockMonitor) State() client.UnitState {
+	args := m.Called()
+	return args.Get(0).(client.UnitState)
 }

--- a/internal/pkg/testing/certs/certs.go
+++ b/internal/pkg/testing/certs/certs.go
@@ -1,0 +1,166 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package certs
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func CertToFile(t *testing.T, cert tls.Certificate, name string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, name+".pem")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("unable to create file: %v", err)
+	}
+	if err := pem.Encode(file, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]}); err != nil {
+		t.Fatalf("unable to write cert: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("unable to close file: %v", err)
+	}
+
+	return path
+}
+
+func KeyToFile(t *testing.T, cert tls.Certificate, name string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, name+".pem")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("unable to create file: %v", err)
+	}
+	p, err := x509.MarshalPKCS8PrivateKey(cert.PrivateKey)
+	if err != nil {
+		t.Fatalf("unable to marshal private key: %v", err)
+	}
+	if err := pem.Encode(file, &pem.Block{Type: "PRIVATE KEY", Bytes: p}); err != nil {
+		t.Fatalf("unable to write key: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("unable to close file: %v", err)
+	}
+
+	return path
+}
+
+// GenCA generates a CA for tests
+// copied from elastic-agent-libs/transport/tlscommon/ca_pinning_test.go
+func GenCA(t *testing.T) tls.Certificate {
+	t.Helper()
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(2000),
+		Subject: pkix.Name{
+			CommonName:    "localhost",
+			Organization:  []string{"TESTING"},
+			Country:       []string{"CANADA"},
+			Province:      []string{"QUEBEC"},
+			Locality:      []string{"MONTREAL"},
+			StreetAddress: []string{"testing road"},
+			PostalCode:    []string{"HOH OHO"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048) // less secure key for quicker testing.
+	if err != nil {
+		t.Fatalf("fail to generate RSA key: %v", err)
+	}
+
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("fail to create certificate: %v", err)
+	}
+
+	leaf, err := x509.ParseCertificate(caBytes)
+	if err != nil {
+		t.Fatalf("fail to parse certificate: %v", err)
+	}
+
+	return tls.Certificate{
+		Certificate: [][]byte{caBytes},
+		PrivateKey:  caKey,
+		Leaf:        leaf,
+	}
+}
+
+// GenCert generates a test keypair and signs the cert with the passed CA.
+// copied from elastic-agent-libs/transport/tlscommon/ca_pinning_test.go
+func GenCert(t *testing.T, ca tls.Certificate) tls.Certificate {
+	t.Helper()
+	ts := time.Now().UTC()
+
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(2000),
+
+		// Subject Alternative Name fields
+		IPAddresses: []net.IP{{127, 0, 0, 1}, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
+		DNSNames:    []string{"localhost"},
+
+		Subject: pkix.Name{
+			CommonName:    "fleet-server testing",
+			Organization:  []string{"TESTING"},
+			Country:       []string{"CANADA"},
+			Province:      []string{"QUEBEC"},
+			Locality:      []string{"MONTREAL"},
+			StreetAddress: []string{"testing road"},
+			PostalCode:    []string{"HOH OHO"},
+		},
+
+		NotBefore:             ts,
+		NotAfter:              ts.Add(24 * time.Hour),
+		IsCA:                  false,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		BasicConstraintsValid: true,
+	}
+
+	certKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("fail to generate RSA key: %v", err)
+	}
+
+	certBytes, err := x509.CreateCertificate(
+		rand.Reader,
+		cert,
+		ca.Leaf,
+		&certKey.PublicKey,
+		ca.PrivateKey,
+	)
+	if err != nil {
+		t.Fatalf("fail to create signed certificate: %v", err)
+	}
+
+	leaf, err := x509.ParseCertificate(certBytes)
+	if err != nil {
+		t.Fatalf("fail to parse the certificate: %v", err)
+	}
+
+	return tls.Certificate{
+		Certificate: [][]byte{certBytes},
+		PrivateKey:  certKey,
+		Leaf:        leaf,
+	}
+}

--- a/internal/pkg/testing/certs/certs.go
+++ b/internal/pkg/testing/certs/certs.go
@@ -19,11 +19,13 @@ import (
 	"time"
 )
 
+const ext = ".pem"
+
 func CertToFile(t *testing.T, cert tls.Certificate, name string) string {
 	t.Helper()
 
 	dir := t.TempDir()
-	path := filepath.Join(dir, name+".pem")
+	path := filepath.Join(dir, name+ext)
 	file, err := os.Create(path)
 	if err != nil {
 		t.Fatalf("unable to create file: %v", err)
@@ -42,7 +44,7 @@ func KeyToFile(t *testing.T, cert tls.Certificate, name string) string {
 	t.Helper()
 
 	dir := t.TempDir()
-	path := filepath.Join(dir, name+".pem")
+	path := filepath.Join(dir, name+ext)
 	file, err := os.Create(path)
 	if err != nil {
 		t.Fatalf("unable to create file: %v", err)


### PR DESCRIPTION
## What is the problem this PR solves?

unit tests for mTLS support.

## How does this PR solve the problem?

Add the mTLS attributes that fleet-server can use to connect to Elasticsearch, and that clients can use to connect to fleet-server in the fleet-server.reference.yml doc. Add unit tests to ensure that mTLS works as expected in the internal es and api packages.