### PR TITLE
Fix dependabot label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       interval: "daily"
     labels:
       - automation
-      - skip-changelog
+      - dependency
       - Team:Fleet
     allow:
       # Only update internal dependencies for now while we evaluate this workflow.


### PR DESCRIPTION
We don't use the `skip-changelog` label