### PR TITLE
Disable all e2e tests that require elastic-agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,7 @@ e2e-docker-stop: ## - Tear down testing Elasticsearch and Kibana instances
 	@$(MAKE) int-docker-stop
 
 .PHONY: test-e2e
-test-e2e: docker-cover-e2e-binaries build-e2e-agent-image e2e-certs build-docker ## - Setup and run the blackbox end to end test suite
+test-e2e: docker-cover-e2e-binaries e2e-certs build-docker ## - Setup and run the blackbox end to end test suite
 	@mkdir -p build/e2e-cover
 	@$(MAKE) e2e-docker-start
 	@set -o pipefail; $(MAKE) test-e2e-set | tee build/test-e2e.out
@@ -381,7 +381,7 @@ test-e2e-set: ## - Run the blackbox end to end tests without setup.
 	AGENT_E2E_IMAGE=$(shell cat "build/e2e-image") \
 	STANDALONE_E2E_IMAGE=$(DOCKER_IMAGE):$(DOCKER_IMAGE_TAG)$(if $(DEV),-dev,) \
 	CGO_ENABLED=1 \
-	go test -v -timeout 30m -tags=e2e -count=1 -race -p 1 ./... -run StandAlone
+	go test -v -timeout 30m -tags=e2e -count=1 -race -p 1 ./...
 
 ##################################################
 # Cloud testing targets

--- a/dev-tools/cloud/Makefile
+++ b/dev-tools/cloud/Makefile
@@ -33,7 +33,7 @@ cloud-deploy: build-and-push-cloud-image  ## Create a new cloud deployment
 
 .PHONY: cloud-clean
 cloud-clean: ## Clean cloud deployment
-	@cd ${TERRAFORM_PATH}; terraform destroy -auto-approve
+	@cd ${TERRAFORM_PATH}; terraform destroy -auto-approve -var="elastic_agent_docker_image=${CI_ELASTIC_AGENT_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG}"
 
 .PHONY: cloud-get-fleet-url
 cloud-get-fleet-url:  ## Get Fleet URL from this deployment

--- a/dev-tools/cloud/Makefile
+++ b/dev-tools/cloud/Makefile
@@ -33,7 +33,7 @@ cloud-deploy: build-and-push-cloud-image  ## Create a new cloud deployment
 
 .PHONY: cloud-clean
 cloud-clean: ## Clean cloud deployment
-	@cd ${TERRAFORM_PATH}; terraform destroy -auto-approve -var="elastic_agent_docker_image=${CI_ELASTIC_AGENT_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG}"
+	@cd ${TERRAFORM_PATH}; terraform destroy -auto-approve
 
 .PHONY: cloud-get-fleet-url
 cloud-get-fleet-url:  ## Get Fleet URL from this deployment

--- a/dev-tools/cloud/launch_cloud_e2e_tests.sh
+++ b/dev-tools/cloud/launch_cloud_e2e_tests.sh
@@ -7,9 +7,12 @@ CLOUD_TESTING_BASE="$(dirname $0)"
 cleanup() {
   r=$?
 
-  echo "--- Cleaning deployment"
-  make -C "${CLOUD_TESTING_BASE}" cloud-clean
-
+  if [ -f ${CLOUD_TESTING_BASE}/terraform/.terraform.lock.hcl ] ; then
+    echo "--- Cleaning deployment"
+    make -C "${CLOUD_TESTING_BASE}" cloud-clean
+  else
+      echo "+++ Skipped cleaning deployment, no terraform files"
+  fi
   exit $r
 }
 trap cleanup EXIT INT TERM

--- a/dev-tools/cloud/launch_cloud_e2e_tests.sh
+++ b/dev-tools/cloud/launch_cloud_e2e_tests.sh
@@ -11,7 +11,7 @@ cleanup() {
     echo "--- Cleaning deployment"
     make -C "${CLOUD_TESTING_BASE}" cloud-clean
   else
-      echo "+++ Skipped cleaning deployment, no terraform files"
+      echo "Skipped cleaning deployment, no Terraform files"
   fi
   exit $r
 }

--- a/testing/e2e/agent_container_test.go
+++ b/testing/e2e/agent_container_test.go
@@ -2,7 +2,10 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build e2e
+// FIXME(ml): test suite is disabled by additional build flag.
+//     we do not want to rely on agent builds in our pipeline.
+
+//go:build e2e && ignore
 
 package e2e
 
@@ -19,15 +22,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/testcontainers/testcontainers-go"
 )
-
-type logger struct {
-	*testing.T
-}
-
-func (l *logger) Printf(format string, v ...interface{}) {
-	l.Helper()
-	l.Logf(format, v...)
-}
 
 type AgentContainerSuite struct {
 	scaffold.Scaffold

--- a/testing/e2e/agent_install_test.go
+++ b/testing/e2e/agent_install_test.go
@@ -3,9 +3,7 @@
 // you may not use this file except in compliance with the Elastic License.
 
 // FIXME(ml): test suite is disabled by additional build flag.
-//     I've had issues getting the test to run in Jenkins (lack of tty).
-//     And there also seem to be issues with uninstalling the agent after each test when running in a VM.
-//     We should fix this once we have migrated to buildkite.
+//     we do not want to rely on agent builds in our pipeline.
 
 //go:build e2e && ignore
 

--- a/testing/e2e/e2e_test.go
+++ b/testing/e2e/e2e_test.go
@@ -16,6 +16,15 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
+type logger struct {
+	*testing.T
+}
+
+func (l *logger) Printf(format string, v ...interface{}) {
+	l.Helper()
+	l.Logf(format, v...)
+}
+
 var longFlag bool
 
 func init() {


### PR DESCRIPTION
Disable the test suites that require elastic-agent and stop building the custom test image for e2e tests.