### PR TITLE
Allow level: trace in settings action

### DIFF
--- a/changelog/fragments/1710319964-Allow-level:-trace-for-settings-actions.yaml
+++ b/changelog/fragments/1710319964-Allow-level:-trace-for-settings-actions.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Allow level: trace for settings actions
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: 3350
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -79,6 +79,12 @@ func TestConvertActionData(t *testing.T) {
 		expect: Action_Data{json.RawMessage(`{"log_level":"error"}`)},
 		hasErr: false,
 	}, {
+		name:   "settings action trace level",
+		aType:  SETTINGS,
+		raw:    json.RawMessage(`{"log_level":"trace"}`),
+		expect: Action_Data{json.RawMessage(`{"log_level":"trace"}`)},
+		hasErr: false,
+	}, {
 		name:   "upgrade action",
 		aType:  UPGRADE,
 		raw:    json.RawMessage(`{"source_uri":"https://localhost:8080","version":"1.2.3"}`),

--- a/internal/pkg/api/openapi.gen.go
+++ b/internal/pkg/api/openapi.gen.go
@@ -45,6 +45,7 @@ const (
 	ActionSettingsLogLevelDebug   ActionSettingsLogLevel = "debug"
 	ActionSettingsLogLevelError   ActionSettingsLogLevel = "error"
 	ActionSettingsLogLevelInfo    ActionSettingsLogLevel = "info"
+	ActionSettingsLogLevelTrace   ActionSettingsLogLevel = "trace"
 	ActionSettingsLogLevelWarning ActionSettingsLogLevel = "warning"
 )
 

--- a/model/openapi.yml
+++ b/model/openapi.yml
@@ -593,6 +593,7 @@ components:
         log_level:
           type: string
           enum:
+            - trace
             - debug
             - info
             - warning

--- a/pkg/api/types.gen.go
+++ b/pkg/api/types.gen.go
@@ -42,6 +42,7 @@ const (
 	ActionSettingsLogLevelDebug   ActionSettingsLogLevel = "debug"
 	ActionSettingsLogLevelError   ActionSettingsLogLevel = "error"
 	ActionSettingsLogLevelInfo    ActionSettingsLogLevel = "info"
+	ActionSettingsLogLevelTrace   ActionSettingsLogLevel = "trace"
 	ActionSettingsLogLevelWarning ActionSettingsLogLevel = "warning"
 )
 


### PR DESCRIPTION
## What is the problem this PR solves?

Allow fleet to set trace level for logging

## How does this PR solve the problem?

Allow the trace level to be set in settings actions.

## Design Checklist


- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)