### PR TITLE
Enable automatic updates of elastic go.mod dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - automation
+      - skip-changelog
+      - Team:Fleet
+    allow:
+      # Only update internal dependencies for now while we evaluate this workflow.
+      - dependency-name: "github.com/elastic/*"
+    reviewers:
+      - "elastic/elastic-agent-control-plane"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Add a dependabot configuration that will automatically open PRs to update dependencies for new releases in the github.com/elastic/* organization.

We have been using this in agent and beats for a while and helps keep us from falling too far behind.