### PR TITLE
fix multiple secret ref replace

### DIFF
--- a/internal/pkg/policy/secret_test.go
+++ b/internal/pkg/policy/secret_test.go
@@ -42,6 +42,23 @@ func TestReplaceStringRefPartial2(t *testing.T) {
 	assert.Equal(t, "http://localhost/services", val)
 }
 
+func TestReplaceStringRefMultiple(t *testing.T) {
+	secretRefs := map[string]string{
+		"secret1": "value1",
+		"secret2": "value2",
+	}
+	val := replaceStringRef("partial \"$co.elastic.secret{secret1}\" \"$co.elastic.secret{secret2}\"", secretRefs)
+	assert.Equal(t, "partial \"value1\" \"value2\"", val)
+}
+
+func TestReplaceStringRefMultipleOneNotFound(t *testing.T) {
+	secretRefs := map[string]string{
+		"secret2": "value2",
+	}
+	val := replaceStringRef("partial \"$co.elastic.secret{secret1}\" \"$co.elastic.secret{secret2}\"", secretRefs)
+	assert.Equal(t, "partial \"$co.elastic.secret{secret1}\" \"$co.elastic.secret{secret2}\"", val)
+}
+
 func TestReplaceStringRefNotASecret(t *testing.T) {
 	secretRefs := map[string]string{
 		"abcd": "value1",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

// Please do not just reference an issue. Explain WHAT the problem this PR solves here.

Fix issue with package policy secrets not being replaced properly when multiple secrets were in a variable.

## How does this PR solve the problem?

// Explain HOW you solved the problem in your code. It is possible that during PR reviews this changes and then this section should be updated.

Improved replace logic to replace all secret refs in a variable value.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

- Build akamai package with enabling secrets from here: https://github.com/elastic/integrations/pull/8725/files [akamai-2.22.0.zip](https://github.com/elastic/fleet-server/files/13840673/akamai-2.22.0.zip)
- upload package to local kibana
```
curl -XPOST -H 'content-type: application/zip' -H 'kbn-xsrf: true' http://localhost:5601/api/fleet/epm/packages -u elastic:changeme --data-binary @akamai-2.22.0.zip
```
- add Akamai integration to a new agent policy and populate secrets with dummy values
- enroll an agent to this agent policy
- download agent diagnostics, check the `computed-config.yml` file
- verify that the secret refs are replaced  in `header.XSignatureBase`

See the fixed value (before the fix: right, after the fix: left):
<img width="1485" alt="image" src="https://github.com/elastic/fleet-server/assets/90178898/24830755-def6-453a-8b6d-2599f0509c08">

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
Relates https://github.com/elastic/integrations/issues/8610
