### PR TITLE
Add e2e test for timeout and 429 on startup

### DIFF
--- a/testing/e2e/statusProxy.go
+++ b/testing/e2e/statusProxy.go
@@ -1,0 +1,73 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"testing"
+)
+
+type statusProxy struct {
+	t       testing.TB
+	enabled *atomic.Bool
+	status  int
+}
+
+// Create a new Status Proxy
+// If the proxy is enabled, the passed status is returned for all requiests
+// If it's disabled requests are made to upstream instead.
+func NewStatusProxy(t testing.TB, status int) *statusProxy {
+	t.Helper()
+	s := &statusProxy{
+		t:       t,
+		enabled: new(atomic.Bool),
+		status:  status,
+	}
+	return s
+}
+
+func (s *statusProxy) Enable() {
+	s.enabled.Store(true)
+}
+
+func (s *statusProxy) Disable() {
+	s.enabled.Store(false)
+}
+
+func (s *statusProxy) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
+	if s.enabled.Load() {
+		wr.WriteHeader(s.status)
+		return
+	}
+	req.RequestURI = ""
+
+	if cIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
+		req.Header.Set("X-Forwarded-For", cIP)
+	}
+
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		s.t.Fatal(err)
+		return
+	}
+	defer resp.Body.Close()
+	for name, values := range resp.Header {
+		for _, value := range values {
+			wr.Header().Add(name, value)
+		}
+	}
+	wr.WriteHeader(resp.StatusCode)
+	io.Copy(wr, resp.Body)
+}

--- a/testing/e2e/testdata/stand-alone-http-proxy.tpl
+++ b/testing/e2e/testdata/stand-alone-http-proxy.tpl
@@ -1,0 +1,13 @@
+output:
+  elasticsearch:
+    hosts: {{ .Hosts }}
+    service_token: {{ .ServiceToken }}
+    proxy_url: {{ .Proxy }}
+
+fleet.agent.id: e2e-test-id
+
+inputs:
+- type: fleet-server
+
+logging:
+  to_stderr: true


### PR DESCRIPTION
## What is the problem this PR solves?

We have observed the fleet-server crashing if a 429 is returned when fleet-server initializes.

## How does this PR solve the problem?

Add e2e tests to for this behaviour to ensure no regressions occur.

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)~~

## Related issues

- Closes #3205 