### PR TITLE
Add optional subscription channel size

### DIFF
--- a/internal/pkg/monitor/mock/monitor.go
+++ b/internal/pkg/monitor/mock/monitor.go
@@ -41,7 +41,7 @@ func NewMockMonitor() *MockMonitor {
 	return &MockMonitor{}
 }
 
-func (m *MockMonitor) Subscribe() monitor.Subscription {
+func (m *MockMonitor) Subscribe(opts ...monitor.SubOption) monitor.Subscription {
 	args := m.Called()
 	if args.Get(0) == nil {
 		return nil

--- a/internal/pkg/monitor/subscription_monitor_test.go
+++ b/internal/pkg/monitor/subscription_monitor_test.go
@@ -1,0 +1,49 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package monitor
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubscribeChSize(t *testing.T) {
+	tests := []struct {
+		i   int
+		exp int
+	}{{
+		i:   -1,
+		exp: 1,
+	}, {
+		i:   0,
+		exp: 1,
+	}, {
+		i:   1,
+		exp: 1,
+	}, {
+		i:   2,
+		exp: 2,
+	}}
+
+	sm := monitorT{
+		subs:       make(map[uint64]*subT, 0),
+		subTimeout: time.Second,
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("size %d", tc.i), func(t *testing.T) {
+			s := sm.Subscribe(ChSize(tc.i))
+			defer sm.Unsubscribe(s)
+			sub, ok := s.(*subT)
+			require.True(t, ok, "expected s to be a *subT")
+
+			assert.Equal(t, tc.exp, cap(sub.c), "channel capacity does not match expected value")
+		})
+	}
+}


### PR DESCRIPTION
## What is the problem this PR solves?

Daily 10k scale tests seems to still be flakey on the multiple policy change test.
This is meant as another simple solution before we try to add early cancelations to dispatching policy changes.

## How does this PR solve the problem?

Add an optional arg when subscribing to a subscription monitor to specify the channel size. Min val of 1 is enforced. Use in policy monitor to allow more buffered changes to be queued as mutex might be help and block other dispatches.

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

- Relates #3254 