### PR TITLE
Change response codes for elasticsearch failures to 503

### DIFF
--- a/changelog/fragments/1706127160-Change-response-codes-for-elasticsearch-failures-to-503.yaml
+++ b/changelog/fragments/1706127160-Change-response-codes-for-elasticsearch-failures-to-503.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Change response codes for elasticsearch failures to 503
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 2852

--- a/internal/pkg/api/error.go
+++ b/internal/pkg/api/error.go
@@ -484,6 +484,16 @@ func NewHTTPErrResp(err error) HTTPErrResp {
 		}
 	}
 
+	var esErr *es.ErrElastic
+	if errors.As(err, &esErr) {
+		return HTTPErrResp{
+			http.StatusServiceUnavailable,
+			esErr.Error(),
+			"elasticsearch error",
+			zerolog.ErrorLevel,
+		}
+	}
+
 	// Check if we have encountered a connectivity error
 	// Predicate taken from https://github.com/golang/go/blob/go1.17.5/src/net/dial_test.go#L798
 	if strings.Contains(err.Error(), "connection refused") {

--- a/internal/pkg/api/error_test.go
+++ b/internal/pkg/api/error_test.go
@@ -92,3 +92,32 @@ func Test_ErrorResp_NoTransaction(t *testing.T) {
 	require.Len(t, payloads.Transactions, 0)
 	require.Len(t, payloads.Errors, 0)
 }
+
+func Test_ErrResp_Status(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		status int
+	}{{
+		name:   "context canceled",
+		err:    context.Canceled,
+		status: 499,
+	}, {
+		name:   "generic error",
+		err:    fmt.Errorf("some error"),
+		status: 500,
+	}, {
+		name: "es error",
+		err: &es.ErrElastic{
+			Status: 500,
+		},
+		status: 503,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewHTTPErrResp(tc.err)
+			require.Equal(t, tc.status, r.StatusCode)
+		})
+	}
+}


### PR DESCRIPTION
## What is the problem this PR solves?

fleet-server returns a 500 if a call to elasticsearch fails

## How does this PR solve the problem?

Change returned status code to 503 to indicate a temporary problem.

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Closes #2852 