### PR TITLE
[Release] Update version to 7.17.19

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/build"
 )
 
-const defaultVersion = "7.17.18"
+const defaultVersion = "7.17.19"
 
 var (
 	Version   string = defaultVersion


### PR DESCRIPTION
Updates references to the new release 7.17.19.

Merge after the release 7.17.18.