### PR TITLE
fix process upgrade details when null

### DIFF
--- a/changelog/fragments/1707481003-fix-upgraded-at.yaml
+++ b/changelog/fragments/1707481003-fix-upgraded-at.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fixed a bug where agents were stuck in non-upgradeable state after upgrade.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+# description: 
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 3264
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 3263

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -381,7 +381,7 @@ func (ct *CheckinT) ProcessRequest(zlog zerolog.Logger, w http.ResponseWriter, r
 func (ct *CheckinT) processUpgradeDetails(ctx context.Context, agent *model.Agent, details *UpgradeDetails) error {
 	if details == nil {
 		// nop if there are no checkin details, and the agent has no details
-		if len(agent.UpgradeDetails) == 0 {
+		if agent.UpgradeDetails == nil || string(agent.UpgradeDetails) == "null" {
 			return nil
 		}
 		span, ctx := apm.StartSpan(ctx, "Mark update complete", "update")

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -381,7 +381,7 @@ func (ct *CheckinT) ProcessRequest(zlog zerolog.Logger, w http.ResponseWriter, r
 func (ct *CheckinT) processUpgradeDetails(ctx context.Context, agent *model.Agent, details *UpgradeDetails) error {
 	if details == nil {
 		// nop if there are no checkin details, and the agent has no details
-		if agent.UpgradeDetails == nil || string(agent.UpgradeDetails) == "null" {
+		if agent.UpgradeDetails == nil {
 			return nil
 		}
 		span, ctx := apm.StartSpan(ctx, "Mark update complete", "update")

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -326,7 +326,7 @@ func TestProcessUpgradeDetails(t *testing.T) {
 		err: nil,
 	}, {
 		name:    "agent has null details checkin details are nil",
-		agent:   &model.Agent{ESDocument: esd, Agent: &model.AgentMetadata{ID: "test-agent"}, UpgradeDetails: json.RawMessage(nil), UpgradedAt: "2024-01-02T12:00:00Z"},
+		agent:   &model.Agent{ESDocument: esd, Agent: &model.AgentMetadata{ID: "test-agent"}, UpgradeDetails: json.RawMessage("null"), UpgradedAt: "2024-01-02T12:00:00Z"},
 		details: nil,
 		bulk: func() *ftesting.MockBulk {
 			return ftesting.NewMockBulk()

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -325,6 +325,17 @@ func TestProcessUpgradeDetails(t *testing.T) {
 		},
 		err: nil,
 	}, {
+		name:    "agent has null details checkin details are nil",
+		agent:   &model.Agent{ESDocument: esd, Agent: &model.AgentMetadata{ID: "test-agent"}, UpgradeDetails: json.RawMessage(nil), UpgradedAt: "2024-01-02T12:00:00Z"},
+		details: nil,
+		bulk: func() *ftesting.MockBulk {
+			return ftesting.NewMockBulk()
+		},
+		cache: func() *testcache.MockCache {
+			return testcache.NewMockCache()
+		},
+		err: nil,
+	}, {
 		name:    "upgrade requested action in cache",
 		agent:   &model.Agent{ESDocument: esd, Agent: &model.AgentMetadata{ID: "test-agent"}},
 		details: &UpgradeDetails{ActionId: "test-action", State: UpgradeDetailsStateUPGREQUESTED},

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -304,7 +304,7 @@ func TestProcessUpgradeDetails(t *testing.T) {
 		err: nil,
 	}, {
 		name:    "agent has details checkin details are nil",
-		agent:   &model.Agent{ESDocument: esd, Agent: &model.AgentMetadata{ID: "test-agent"}, UpgradeDetails: json.RawMessage(`{"action_id":"test"}`)},
+		agent:   &model.Agent{ESDocument: esd, Agent: &model.AgentMetadata{ID: "test-agent"}, UpgradeDetails: &model.UpgradeDetails{}},
 		details: nil,
 		bulk: func() *ftesting.MockBulk {
 			mBulk := ftesting.NewMockBulk()
@@ -319,17 +319,6 @@ func TestProcessUpgradeDetails(t *testing.T) {
 				return doc.Doc[dl.FieldUpgradeDetails] == nil && doc.Doc[dl.FieldUpgradeStartedAt] == nil && doc.Doc[dl.FieldUpgradeStatus] == nil && doc.Doc[dl.FieldUpgradedAt] != ""
 			}), mock.Anything, mock.Anything).Return(nil)
 			return mBulk
-		},
-		cache: func() *testcache.MockCache {
-			return testcache.NewMockCache()
-		},
-		err: nil,
-	}, {
-		name:    "agent has null details checkin details are nil",
-		agent:   &model.Agent{ESDocument: esd, Agent: &model.AgentMetadata{ID: "test-agent"}, UpgradeDetails: json.RawMessage("null"), UpgradedAt: "2024-01-02T12:00:00Z"},
-		details: nil,
-		bulk: func() *ftesting.MockBulk {
-			return ftesting.NewMockBulk()
 		},
 		cache: func() *testcache.MockCache {
 			return testcache.NewMockCache()

--- a/internal/pkg/model/schema.go
+++ b/internal/pkg/model/schema.go
@@ -196,7 +196,7 @@ type Agent struct {
 	UpdatedAt string `json:"updated_at,omitempty"`
 
 	// Additional upgrade status details.
-	UpgradeDetails json.RawMessage `json:"upgrade_details,omitempty"`
+	UpgradeDetails *UpgradeDetails `json:"upgrade_details,omitempty"`
 
 	// Date/time the Elastic Agent started the current upgrade
 	UpgradeStartedAt string `json:"upgrade_started_at,omitempty"`
@@ -496,4 +496,8 @@ type ToRetireAPIKeyIdsItems struct {
 
 	// Date/time the API key was retired
 	RetiredAt string `json:"retired_at,omitempty"`
+}
+
+// UpgradeDetails Additional upgrade status details.
+type UpgradeDetails struct {
 }

--- a/model/schema.json
+++ b/model/schema.json
@@ -628,7 +628,7 @@
         },
         "upgrade_details": {
             "description": "Additional upgrade status details.",
-            "format": "raw"
+            "type": "object"
         }
       },
       "required": [


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

Agent was never upgradeable again after an upgrade to 8.12.0

## How does this PR solve the problem?

When `upgrade_details: null` comes from the agent doc, the logic incorrectly supposed it has a value, and set `upgraded_at: now`. This resulted the agent never being upgradeable again on the UI (as it is not allowed to upgrade again within 10 minutes of an upgrade).
Upgraded the schema, so that the `null` value is correctly translated to `nil`, and the condition in `handleCheckin` can check for `nil`.

## How to test this PR locally

- Start a stack at least 8.12.1 or latest.
- enroll an agent 8.11.4 or older
- upgrade to 8.12.0
- wait 10 minutes so that the watcher period ends
- expect the agent to be upgradeable again to 8.12.1

<img width="1532" alt="image" src="https://github.com/elastic/fleet-server/assets/90178898/bbd012ad-4833-485a-9913-b0cfb2d0c2b3">

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
Closes https://github.com/elastic/fleet-server/issues/3263