### PR TITLE
Revert "Replace policy and action limiters with a checkin limiter"

### DIFF
--- a/changelog/fragments/1702940211-Replace-policy-throttle-with-limiter.yaml
+++ b/changelog/fragments/1702940211-Replace-policy-throttle-with-limiter.yaml
@@ -11,17 +11,16 @@
 kind: enhancement
 
 # Change summary; a 80ish characters long description of the change.
-summary: Move action limiter to checkin response writer
+summary: Replace policy throttle with limiter
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.
 # NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
 description: |
-  Remove the policy_limiter that was added by 3008 and not released.
-  Move the action limiter to the checkin handler's write response method before a gzip.Writer is retrieved from the pool or allocated.
-  This allows fleet-server to control gzip.Writer access for responses that contain either actions from the action dispatcher, or a
-  POLICY_CHANGE action from the policy monitor.
-  Removing the throttle/limiter from the policy monitor also greatly improves performance of policy dispatches.
+  Replace the existing policy_throttle setting with a policy_limit
+  setting that controls the same thing, how fast policies are passed to
+  subscriptions to control mass responses. If no policy_limit settings
+  are specified the policy_throttle is used with burst 1.
 
 # Affected component; a word indicating the component this changeset affects.
 component:
@@ -30,8 +29,8 @@ component:
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-pr: 3255
+#pr: https://github.com/owner/repo/1234
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.
-issue: 3254
+issue: 3008

--- a/fleet-server.reference.yml
+++ b/fleet-server.reference.yml
@@ -145,14 +145,14 @@ fleet:
 #       # If specified a set of other limits is automatically loaded.
 #       max_agents: 0
 #       # policy_throttle is the duration that the fleet-server will wait in between attempts to dispatch policy updates to polling agents
-#       # deprecated: replaced by action_limit settings
-#       policy_throttle: 5ms
+#       # deprecated: replaced by policy_limit settings
+#       policy_throttle: 5ms # 1ms min is forced
 #       # max_header_byte_size is the request header size limit
 #       max_header_byte_size: 8192 # 8Kib
 #       # max_connections is the maximum number of connnections per API endpoint
 #       max_connections: 0
 #
-#       # action_limit is a limiter for checkin responses that contain actions
+#       # action_limit is a limiter for the action dispatcher, it is added to control how fast the checkin endpoint writes responses when an action effecting multiple agents is detected.
 #       # This is done in order to be able to reuse gzip writers if gzip is requested as allocating new writers is expensive (around 1.2MB for a new allocation).
 #       # If the interval is too high it may negativly effect assumtions around server write timeouts and poll poll durations, if used we expect the value to be around 5ms.
 #       # An interval value of 0 disables the limiter by using an infinite rate limit (default behavior).
@@ -160,6 +160,16 @@ fleet:
 #       action_limit:
 #         interval: 0
 #         burst: 5
+#
+#       # policy_limit is a limiter used to control how fast fleet-server sends POLICY_CHANGE actions to agents.
+#       # As with the action_limit settings this is done to avoid allocating a lot of gzip writers.
+#       # The default settings are to have the interval of 5ms with a burst of 1.
+#       # A min burst value of 1 is always enforced.
+#       # If no interval is specified, the policy_throttle may be used as the interval instead.
+#       # if both interval and policy_throttle are 0, a value of 1ns is used instead.
+#       policy_limit:
+#         interval: 5ms
+#         burst: 1
 #
 #       # endpoint specific limits below
 #       checkin_limit:

--- a/internal/pkg/action/dispatcher.go
+++ b/internal/pkg/action/dispatcher.go
@@ -17,6 +17,7 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/sqn"
 
 	"github.com/rs/zerolog"
+	"golang.org/x/time/rate"
 )
 
 // Sub is an action subscription that will give a single agent all of it's actions.
@@ -33,17 +34,23 @@ func (s Sub) Ch() chan []model.Action {
 
 // Dispatcher tracks agent subscriptions and emits actions to the subscriptions.
 type Dispatcher struct {
-	am monitor.SimpleMonitor
+	am    monitor.SimpleMonitor
+	limit *rate.Limiter
 
 	mx   sync.RWMutex
 	subs map[string]Sub
 }
 
 // NewDispatcher creates a Dispatcher using the provided monitor.
-func NewDispatcher(am monitor.SimpleMonitor) *Dispatcher {
+func NewDispatcher(am monitor.SimpleMonitor, throttle time.Duration, i int) *Dispatcher {
+	r := rate.Inf
+	if throttle > 0 {
+		r = rate.Every(throttle)
+	}
 	return &Dispatcher{
-		am:   am,
-		subs: make(map[string]Sub),
+		am:    am,
+		limit: rate.NewLimiter(r, i),
+		subs:  make(map[string]Sub),
 	}
 }
 
@@ -122,6 +129,10 @@ func (d *Dispatcher) process(ctx context.Context, hits []es.HitT) {
 	}
 
 	for agentID, actions := range agentActions {
+		if err := d.limit.Wait(ctx); err != nil {
+			zerolog.Ctx(ctx).Error().Err(err).Msg("action dispatcher rate limit error")
+			return
+		}
 		d.dispatch(ctx, agentID, actions)
 	}
 }

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -34,7 +34,6 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/miolini/datacounter"
 	"github.com/rs/zerolog"
-	"golang.org/x/time/rate"
 
 	"go.elastic.co/apm/module/apmhttp/v2"
 	"go.elastic.co/apm/v2"
@@ -77,7 +76,6 @@ type CheckinT struct {
 	// gwPool is a gzip.Writer pool intended to lower the amount of writers created when responding to checkin requests.
 	// gzip.Writer allocations are expensive (~1.2MB each) and can exhaust an instance's memory if a lot of concurrent responses are sent (this occurs when a mass-action such as an upgrade is detected).
 	// effectiveness of the pool is controlled by rate limiter configured through the limit.action_limit attribute.
-	limit  *rate.Limiter
 	gwPool sync.Pool
 	bulker bulk.Bulk
 }
@@ -93,13 +91,6 @@ func NewCheckinT(
 	tr *action.TokenResolver,
 	bulker bulk.Bulk,
 ) *CheckinT {
-	rt := rate.Every(cfg.Limits.ActionLimit.Interval)
-	if cfg.Limits.ActionLimit.Interval == 0 && cfg.Limits.PolicyThrottle != 0 {
-		rt = rate.Every(cfg.Limits.PolicyThrottle)
-	} else if cfg.Limits.ActionLimit.Interval == 0 && cfg.Limits.PolicyThrottle == 0 {
-		rt = rate.Inf
-	}
-	zerolog.Ctx(context.TODO()).Debug().Any("event_rate", rt).Int("burst", cfg.Limits.ActionLimit.Burst).Msg("checkin response gzip limiter")
 	ct := &CheckinT{
 		verCon: verCon,
 		cfg:    cfg,
@@ -109,7 +100,6 @@ func NewCheckinT(
 		gcp:    gcp,
 		ad:     ad,
 		tr:     tr,
-		limit:  rate.NewLimiter(rt, cfg.Limits.ActionLimit.Burst),
 		gwPool: sync.Pool{
 			New: func() any {
 				zipper, err := gzip.NewWriterLevel(io.Discard, cfg.CompressionLevel)
@@ -567,17 +557,7 @@ func (ct *CheckinT) writeResponse(zlog zerolog.Logger, w http.ResponseWriter, r 
 	compressionLevel := ct.cfg.CompressionLevel
 	compressThreshold := ct.cfg.CompressionThresh
 
-	if (len(fromPtr(resp.Actions)) > 0 || len(payload) > compressThreshold) && compressionLevel != flate.NoCompression && acceptsEncoding(r, kEncodingGzip) {
-		// We compress the response if it would be over the threshold (default 1kb) or we are sending an action.
-		// gzip.Writer allocations are expensive, and we can easily hit an OOM issue if we try to write a large number of responses at once.
-		// This is likely to happen on bulk upgrades, or policy changes.
-		// In order to avoid a massive memory allocation we do two things:
-		// 1. re-use gzip.Writer instances across responses (through a pool)
-		// 2. rate-limit access to the writer pool
-		if err := ct.limit.Wait(ctx); err != nil {
-			return fmt.Errorf("checkin response limiter error: %w", err)
-		}
-
+	if len(payload) > compressThreshold && compressionLevel != flate.NoCompression && acceptsEncoding(r, kEncodingGzip) {
 		wrCounter := datacounter.NewWriterCounter(w)
 
 		zipper, _ := ct.gwPool.Get().(*gzip.Writer)

--- a/internal/pkg/api/server_test.go
+++ b/internal/pkg/api/server_test.go
@@ -51,7 +51,7 @@ func Test_server_Run(t *testing.T) {
 	require.NoError(t, err)
 	bulker := ftesting.NewMockBulk()
 	pim := mock.NewMockMonitor()
-	pm := policy.NewMonitor(bulker, pim)
+	pm := policy.NewMonitor(bulker, pim, config.ServerLimits{PolicyLimit: config.Limit{Interval: 5 * time.Millisecond, Burst: 1}})
 	bc := checkin.NewBulk(nil)
 	ct := NewCheckinT(verCon, cfg, c, bc, pm, nil, nil, nil, nil)
 	et, err := NewEnrollerT(verCon, cfg, nil, c)

--- a/internal/pkg/config/defaults/lte10000_limits.yml
+++ b/internal/pkg/config/defaults/lte10000_limits.yml
@@ -9,7 +9,10 @@ server_limits:
   max_connections: 22000
   action_limit:
     interval: 1ms
-    burst: 100
+    burst: 10
+  policy_interval:
+    interval: 5ms
+    burst: 1
   checkin_limit:
     interval: 1ms
     burst: 2000

--- a/internal/pkg/config/defaults/lte20000_limits.yml
+++ b/internal/pkg/config/defaults/lte20000_limits.yml
@@ -10,6 +10,9 @@ server_limits:
   action_limit:
     interval: 1ms
     burst: 100
+  policy_limit:
+    interval: 5ms
+    burst: 1
   checkin_limit:
     interval: 0.5ms
     burst: 4000

--- a/internal/pkg/config/defaults/lte2500_limite.yml
+++ b/internal/pkg/config/defaults/lte2500_limite.yml
@@ -9,7 +9,10 @@ server_limits:
   max_connections: 7000
   action_limit:
     interval: 5ms
-    burst: 20
+    burst: 1
+  policy_limit:
+    interval: 5ms
+    burst: 1
   checkin_limit:
     interval: 5ms
     burst: 500

--- a/internal/pkg/config/defaults/lte40000_limits.yml
+++ b/internal/pkg/config/defaults/lte40000_limits.yml
@@ -8,7 +8,10 @@ cache_limits:
 server_limits:
   action_limit:
     interval: 0.5ms
-    burst: 200
+    burst: 100
+  policy_limit:
+    interval: 2ms
+    burst: 1
   checkin_limit:
     interval: 0.5ms
     burst: 4000

--- a/internal/pkg/config/defaults/lte5000_limits.yml
+++ b/internal/pkg/config/defaults/lte5000_limits.yml
@@ -10,6 +10,9 @@ server_limits:
   action_limit:
     interval: 5ms
     burst: 5
+  policy_limit:
+    interval: 5ms
+    burst: 1
   checkin_limit:
     interval: 2ms
     burst: 1000

--- a/internal/pkg/config/defaults/max_limits.yml
+++ b/internal/pkg/config/defaults/max_limits.yml
@@ -7,7 +7,10 @@ cache_limits:
 server_limits:
   action_limit:
     interval: 0.25ms
-    burst: 1000
+    burst: 100
+  policy_limit:
+    interval: 0.25ms
+    burst: 1
   checkin_limit:
     interval: 0.25ms
     burst: 8000

--- a/internal/pkg/config/env_defaults.go
+++ b/internal/pkg/config/env_defaults.go
@@ -26,8 +26,11 @@ const (
 
 	defaultMaxConnections = 0 // no limit
 
-	defaultActionInterval = 0 // no limit
+	defaultActionInterval = 0 // no throttle
 	defaultActionBurst    = 5
+
+	defaultPolicyInterval = time.Millisecond * 5
+	defaultPolicyBurst    = 1 // NOTE: burst 1 keeps the same behaviour as the previous throttle
 
 	defaultCheckinInterval = time.Millisecond
 	defaultCheckinBurst    = 1000
@@ -133,10 +136,11 @@ type limit struct {
 }
 
 type serverLimitDefaults struct {
-	PolicyThrottle time.Duration `config:"policy_throttle"` // deprecated: replaced by action_limit
+	PolicyThrottle time.Duration `config:"policy_throttle"` // deprecated: replaced by policy_limit
 	MaxConnections int           `config:"max_connections"`
 
 	ActionLimit      limit `config:"action_limit"`
+	PolicyLimit      limit `config:"policy_limit"`
 	CheckinLimit     limit `config:"checkin_limit"`
 	ArtifactLimit    limit `config:"artifact_limit"`
 	EnrollLimit      limit `config:"enroll_limit"`
@@ -155,6 +159,10 @@ func defaultserverLimitDefaults() *serverLimitDefaults {
 		ActionLimit: limit{
 			Interval: defaultActionInterval,
 			Burst:    defaultActionBurst,
+		},
+		PolicyLimit: limit{
+			Interval: defaultPolicyInterval,
+			Burst:    defaultPolicyBurst,
 		},
 		CheckinLimit: limit{
 			Interval: defaultCheckinInterval,

--- a/internal/pkg/config/limits.go
+++ b/internal/pkg/config/limits.go
@@ -17,11 +17,12 @@ type Limit struct {
 
 type ServerLimits struct {
 	MaxAgents         int           `config:"max_agents"`
-	PolicyThrottle    time.Duration `config:"policy_throttle"` // deprecated: replaced by action_limit
+	PolicyThrottle    time.Duration `config:"policy_throttle"` // deprecated: replaced by policy_limit
 	MaxHeaderByteSize int           `config:"max_header_byte_size"`
 	MaxConnections    int           `config:"max_connections"`
 
 	ActionLimit      Limit `config:"action_limit"`
+	PolicyLimit      Limit `config:"policy_limit"`
 	CheckinLimit     Limit `config:"checkin_limit"`
 	ArtifactLimit    Limit `config:"artifact_limit"`
 	EnrollLimit      Limit `config:"enroll_limit"`
@@ -51,6 +52,7 @@ func (c *ServerLimits) LoadLimits(limits *envLimits) {
 	}
 
 	c.ActionLimit = mergeEnvLimit(c.ActionLimit, l.ActionLimit)
+	c.PolicyLimit = mergeEnvLimit(c.PolicyLimit, l.PolicyLimit)
 	c.CheckinLimit = mergeEnvLimit(c.CheckinLimit, l.CheckinLimit)
 	c.ArtifactLimit = mergeEnvLimit(c.ArtifactLimit, l.ArtifactLimit)
 	c.EnrollLimit = mergeEnvLimit(c.EnrollLimit, l.EnrollLimit)

--- a/internal/pkg/policy/monitor_integration_test.go
+++ b/internal/pkg/policy/monitor_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/fleet-server/v7/internal/pkg/config"
 	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
 	"github.com/elastic/fleet-server/v7/internal/pkg/model"
 	"github.com/elastic/fleet-server/v7/internal/pkg/monitor"
@@ -56,7 +57,7 @@ func TestMonitor_Integration(t *testing.T) {
 		}
 	}()
 
-	m := NewMonitor(bulker, im)
+	m := NewMonitor(bulker, im, config.ServerLimits{})
 	pm, ok := m.(*monitorT)
 	if !ok {
 		t.Fatalf("unable to cast monitor m (type %T) as *monitorT", m)
@@ -153,7 +154,7 @@ func TestMonitor_Debounce_Integration(t *testing.T) {
 		}
 	}()
 
-	m := NewMonitor(bulker, im)
+	m := NewMonitor(bulker, im, config.ServerLimits{})
 	pm, ok := m.(*monitorT)
 	if !ok {
 		t.Fatalf("unable to cast monitor m (type %T) as *monitorT", m)
@@ -345,7 +346,7 @@ func TestMonitor_Revisions(t *testing.T) {
 		}
 	}()
 
-	m := NewMonitor(bulker, im)
+	m := NewMonitor(bulker, im, config.ServerLimits{})
 	pm, ok := m.(*monitorT)
 	if !ok {
 		t.Fatalf("unable to cast monitor m (type %T) as *monitorT", m)
@@ -469,7 +470,7 @@ func TestMonitor_KickDeploy(t *testing.T) {
 		}
 	}()
 
-	m := NewMonitor(bulker, im)
+	m := NewMonitor(bulker, im, config.ServerLimits{})
 	pm, ok := m.(*monitorT)
 	if !ok {
 		t.Fatalf("unable to cast monitor m (type %T) as *monitorT", m)

--- a/internal/pkg/policy/monitor_test.go
+++ b/internal/pkg/policy/monitor_test.go
@@ -16,10 +16,13 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/google/go-cmp/cmp"
 	"github.com/rs/xid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
+	"github.com/elastic/fleet-server/v7/internal/pkg/config"
 	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
 	"github.com/elastic/fleet-server/v7/internal/pkg/es"
 	"github.com/elastic/fleet-server/v7/internal/pkg/model"
@@ -36,6 +39,41 @@ var policyDataDefault = &model.PolicyData{
 	},
 }
 
+func TestNewMonitor(t *testing.T) {
+	tests := []struct {
+		name  string
+		cfg   config.ServerLimits
+		burst int
+		rate  float64
+	}{{
+		name:  "no settings",
+		cfg:   config.ServerLimits{},
+		burst: 1,
+		rate:  float64(rate.Every(time.Nanosecond)),
+	}, {
+		name:  "limit specified",
+		cfg:   config.ServerLimits{PolicyLimit: config.Limit{Burst: 2, Interval: time.Second}},
+		burst: 2,
+		rate:  1,
+	}, {
+		name:  "no limit",
+		cfg:   config.ServerLimits{PolicyThrottle: time.Second},
+		burst: 1,
+		rate:  1,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			M := NewMonitor(nil, nil, tc.cfg)
+			m, ok := M.(*monitorT)
+			require.True(t, ok, "Expected to be able to cast Monitor as monitorT")
+			assert.Equal(t, tc.burst, m.limit.Burst())
+			assert.Equal(t, tc.rate, float64(m.limit.Limit()))
+
+		})
+	}
+}
+
 func TestMonitor_NewPolicy(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -50,7 +88,7 @@ func TestMonitor_NewPolicy(t *testing.T) {
 	mm.On("Unsubscribe", mock.Anything).Return().Once()
 	bulker := ftesting.NewMockBulk()
 
-	monitor := NewMonitor(bulker, mm)
+	monitor := NewMonitor(bulker, mm, config.ServerLimits{})
 	pm := monitor.(*monitorT)
 	pm.policyF = func(ctx context.Context, bulker bulk.Bulk, opt ...dl.Option) ([]model.Policy, error) {
 		return []model.Policy{}, nil
@@ -130,7 +168,7 @@ func TestMonitor_SamePolicy(t *testing.T) {
 	mm.On("Unsubscribe", mock.Anything).Return().Once()
 	bulker := ftesting.NewMockBulk()
 
-	monitor := NewMonitor(bulker, mm)
+	monitor := NewMonitor(bulker, mm, config.ServerLimits{})
 	pm := monitor.(*monitorT)
 	pm.policyF = func(ctx context.Context, bulker bulk.Bulk, opt ...dl.Option) ([]model.Policy, error) {
 		return []model.Policy{}, nil
@@ -208,7 +246,7 @@ func TestMonitor_NewPolicyUncoordinated(t *testing.T) {
 	mm.On("Unsubscribe", mock.Anything).Return().Once()
 	bulker := ftesting.NewMockBulk()
 
-	monitor := NewMonitor(bulker, mm)
+	monitor := NewMonitor(bulker, mm, config.ServerLimits{})
 	pm := monitor.(*monitorT)
 	pm.policyF = func(ctx context.Context, bulker bulk.Bulk, opt ...dl.Option) ([]model.Policy, error) {
 		return []model.Policy{}, nil
@@ -306,7 +344,7 @@ func runTestMonitor_NewPolicyExists(t *testing.T, delay time.Duration) {
 	mm.On("Unsubscribe", mock.Anything).Return().Once()
 	bulker := ftesting.NewMockBulk()
 
-	monitor := NewMonitor(bulker, mm)
+	monitor := NewMonitor(bulker, mm, config.ServerLimits{})
 	pm := monitor.(*monitorT)
 
 	agentId := uuid.Must(uuid.NewV4()).String()
@@ -361,4 +399,132 @@ func runTestMonitor_NewPolicyExists(t *testing.T, delay time.Duration) {
 		t.Fatal(merr)
 	}
 	require.False(t, timedout, "never got policy update; timed out after 500ms")
+}
+
+func Test_Monitor_Limit_Delay(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = testlog.SetLogger(t).WithContext(ctx)
+
+	chHitT := make(chan []es.HitT, 1)
+	defer close(chHitT)
+	ms := mmock.NewMockSubscription()
+	ms.On("Output").Return((<-chan []es.HitT)(chHitT))
+	mm := mmock.NewMockMonitor()
+	mm.On("Subscribe").Return(ms).Once()
+	mm.On("Unsubscribe", mock.Anything).Return().Once()
+	bulker := ftesting.NewMockBulk()
+
+	monitor := NewMonitor(bulker, mm, config.ServerLimits{PolicyLimit: config.Limit{Burst: 1, Interval: time.Millisecond * 50}})
+	pm := monitor.(*monitorT)
+	pm.policyF = func(ctx context.Context, bulker bulk.Bulk, opt ...dl.Option) ([]model.Policy, error) {
+		return []model.Policy{}, nil
+	}
+
+	var merr error
+	var mwg sync.WaitGroup
+	mwg.Add(1)
+	go func() {
+		defer mwg.Done()
+		merr = monitor.Run(ctx)
+	}()
+
+	err := monitor.(*monitorT).waitStart(ctx)
+	require.NoError(t, err)
+
+	agentId := uuid.Must(uuid.NewV4()).String()
+	policyID := uuid.Must(uuid.NewV4()).String()
+	s, err := monitor.Subscribe(agentId, policyID, 0, 0)
+	defer monitor.Unsubscribe(s)
+	require.NoError(t, err)
+
+	agentId = uuid.Must(uuid.NewV4()).String()
+	policyID2 := uuid.Must(uuid.NewV4()).String()
+	s2, err := monitor.Subscribe(agentId, policyID, 0, 0)
+	defer monitor.Unsubscribe(s2)
+	require.NoError(t, err)
+
+	rId := xid.New().String()
+	policy := model.Policy{
+		ESDocument: model.ESDocument{
+			Id:      rId,
+			Version: 1,
+			SeqNo:   1,
+		},
+		PolicyID:       policyID,
+		CoordinatorIdx: 1,
+		Data:           policyDataDefault,
+		RevisionIdx:    1,
+	}
+	policyData, err := json.Marshal(&policy)
+	require.NoError(t, err)
+
+	chHitT <- []es.HitT{{
+		ID:      rId,
+		SeqNo:   1,
+		Version: 1,
+		Source:  policyData,
+	}}
+
+	policy2 := model.Policy{
+		ESDocument: model.ESDocument{
+			Id:      rId,
+			Version: 1,
+			SeqNo:   1,
+		},
+		PolicyID:       policyID2,
+		CoordinatorIdx: 1,
+		Data:           policyDataDefault,
+		RevisionIdx:    1,
+	}
+	policyData, err = json.Marshal(&policy2)
+	require.NoError(t, err)
+	chHitT <- []es.HitT{{
+		ID:      rId,
+		SeqNo:   1,
+		Version: 1,
+		Source:  policyData,
+	}}
+
+	timedout := false
+	tm := time.NewTimer(2 * time.Second)
+	var ts1, ts2 time.Time
+LOOP:
+	for {
+		select {
+		case subPolicy := <-s.Output():
+			ts1 = time.Now().UTC()
+			if !ts2.IsZero() {
+				tm.Stop()
+				break LOOP
+			}
+			diff := cmp.Diff(policy, subPolicy.Policy)
+			require.Empty(t, diff)
+		case subPolicy := <-s2.Output():
+			ts2 = time.Now().UTC()
+			if !ts1.IsZero() {
+				tm.Stop()
+				break LOOP
+			}
+			diff := cmp.Diff(policy2, subPolicy.Policy)
+			require.Empty(t, diff)
+		case <-tm.C:
+			timedout = true
+			break LOOP
+		}
+	}
+
+	cancel()
+	mwg.Wait()
+	if merr != nil && merr != context.Canceled {
+		t.Fatal(merr)
+	}
+	require.False(t, timedout, "never got policy update; timed out after 2s")
+	d := ts2.Sub(ts1)
+	if ts1.After(ts2) {
+		d *= -1
+	}
+	assert.LessOrEqual(t, 45*time.Millisecond, d) // use 45ms instead of 50ms because we are testing buffered channel output here, not dispatch from the run loop which means we are measuring something that may be smaller then the delay
+	ms.AssertExpectations(t)
+	mm.AssertExpectations(t)
 }

--- a/internal/pkg/server/fleet.go
+++ b/internal/pkg/server/fleet.go
@@ -481,7 +481,7 @@ func (f *Fleet) runSubsystems(ctx context.Context, cfg *config.Config, g *errgro
 	g.Go(loggedRunFunc(ctx, "Coordinator policy monitor", cord.Run))
 
 	// Policy monitor
-	pm := policy.NewMonitor(bulker, pim)
+	pm := policy.NewMonitor(bulker, pim, cfg.Inputs[0].Server.Limits)
 	g.Go(loggedRunFunc(ctx, "Policy monitor", pm.Run))
 
 	// Policy self monitor
@@ -509,7 +509,7 @@ func (f *Fleet) runSubsystems(ctx context.Context, cfg *config.Config, g *errgro
 	}
 	g.Go(loggedRunFunc(ctx, "Action monitor", am.Run))
 
-	ad = action.NewDispatcher(am)
+	ad = action.NewDispatcher(am, cfg.Inputs[0].Server.Limits.ActionLimit.Interval, cfg.Inputs[0].Server.Limits.ActionLimit.Burst)
 	g.Go(loggedRunFunc(ctx, "Action dispatcher", ad.Run))
 	tr, err = action.NewTokenResolver(bulker)
 	if err != nil {


### PR DESCRIPTION
Reverts elastic/fleet-server#3255

Unified limiter is causing OOM issues in serverless pods during scale testing (upgrade actions)