### PR TITLE
Pass logger to mtls server in tests

### DIFF
--- a/internal/pkg/api/server_test.go
+++ b/internal/pkg/api/server_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/policy"
 	ftesting "github.com/elastic/fleet-server/v7/internal/pkg/testing"
 	"github.com/elastic/fleet-server/v7/internal/pkg/testing/certs"
+	testlog "github.com/elastic/fleet-server/v7/internal/pkg/testing/log"
 )
 
 func Test_server_Run(t *testing.T) {
@@ -116,6 +117,7 @@ func Test_server_ClientCert(t *testing.T) {
 	t.Run("no client certs", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		ctx = testlog.SetLogger(t).WithContext(ctx)
 
 		port, err := ftesting.FreePort()
 		require.NoError(t, err)
@@ -174,6 +176,7 @@ func Test_server_ClientCert(t *testing.T) {
 	t.Run("valid client certs", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		ctx = testlog.SetLogger(t).WithContext(ctx)
 
 		port, err := ftesting.FreePort()
 		require.NoError(t, err)
@@ -234,6 +237,7 @@ func Test_server_ClientCert(t *testing.T) {
 	t.Run("invalid client certs", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		ctx = testlog.SetLogger(t).WithContext(ctx)
 
 		port, err := ftesting.FreePort()
 		require.NoError(t, err)
@@ -293,6 +297,7 @@ func Test_server_ClientCert(t *testing.T) {
 	t.Run("valid client certs no certs requested", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		ctx = testlog.SetLogger(t).WithContext(ctx)
 
 		port, err := ftesting.FreePort()
 		require.NoError(t, err)


### PR DESCRIPTION
Pass a test logger with the context used in the mtls unit tests.

Tests are flakey more logs would be useful to debug

## Related issues

- Relates #3266 