### PR TITLE
remove io.ReadAll from bulker and API endpoints

### DIFF
--- a/internal/pkg/api/handleAck.go
+++ b/internal/pkg/api/handleAck.go
@@ -10,12 +10,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/miolini/datacounter"
 	"github.com/rs/zerolog"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
@@ -149,20 +149,17 @@ func (ack *AckT) validateRequest(zlog zerolog.Logger, w http.ResponseWriter, r *
 	if ack.cfg.Limits.AckLimit.MaxBody > 0 {
 		body = http.MaxBytesReader(w, body, ack.cfg.Limits.AckLimit.MaxBody)
 	}
-
-	raw, err := io.ReadAll(body)
-	if err != nil {
-		return nil, fmt.Errorf("handleAcks read body: %w", err)
-	}
-
-	cntAcks.bodyIn.Add(uint64(len(raw)))
+	readCounter := datacounter.NewReaderCounter(body)
 
 	var req AckRequest
-	if err := json.Unmarshal(raw, &req); err != nil {
-		return nil, fmt.Errorf("handleAcks unmarshal: %w", err)
+	dec := json.NewDecoder(readCounter)
+	if err := dec.Decode(&req); err != nil {
+		return nil, fmt.Errorf("unable to decode ack request: %w", err)
 	}
-	zlog.Trace().RawJSON("raw", raw).Msg("Ack request")
-	return &req, err
+
+	cntAcks.bodyIn.Add(readCounter.Count())
+	zlog.Trace().Msg("Ack request")
+	return &req, nil
 }
 
 func eventToActionResult(agentID, aType string, ev AckRequest_Events_Item) (acr model.ActionResult) {

--- a/internal/pkg/api/handlePGPRequest.go
+++ b/internal/pkg/api/handlePGPRequest.go
@@ -5,6 +5,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -143,7 +144,9 @@ func (pt *PGPRetrieverT) getPGPFromUpstream(ctx context.Context) ([]byte, error)
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%w: %d", ErrUpstreamStatus, resp.StatusCode)
 	}
-	return io.ReadAll(resp.Body)
+	var b bytes.Buffer
+	_, err = io.Copy(&b, resp.Body)
+	return b.Bytes(), err
 }
 
 // writeKeyToDir will write the specified key to the keys directory

--- a/internal/pkg/bulk/helpers.go
+++ b/internal/pkg/bulk/helpers.go
@@ -5,6 +5,7 @@
 package bulk
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 
@@ -41,11 +42,12 @@ func parseError(res *esapi.Response, log *zerolog.Logger) error {
 
 	if err := decoder.Decode(&e); err != nil {
 		log.Error().Err(err).Msg("Cannot decode Elasticsearch error body")
-		bodyBytes, readErr := io.ReadAll(res.Body)
+		var b bytes.Buffer
+		_, readErr := io.Copy(&b, res.Body)
 		if readErr != nil {
 			log.Debug().Err(readErr).Msg("Error reading error response body from Elasticsearch")
 		} else {
-			log.Debug().Err(err).Bytes("body", bodyBytes).Msg("Error content")
+			log.Debug().Err(err).Bytes("body", b.Bytes()).Msg("Error content")
 		}
 
 		return err


### PR DESCRIPTION
Use io.Copy  or a json decoder instead of io.ReadAll on bulker/API.
Copying to a bytes.Buffer results in fewer allocations then ReadAll.
