### PR TITLE
Use fleet-server binary version for cloude2e images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ release-manager-release: ## - Builds a snapshot release. The Go version defined 
 ## get-version : Get the Fleet server version
 .PHONY: get-version
 get-version:
-	@echo $(DEFAULT_VERSION)
+	@echo $(VERSION)
 
 ##################################################
 # Integration testing targets

--- a/dev-tools/cloud/docker/build.sh
+++ b/dev-tools/cloud/docker/build.sh
@@ -26,7 +26,7 @@ VCS_REF=$(docker inspect -f '{{index .Config.Labels "org.label-schema.vcs-ref"}}
 CUSTOM_IMAGE_TAG=${CUSTOM_IMAGE_TAG:-"${STACK_VERSION}-${USER_NAME}-$(date +%s)"}
 
 SNAPSHOT=true make -C $REPO_ROOT release-linux/${GOARCH}
-FLEET_VERSION=$(SNAPSHOT=true make -s -C $REPO_ROOT get-version)
+FLEET_VERSION=$(SNAPSHOT=true make -s --no-print-directory -C $REPO_ROOT get-version)
 echo "Fleet version: ${FLEET_VERSION}"
 
 docker build \

--- a/dev-tools/cloud/docker/build.sh
+++ b/dev-tools/cloud/docker/build.sh
@@ -26,7 +26,7 @@ VCS_REF=$(docker inspect -f '{{index .Config.Labels "org.label-schema.vcs-ref"}}
 CUSTOM_IMAGE_TAG=${CUSTOM_IMAGE_TAG:-"${STACK_VERSION}-${USER_NAME}-$(date +%s)"}
 
 SNAPSHOT=true make -C $REPO_ROOT release-linux/${GOARCH}
-FLEET_VERSION=$(SNAPSHOT=true make -C $REPO_ROOT get-version)
+FLEET_VERSION=$(SNAPSHOT=true make -s -C $REPO_ROOT get-version)
 echo "Fleet version: ${FLEET_VERSION}"
 
 docker build \

--- a/dev-tools/cloud/docker/build.sh
+++ b/dev-tools/cloud/docker/build.sh
@@ -26,11 +26,12 @@ VCS_REF=$(docker inspect -f '{{index .Config.Labels "org.label-schema.vcs-ref"}}
 CUSTOM_IMAGE_TAG=${CUSTOM_IMAGE_TAG:-"${STACK_VERSION}-${USER_NAME}-$(date +%s)"}
 
 SNAPSHOT=true make -C $REPO_ROOT release-linux/${GOARCH}
+FLEET_VERSION=$(SNAPSHOT=true make -C $REPO_ROOT get-version)
 
 docker build \
 	-f $REPO_ROOT/dev-tools/cloud/docker/Dockerfile \
 	--build-arg ELASTIC_AGENT_IMAGE=$BASE_IMAGE \
-	--build-arg STACK_VERSION=$STACK_VERSION \
+	--build-arg STACK_VERSION=$FLEET_VERSION \
 	--build-arg VCS_REF_SHORT=${VCS_REF:0:6} \
 	--platform linux/$GOARCH \
 	-t ${CI_ELASTIC_AGENT_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG} \

--- a/dev-tools/cloud/docker/build.sh
+++ b/dev-tools/cloud/docker/build.sh
@@ -27,11 +27,12 @@ CUSTOM_IMAGE_TAG=${CUSTOM_IMAGE_TAG:-"${STACK_VERSION}-${USER_NAME}-$(date +%s)"
 
 SNAPSHOT=true make -C $REPO_ROOT release-linux/${GOARCH}
 FLEET_VERSION=$(SNAPSHOT=true make -C $REPO_ROOT get-version)
+echo "Fleet version: ${FLEET_VERSION}"
 
 docker build \
 	-f $REPO_ROOT/dev-tools/cloud/docker/Dockerfile \
 	--build-arg ELASTIC_AGENT_IMAGE=$BASE_IMAGE \
-	--build-arg STACK_VERSION=$FLEET_VERSION \
+	--build-arg STACK_VERSION=${FLEET_VERSION} \
 	--build-arg VCS_REF_SHORT=${VCS_REF:0:6} \
 	--platform linux/$GOARCH \
 	-t ${CI_ELASTIC_AGENT_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG} \


### PR DESCRIPTION
## What is the problem this PR solves?

Bumping fleet-server versions causes the cloude2e test to fail

## How does this PR solve the problem?

Use the fleet-server binary version with snapshot flag when building the cloude2e test image instead of the stack version so fleet-server builds will not fail on version bumps.