### PR TITLE
fix for docker image script

### DIFF
--- a/.buildkite/scripts/build_push_docker_image.sh
+++ b/.buildkite/scripts/build_push_docker_image.sh
@@ -12,6 +12,6 @@ fi
 
 if [[ "${DOCKER_IMAGE_GIT_TAG}" == "main" ]]; then
     DOCKER_IMAGE=${DOCKER_IMAGE} DOCKER_IMAGE_TAG="${DOCKER_IMAGE_LATEST_TAG}" make build-and-push-docker
-else
+elif [[ ${BUILDKITE_PULL_REQUEST} == "false" ]]; then
     DOCKER_IMAGE=${DOCKER_IMAGE} DOCKER_IMAGE_TAG="${DOCKER_IMAGE_GIT_TAG}" make build-and-push-docker
 fi


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

Failed docker publish on prs. After the last changes, the script tries to create a docker image tag with the name of the pr branch, which is invalid (probably because of `:`)
https://buildkite.com/elastic/fleet-server-perf-tests/builds/23#018e6605-24ea-4443-93bd-c67bc6a2b6b6
```
ERROR: invalid tag "docker.elastic.co/observability-ci/fleet-server:szwarckonrad:test-pipeline": invalid reference format
--
  | make: *** [Makefile:220: build-and-push-docker] Error 1

```

## How does this PR solve the problem?

Only publish to branch name tag if not on a pr (e.g. 8.13)

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
Follow up after https://github.com/elastic/fleet-server/pull/3388