### PR TITLE
Stricter validation for required checkin API attributes

### DIFF
--- a/changelog/fragments/1705963635-Stricter-validation-for-required-checkin-API-attributes.yaml
+++ b/changelog/fragments/1705963635-Stricter-validation-for-required-checkin-API-attributes.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Stricter validation for required checkin API attributes
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 2420

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -181,6 +181,13 @@ func (ct *CheckinT) validateRequest(zlog zerolog.Logger, w http.ResponseWriter, 
 	}
 	cntCheckin.bodyIn.Add(readCounter.Count())
 
+	if req.Status == CheckinRequestStatus("") {
+		return val, fmt.Errorf("checkin status missing")
+	}
+	if len(req.Message) == 0 {
+		return val, fmt.Errorf("checkin message missing")
+	}
+
 	var pDur time.Duration
 	var err error
 	if req.PollTimeout != nil {

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -185,7 +185,7 @@ func (ct *CheckinT) validateRequest(zlog zerolog.Logger, w http.ResponseWriter, 
 		return val, fmt.Errorf("checkin status missing")
 	}
 	if len(req.Message) == 0 {
-		return val, fmt.Errorf("checkin message missing")
+		zlog.Warn().Msg("checkin request method is empty.")
 	}
 
 	var pDur time.Duration

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -61,7 +61,7 @@ const (
 	}`
 	checkinBody = `{
 	    "status": "online",
-	    "message": ""
+	    "message": "checkin ok"
 	}`
 )
 
@@ -1131,7 +1131,7 @@ func Test_SmokeTest_CheckinPollTimeout(t *testing.T) {
 	req, err = http.NewRequestWithContext(ctx, "POST", srv.baseURL()+"/api/fleet/agents/"+agentID+"/checkin", strings.NewReader(fmt.Sprintf(`{
 	    "ack_token": "%s",
 	    "status": "online",
-	    "message": "",
+	    "message": "checkin ok",
 	    "poll_timeout": "3m"
 	}`, *checkinResponse.AckToken)))
 	require.NoError(t, err)
@@ -1159,7 +1159,7 @@ func Test_SmokeTest_CheckinPollTimeout(t *testing.T) {
 	req, err = http.NewRequestWithContext(ctx, "POST", srv.baseURL()+"/api/fleet/agents/"+agentID+"/checkin", strings.NewReader(fmt.Sprintf(`{
 	    "ack_token": "%s",
 	    "status": "online",
-	    "message": "",
+	    "message": "checkin ok",
 	    "poll_timeout": "10m"
 	}`, *checkinResponse.AckToken)))
 	require.NoError(t, err)
@@ -1262,7 +1262,7 @@ func Test_SmokeTest_CheckinPollShutdown(t *testing.T) {
 	req, err = http.NewRequest("POST", srv.baseURL()+"/api/fleet/agents/"+agentID+"/checkin", strings.NewReader(fmt.Sprintf(`{
 	    "ack_token": "%s",
 	    "status": "online",
-	    "message": "",
+	    "message": "checkin ok",
 	    "poll_timeout": "3m"
 	}`, *checkinResponse.AckToken)))
 	require.NoError(t, err)

--- a/testing/e2e/api_version/client_api_2023_06_01.go
+++ b/testing/e2e/api_version/client_api_2023_06_01.go
@@ -124,6 +124,7 @@ func (tester *ClientAPITester20230601) Checkin(ctx context.Context, apiKey, agen
 		&api.AgentCheckinParams{UserAgent: "elastic agent " + version.DefaultVersion},
 		api.AgentCheckinJSONRequestBody{
 			Status:      api.CheckinRequestStatusOnline,
+			Message:     "test checkin",
 			AckToken:    ackToken,
 			PollTimeout: dur,
 		},

--- a/testing/e2e/api_version/client_api_current.go
+++ b/testing/e2e/api_version/client_api_current.go
@@ -110,6 +110,7 @@ func (tester *ClientAPITester) Checkin(ctx context.Context, apiKey, agentID stri
 		&api.AgentCheckinParams{UserAgent: "elastic agent " + version.DefaultVersion},
 		api.AgentCheckinJSONRequestBody{
 			Status:      api.CheckinRequestStatusOnline,
+			Message:     "test checkin",
 			AckToken:    ackToken,
 			PollTimeout: dur,
 		},


### PR DESCRIPTION
## What is the problem this PR solves?

Checkin endpoint does not check for required attributes

## How does this PR solve the problem?

Add validation to make sure that status and message are present in the checkin request body.

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Closes #2420 