### PR TITLE
Stop self monitor output health reporting if output config is not ack…

### DIFF
--- a/changelog/fragments/1710157707-fix-self-monitor-output-health.yaml
+++ b/changelog/fragments/1710157707-fix-self-monitor-output-health.yaml
@@ -25,7 +25,7 @@ component:
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-#pr: https://github.com/owner/repo/1234
+pr: 3335
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.

--- a/changelog/fragments/1710157707-fix-self-monitor-output-health.yaml
+++ b/changelog/fragments/1710157707-fix-self-monitor-output-health.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Self monitor stops output health reporting if output config is not acked by agents
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: 3334

--- a/internal/pkg/policy/self_test.go
+++ b/internal/pkg/policy/self_test.go
@@ -743,3 +743,22 @@ func TestSelfMonitor_reportOutputSkipIfOutdated(t *testing.T) {
 	bulker.AssertExpectations(t)
 	outputBulker.AssertExpectations(t)
 }
+
+func TestSelfMonitor_reportOutputSkipIfNotFound(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	logger := testlog.SetLogger(t)
+
+	bulker := ftesting.NewMockBulk()
+	bulkerMap := make(map[string]bulk.Bulk)
+	outputBulker := ftesting.NewMockBulk()
+	bulkerMap["outdated"] = outputBulker
+	bulker.On("GetBulkerMap").Return(bulkerMap)
+	bulker.On("Search", mock.Anything, dl.FleetPolicies, mock.Anything, mock.Anything).Return(
+		&es.ResultT{}, errors.New("output not found"))
+
+	reportOutputHealth(ctx, bulker, logger)
+
+	bulker.AssertExpectations(t)
+	outputBulker.AssertExpectations(t)
+}

--- a/internal/pkg/policy/self_test.go
+++ b/internal/pkg/policy/self_test.go
@@ -667,6 +667,14 @@ func TestSelfMonitor_reportOutputHealthyState(t *testing.T) {
 		}
 		return doc.Message == "" && doc.State == client.UnitStateHealthy.String()
 	}), mock.Anything).Return("", nil)
+	bulker.On("Search", mock.Anything, dl.FleetPolicies, mock.Anything, mock.Anything).Return(
+		&es.ResultT{
+			HitsT: es.HitsT{
+				Hits: []es.HitT{
+					{Source: []byte(`{"data": {"outputs":{"remote":{"type":"remote_elasticsearch","hosts":["http://localhost:9200"]}}}}`)},
+				},
+			},
+		}, nil)
 
 	reportOutputHealth(ctx, bulker, logger)
 
@@ -696,6 +704,39 @@ func TestSelfMonitor_reportOutputDegradedState(t *testing.T) {
 		}
 		return doc.Message == "remote ES is not reachable due to error: error connecting" && doc.State == client.UnitStateDegraded.String()
 	}), mock.Anything).Return("", nil)
+	bulker.On("Search", mock.Anything, dl.FleetPolicies, mock.Anything, mock.Anything).Return(
+		&es.ResultT{
+			HitsT: es.HitsT{
+				Hits: []es.HitT{
+					{Source: []byte(`{"data": {"outputs":{"remote":{"type":"remote_elasticsearch","hosts":["http://localhost:9200"]}}}}`)},
+				},
+			},
+		}, nil)
+
+	reportOutputHealth(ctx, bulker, logger)
+
+	bulker.AssertExpectations(t)
+	outputBulker.AssertExpectations(t)
+}
+
+func TestSelfMonitor_reportOutputSkipIfOutdated(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	logger := testlog.SetLogger(t)
+
+	bulker := ftesting.NewMockBulk()
+	bulkerMap := make(map[string]bulk.Bulk)
+	outputBulker := ftesting.NewMockBulk()
+	bulkerMap["outdated"] = outputBulker
+	bulker.On("GetBulkerMap").Return(bulkerMap)
+	bulker.On("Search", mock.Anything, dl.FleetPolicies, mock.Anything, mock.Anything).Return(
+		&es.ResultT{
+			HitsT: es.HitsT{
+				Hits: []es.HitT{
+					{Source: []byte(`{"data": {"outputs":{"outdated":{"type":"remote_elasticsearch","hosts":["http://localhost:9200"]}}}}`)},
+				},
+			},
+		}, nil)
 
 	reportOutputHealth(ctx, bulker, logger)
 

--- a/internal/pkg/testing/bulk.go
+++ b/internal/pkg/testing/bulk.go
@@ -148,4 +148,8 @@ func (m *MockBulk) StartTransactionOptions(name, transactionType string, opts ap
 	return nil
 }
 
+func (m *MockBulk) RemoteOutputConfigChanged(zlog zerolog.Logger, name string, newCfg map[string]interface{}) bool {
+	return name == "outdated"
+}
+
 var _ bulk.Bulk = (*MockBulk)(nil)


### PR DESCRIPTION
…ed by agents

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

Output health kept reporting incorrect state after output config was updated, but the new config was not yet acked by any agents.

## How does this PR solve the problem?

Self monitor compares the current bulker output config with the latest output config from `.fleet-policies`. If the bulker doesn't use the latest config, the self monitor will stop reporting output health until an agent acks it.


## How to test this PR locally

- Create a remote es output that points to a second ES
- Enroll an agent that uses the remote es
- Update the remote es config to point to an invalid host
- The output health UI should show the connection error
- Stop the agent
- Update the remote es config to point to a valid host again
- The output health UI should clear
- Re-start the agent
- The output health UI should show healthy status


https://github.com/elastic/fleet-server/assets/90178898/94a7f681-ff32-476d-b869-01e50045a68e



## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
Closes https://github.com/elastic/fleet-server/issues/3334