### PR TITLE
[Fleet] Ignore not yet created .fleet-policies index

### DIFF
--- a/internal/pkg/bulk/bulk_integration_test.go
+++ b/internal/pkg/bulk/bulk_integration_test.go
@@ -282,6 +282,29 @@ func TestBulkSearch(t *testing.T) {
 	}
 }
 
+func TestBulkSearchWithIgnoreUnavailable(t *testing.T) {
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+	ctx = testlog.SetLogger(t).WithContext(ctx)
+
+	_, bulker := SetupIndexWithBulk(ctx, t, testPolicy)
+
+	// Search
+	dsl := fmt.Sprintf(`{"query": { "term": {"kwval": "%s"}}}`, "random")
+
+	res, err := bulker.Search(ctx, ".fleet-policies-do-not-exists-yet", []byte(dsl), WithIgnoreUnavailble())
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Hits) != 0 {
+		t.Fatalf("hit mismatch: %d", len(res.Hits))
+	}
+	if res == nil {
+		t.Fatal(nil)
+	}
+}
+
 func TestBulkDelete(t *testing.T) {
 	ctx, cn := context.WithCancel(context.Background())
 	defer cn()

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -24,6 +24,7 @@ type optionsT struct {
 	RetryOnConflict    string
 	Indices            []string
 	WaitForCheckpoints []int64
+	IgnoreUnavailable  bool
 	spanLink           *apm.SpanLink
 }
 
@@ -32,6 +33,12 @@ type Opt func(*optionsT)
 func WithRefresh() Opt {
 	return func(opt *optionsT) {
 		opt.Refresh = true
+	}
+}
+
+func WithIgnoreUnavailble() Opt {
+	return func(opt *optionsT) {
+		opt.IgnoreUnavailable = true
 	}
 }
 

--- a/internal/pkg/dl/policies.go
+++ b/internal/pkg/dl/policies.go
@@ -39,14 +39,15 @@ func prepareQueryLatestPolicies() []byte {
 // QueryLatestPolicies gets the latest revision for a policy
 func QueryLatestPolicies(ctx context.Context, bulker bulk.Bulk, opt ...Option) ([]model.Policy, error) {
 	o := newOption(FleetPolicies, opt...)
-	res, err := bulker.Search(ctx, o.indexName, tmplQueryLatestPolicies)
+	res, err := bulker.Search(ctx, o.indexName, tmplQueryLatestPolicies, bulk.WithIgnoreUnavailble())
 	if err != nil {
 		return nil, err
 	}
 
 	policyID, ok := res.Aggregations[FieldPolicyID]
 	if !ok {
-		return nil, ErrMissingAggregations
+		// Aggregation will not be here if there index is not available
+		return []model.Policy{}, nil
 	}
 	if len(policyID.Buckets) == 0 {
 		return []model.Policy{}, nil


### PR DESCRIPTION
## Description 

Ignore not yet created .fleet-policies index to avoid returning 500 when that index do not exists yet.

## How to tests

run a fleet server with `.fleet-policies` not yet created and static tokens 
```
inputs:
  - type: fleet-server
    policy.id: "${FLEET_SERVER_POLICY_ID:fleet-server-policy}"
    server:
      static_policy_tokens:
        enabled: true
        policy_tokens:
          - policy_id: 901b70f0-fefa-11ed-aa5e-5974b0535e80
            token_key: abcdefg
```

Try to enroll an agent  it should return a 400 instead of a 500 previously

```
curl --request POST \
  --url http://localhost:8220/api/fleet/agents/enroll \
  --header 'Authorization: ApiKey MDEyMzQ6YWJjZGVmZw==' \
  --header 'Content-Type: application/json' \
  --header 'User-Agent: elastic agent 8.9.0' \
  --header 'kbn-xsrf: xx' \
  --data '{
  "type": "PERMANENT",
  "metadata": {
    "local": {
      "host": {
        "hostname": "TEST"
      },
      "elastic": {
        "agent": {
          "version": "8.6.0",
          "upgradeable": true
        }
      }
    }
  }
}'
```


