### PR TITLE
Consume APMConfig from input units in agent mode

### DIFF
--- a/changelog/fragments/1707852625-Prefer-elastic-agent-client-APMConfig-in-agent-mode.yaml
+++ b/changelog/fragments/1707852625-Prefer-elastic-agent-client-APMConfig-in-agent-mode.yaml
@@ -1,0 +1,36 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Prefer elastic-agent-client APMConfig in agent mode
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  While running in agent-mode fleet-server will use the APMConfig
+  settings of expected input if it's set over the settings in
+  inputs[0].server.instrumentation; this should make it easier for
+  managing agents to inject APM config data.
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 2868

--- a/changelog/fragments/1707852625-Prefer-elastic-agent-client-APMConfig-in-agent-mode.yaml
+++ b/changelog/fragments/1707852625-Prefer-elastic-agent-client-APMConfig-in-agent-mode.yaml
@@ -29,7 +29,7 @@ component:
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-#pr: https://github.com/owner/repo/1234
+pr: 3277
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.

--- a/internal/pkg/server/agent.go
+++ b/internal/pkg/server/agent.go
@@ -470,5 +470,5 @@ func apmConfigToInstrumentation(src *proto.APMConfig) (config.Instrumentation, e
 		}
 		return cfg, nil
 	}
-	return config.Instrumentation{}, fmt.Errorf("unable to transform APMConfig to instrumentatiopn")
+	return config.Instrumentation{}, fmt.Errorf("unable to transform APMConfig to instrumentation")
 }


### PR DESCRIPTION
## What is the problem this PR solves?

elastic-agent-client is now able to send APMConfig settings separately from expected config (similar to how the log level can be separated), but fleet-server is unable to use these settings.

## How does this PR solve the problem?

Consume and prefer APMConfig from the expected input component while operating in agent mode over config in inputs[0].server.instrumentation.

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Closes #2868 