### PR TITLE
Ignore DNSErrors caused by context cancelation in tests

### DIFF
--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"path"
@@ -87,6 +88,17 @@ func (s *tserver) waitExit() error {
 	if errors.Is(err, context.Canceled) {
 		return nil
 	}
+
+	// FIXME: Below is a work around to net.DNSError not supporting the `Unwrap` method.
+	// It is so we can ignore errors caused by context cancelation.
+	// It can be removed when DNSError.Unwrap is added to the stdlib.
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		if strings.Contains(dnsErr.Err, "operation was canceled") {
+			return nil
+		}
+	}
+
 	return err
 }
 


### PR DESCRIPTION
## What is the problem this PR solves?

Fix flaky instrumentation test

## How does this PR solve the problem?

Ignore DNSErrors caused by context cancelation.
DNSError does not (currently) support the `Unwrap` method so a manual workaround is needed.

## Related issues

- Closes #3219 