### PR TITLE
[Fleet] Change action and policy rate limiter error log level to warn

### DIFF
--- a/internal/pkg/action/dispatcher.go
+++ b/internal/pkg/action/dispatcher.go
@@ -130,7 +130,7 @@ func (d *Dispatcher) process(ctx context.Context, hits []es.HitT) {
 
 	for agentID, actions := range agentActions {
 		if err := d.limit.Wait(ctx); err != nil {
-			zerolog.Ctx(ctx).Error().Err(err).Msg("action dispatcher rate limit error")
+			zerolog.Ctx(ctx).Warn().Err(err).Msg("action dispatcher rate limit error")
 			return
 		}
 		d.dispatch(ctx, agentID, actions)

--- a/internal/pkg/policy/monitor.go
+++ b/internal/pkg/policy/monitor.go
@@ -247,7 +247,7 @@ func (m *monitorT) dispatchPending(ctx context.Context) {
 		// If too many (checkin) responses are written concurrently memory usage may explode due to allocating gzip writers.
 		err := m.limit.Wait(ctx)
 		if err != nil {
-			m.log.Error().Err(err).Msg("Policy limit error")
+			m.log.Warn().Err(err).Msg("Policy limit error")
 			return
 		}
 		// Lookup the latest policy for this subscription


### PR DESCRIPTION
## Description 

The scale tests is hitting some of the limit and logging this as errors seems to make the quality gates failling.

That PR should fix it by changing the log level

An example of a log message that will be logged as warning instead of error.

<img width="1244" alt="Screenshot 2024-03-26 at 1 44 18 PM" src="https://github.com/elastic/fleet-server/assets/1336873/7d8325d9-54d7-4d18-991a-b21656a7e788">
