### PR TITLE
3110 return 4xx errors instead of 5xx errors for bad requests payloads

### DIFF
--- a/changelog/fragments/1711580899-fix-bad-request-status-code-checkin.yaml
+++ b/changelog/fragments/1711580899-fix-bad-request-status-code-checkin.yaml
@@ -11,7 +11,7 @@
 kind: bug-fix
 
 # Change summary; a 80ish characters long description of the change.
-summary: Checkin endpoint returns 400 status code instead of 500 for bad requests
+summary: Updated endpoints to return 400 status code instead of 500 for bad requests
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.

--- a/changelog/fragments/1711580899-fix-bad-request-status-code-checkin.yaml
+++ b/changelog/fragments/1711580899-fix-bad-request-status-code-checkin.yaml
@@ -1,0 +1,31 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Checkin endpoint returns 400 status code instead of 500 for bad requests
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component:
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/fleet-server/pull/3407
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/fleet-server/issues/3110

--- a/internal/pkg/api/error.go
+++ b/internal/pkg/api/error.go
@@ -42,19 +42,19 @@ const (
 	LogAccessAPIKeyID = logger.AccessAPIKeyID
 )
 
-// DecodeReqErr is intended to be a wrapper around any possible json decoding errors that
-// may occur while decoding requests. These errors are mainly json.SyntaxError, json.UnmarshalTypeError, and
-// io.EOF errors.
-type DecodeReqErr struct {
-	Msg     string
+// BadRequestErr is used for request validation errors. These can be json
+// unmarshal errors such as json.SyntaxError, or any other input validation
+// error.
+type BadRequestErr struct {
+	msg     string
 	nextErr error
 }
 
-func (e *DecodeReqErr) Error() string {
-	return fmt.Sprintf("Request decoding error: %s", e.Msg)
+func (e *BadRequestErr) Error() string {
+	return fmt.Sprintf("Bad request: %s", e.msg)
 }
 
-func (e *DecodeReqErr) Unwrap() error {
+func (e *BadRequestErr) Unwrap() error {
 	return e.nextErr
 }
 
@@ -498,12 +498,12 @@ func NewHTTPErrResp(err error) HTTPErrResp {
 		}
 	}
 
-	var drErr *DecodeReqErr
+	var drErr *BadRequestErr
 	if errors.As(err, &drErr) {
 		return HTTPErrResp{
 			http.StatusBadRequest,
+			"BadRequest",
 			err.Error(),
-			"Fleet server unable to decode request",
 			zerolog.ErrorLevel,
 		}
 	}

--- a/internal/pkg/api/error_test.go
+++ b/internal/pkg/api/error_test.go
@@ -112,6 +112,13 @@ func Test_ErrResp_Status(t *testing.T) {
 			Status: 500,
 		},
 		status: 503,
+	}, {
+		name: "decode req error",
+		err: &DecodeReqErr{
+			Msg:     "testMessage",
+			nextErr: fmt.Errorf("testError"),
+		},
+		status: 400,
 	}}
 
 	for _, tc := range tests {

--- a/internal/pkg/api/error_test.go
+++ b/internal/pkg/api/error_test.go
@@ -114,8 +114,8 @@ func Test_ErrResp_Status(t *testing.T) {
 		status: 503,
 	}, {
 		name: "decode req error",
-		err: &DecodeReqErr{
-			Msg:     "testMessage",
+		err: &BadRequestErr{
+			msg:     "testMessage",
 			nextErr: fmt.Errorf("testError"),
 		},
 		status: 400,

--- a/internal/pkg/api/handleAck.go
+++ b/internal/pkg/api/handleAck.go
@@ -155,7 +155,7 @@ func (ack *AckT) validateRequest(zlog zerolog.Logger, w http.ResponseWriter, r *
 	var req AckRequest
 	dec := json.NewDecoder(readCounter)
 	if err := dec.Decode(&req); err != nil {
-		return nil, fmt.Errorf("unable to decode ack request: %w", err)
+		return nil, &BadRequestErr{msg: "unable to decode ack request", nextErr: err}
 	}
 
 	cntAcks.bodyIn.Add(readCounter.Count())

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -181,7 +181,7 @@ func (ct *CheckinT) validateRequest(zlog zerolog.Logger, w http.ResponseWriter, 
 	var req CheckinRequest
 	decoder := json.NewDecoder(readCounter)
 	if err := decoder.Decode(&req); err != nil {
-		return val, &BadRequestErr{msg: "checkin request decode error", nextErr: err}
+		return val, &BadRequestErr{msg: "unable to decode checkin request", nextErr: err}
 	}
 	cntCheckin.bodyIn.Add(readCounter.Count())
 

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -181,12 +181,12 @@ func (ct *CheckinT) validateRequest(zlog zerolog.Logger, w http.ResponseWriter, 
 	var req CheckinRequest
 	decoder := json.NewDecoder(readCounter)
 	if err := decoder.Decode(&req); err != nil {
-		return val, &DecodeReqErr{Msg: "checkin request decode error", nextErr: err}
+		return val, &BadRequestErr{msg: "checkin request decode error", nextErr: err}
 	}
 	cntCheckin.bodyIn.Add(readCounter.Count())
 
 	if req.Status == CheckinRequestStatus("") {
-		return val, fmt.Errorf("checkin status missing")
+		return val, &BadRequestErr{msg: "checkin status missing"}
 	}
 	if len(req.Message) == 0 {
 		zlog.Warn().Msg("checkin request method is empty.")
@@ -197,7 +197,7 @@ func (ct *CheckinT) validateRequest(zlog zerolog.Logger, w http.ResponseWriter, 
 	if req.PollTimeout != nil {
 		pDur, err = time.ParseDuration(*req.PollTimeout)
 		if err != nil {
-			return val, fmt.Errorf("poll_timeout cannot be parsed as duration: %w", err)
+			return val, &BadRequestErr{msg: "poll_timeout cannot be parsed as duration", nextErr: err}
 		}
 	}
 

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -181,7 +181,7 @@ func (ct *CheckinT) validateRequest(zlog zerolog.Logger, w http.ResponseWriter, 
 	var req CheckinRequest
 	decoder := json.NewDecoder(readCounter)
 	if err := decoder.Decode(&req); err != nil {
-		return val, fmt.Errorf("decode checkin request: %w", err)
+		return val, &DecodeReqErr{Msg: "checkin request decode error", nextErr: err}
 	}
 	cntCheckin.bodyIn.Add(readCounter.Count())
 
@@ -638,7 +638,6 @@ func (ct *CheckinT) resolveSeqNo(ctx context.Context, zlog zerolog.Logger, req C
 
 func (ct *CheckinT) fetchAgentPendingActions(ctx context.Context, seqno sqn.SeqNo, agentID string) ([]model.Action, error) {
 	actions, err := dl.FindAgentActions(ctx, ct.bulker, seqno, ct.gcp.GetCheckpoint(), agentID)
-
 	if err != nil {
 		return nil, fmt.Errorf("fetchAgentPendingActions: %w", err)
 	}
@@ -660,7 +659,6 @@ func filterActions(zlog zerolog.Logger, agentID string, actions []model.Action) 
 		resp = append(resp, action)
 	}
 	return resp
-
 }
 
 // convertActionData converts the passed raw message data to Action_Data using aType as a discriminator.

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -875,7 +875,7 @@ func TestParseComponents(t *testing.T) {
 	}
 }
 
-func TestValidateRequest(t *testing.T) {
+func TestValidateCheckinRequest(t *testing.T) {
 	verCon := mustBuildConstraints("8.0.0")
 
 	tests := []struct {

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -10,8 +10,10 @@ import (
 	"compress/flate"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -869,6 +871,49 @@ func TestParseComponents(t *testing.T) {
 			assert.Equal(t, tc.outComponents, outComponents)
 			assert.Equal(t, tc.unhealthyReason, unhealthyReason)
 			assert.Equal(t, tc.err, err)
+		})
+	}
+}
+
+func TestValidateRequest(t *testing.T) {
+	verCon := mustBuildConstraints("8.0.0")
+
+	tests := []struct {
+		name     string
+		req      *http.Request
+		cfg      *config.Server
+		expErr   error
+		expValid validatedCheckin
+	}{
+		{
+			name: "Invalid JSON",
+			req: &http.Request{
+				Body: io.NopCloser(strings.NewReader(`{"invalidJson":}`)),
+			},
+			expErr: &DecodeReqErr{},
+			cfg: &config.Server{
+				Limits: config.ServerLimits{
+					CheckinLimit: config.Limit{
+						MaxBody: 0,
+					},
+				},
+			},
+			expValid: validatedCheckin{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			checkin := NewCheckinT(verCon, tc.cfg, nil, nil, nil, nil, nil, nil, nil)
+			wr := httptest.NewRecorder()
+			logger := testlog.SetLogger(t)
+			valid, err := checkin.validateRequest(logger, wr, tc.req, time.Time{}, nil)
+			if tc.expErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorAs(t, err, &tc.expErr)
+			}
+			assert.Equal(t, tc.expValid, valid)
 		})
 	}
 }

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -890,7 +890,7 @@ func TestValidateCheckinRequest(t *testing.T) {
 			req: &http.Request{
 				Body: io.NopCloser(strings.NewReader(`{"invalidJson":}`)),
 			},
-			expErr: &BadRequestErr{msg: "checkin request decode error"},
+			expErr: &BadRequestErr{msg: "unable to decode checkin request"},
 			cfg: &config.Server{
 				Limits: config.ServerLimits{
 					CheckinLimit: config.Limit{

--- a/internal/pkg/api/handleEnroll.go
+++ b/internal/pkg/api/handleEnroll.go
@@ -523,7 +523,7 @@ func validateRequest(ctx context.Context, data io.Reader) (*EnrollRequest, error
 	var req EnrollRequest
 	decoder := json.NewDecoder(data)
 	if err := decoder.Decode(&req); err != nil {
-		return nil, &BadRequestErr{msg: "decode enroll request", nextErr: err}
+		&BadRequestErr{msg: "unable to decode enroll request", nextErr: err}
 	}
 
 	// Validate

--- a/internal/pkg/api/handleEnroll.go
+++ b/internal/pkg/api/handleEnroll.go
@@ -523,7 +523,7 @@ func validateRequest(ctx context.Context, data io.Reader) (*EnrollRequest, error
 	var req EnrollRequest
 	decoder := json.NewDecoder(data)
 	if err := decoder.Decode(&req); err != nil {
-		return nil, fmt.Errorf("decode enroll request: %w", err)
+		return nil, &BadRequestErr{msg: "decode enroll request", nextErr: err}
 	}
 
 	// Validate

--- a/internal/pkg/api/handleEnroll.go
+++ b/internal/pkg/api/handleEnroll.go
@@ -523,7 +523,7 @@ func validateRequest(ctx context.Context, data io.Reader) (*EnrollRequest, error
 	var req EnrollRequest
 	decoder := json.NewDecoder(data)
 	if err := decoder.Decode(&req); err != nil {
-		&BadRequestErr{msg: "unable to decode enroll request", nextErr: err}
+		return nil, &BadRequestErr{msg: "unable to decode enroll request", nextErr: err}
 	}
 
 	// Validate

--- a/internal/pkg/api/handleEnroll_test.go
+++ b/internal/pkg/api/handleEnroll_test.go
@@ -251,6 +251,6 @@ func TestEnrollerT_retrieveStaticTokenEnrollmentToken(t *testing.T) {
 
 func TestValidateEnrollRequest(t *testing.T) {
 	req, err := validateRequest(context.Background(), strings.NewReader("not a json"))
-	assert.Equal(t, "Bad request: decode enroll request", err.Error())
+	assert.Equal(t, "Bad request: unable to decode enroll request", err.Error())
 	assert.Nil(t, req)
 }

--- a/internal/pkg/api/handleEnroll_test.go
+++ b/internal/pkg/api/handleEnroll_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
@@ -246,4 +247,10 @@ func TestEnrollerT_retrieveStaticTokenEnrollmentToken(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestValidateEnrollRequest(t *testing.T) {
+	req, err := validateRequest(context.Background(), strings.NewReader("not a json"))
+	assert.Equal(t, "Bad request: decode enroll request", err.Error())
+	assert.Nil(t, req)
 }

--- a/internal/pkg/api/handleUpload.go
+++ b/internal/pkg/api/handleUpload.go
@@ -185,7 +185,7 @@ func (ut *UploadT) validateUploadCompleteRequest(r *http.Request, id string) (st
 
 	var req UploadCompleteRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return "", &BadRequestErr{msg: "unable to parse upload complete request body"}
+		&BadRequestErr{msg: "unable to decode upload complete request"}
 	}
 
 	hash := strings.TrimSpace(req.Transithash.Sha256)

--- a/internal/pkg/api/handleUpload.go
+++ b/internal/pkg/api/handleUpload.go
@@ -77,7 +77,7 @@ func (ut *UploadT) validateUploadBeginRequest(ctx context.Context, reader io.Rea
 		if errors.Is(err, io.EOF) {
 			return nil, "", fmt.Errorf("%w: %w", ErrFileInfoBodyRequired, err)
 		}
-		return nil, "", &BadRequestErr{msg: "error decoding upload begin request", nextErr: err}
+		return nil, "", &BadRequestErr{msg: "unable to decode upload begin request", nextErr: err}
 	}
 
 	// check API key matches payload agent ID

--- a/internal/pkg/api/handleUpload.go
+++ b/internal/pkg/api/handleUpload.go
@@ -77,7 +77,7 @@ func (ut *UploadT) validateUploadBeginRequest(ctx context.Context, reader io.Rea
 		if errors.Is(err, io.EOF) {
 			return nil, "", fmt.Errorf("%w: %w", ErrFileInfoBodyRequired, err)
 		}
-		return nil, "", err
+		return nil, "", &BadRequestErr{msg: "error decoding upload begin request", nextErr: err}
 	}
 
 	// check API key matches payload agent ID

--- a/internal/pkg/api/handleUpload.go
+++ b/internal/pkg/api/handleUpload.go
@@ -185,7 +185,7 @@ func (ut *UploadT) validateUploadCompleteRequest(r *http.Request, id string) (st
 
 	var req UploadCompleteRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return "", errors.New("unable to parse request body")
+		return "", &BadRequestErr{msg: "unable to parse upload complete request body"}
 	}
 
 	hash := strings.TrimSpace(req.Transithash.Sha256)

--- a/internal/pkg/api/handleUpload.go
+++ b/internal/pkg/api/handleUpload.go
@@ -185,7 +185,7 @@ func (ut *UploadT) validateUploadCompleteRequest(r *http.Request, id string) (st
 
 	var req UploadCompleteRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		&BadRequestErr{msg: "unable to decode upload complete request"}
+		return "", &BadRequestErr{msg: "unable to decode upload complete request"}
 	}
 
 	hash := strings.TrimSpace(req.Transithash.Sha256)

--- a/internal/pkg/api/handleUpload_test.go
+++ b/internal/pkg/api/handleUpload_test.go
@@ -989,7 +989,7 @@ func TestUploadCompleteBadRequests(t *testing.T) {
 	hr.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
-	assert.Equal(t, rec.Body.String(), "{\"statusCode\":400,\"error\":\"BadRequest\",\"message\":\"Bad request: unable to parse upload complete request body\"}")
+	assert.Equal(t, rec.Body.String(), "{\"statusCode\":400,\"error\":\"BadRequest\",\"message\":\"Bad request: unable to decode upload complete request\"}")
 }
 
 /*

--- a/internal/pkg/api/handleUpload_test.go
+++ b/internal/pkg/api/handleUpload_test.go
@@ -338,6 +338,14 @@ func TestUploadBeginWritesTimestampToMeta(t *testing.T) {
 	)
 }
 
+func TestUploadBeginBadRequest(t *testing.T) {
+	hr, _, _, _ := prepareUploaderMock(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, RouteUploadBegin, strings.NewReader("not a json"))
+	hr.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
 /*
   Chunk data upload route
 */

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -269,7 +269,6 @@ func (s *tserver) waitServerUp(ctx context.Context, dur time.Duration) error {
 		case <-time.After(100 * time.Millisecond):
 		}
 	}
-
 }
 
 func (s *tserver) buildURL(id string, cmd string) string {
@@ -1022,7 +1021,7 @@ func Test_Agent_request_errors(t *testing.T) {
 		res, err := cli.Do(req)
 		require.NoError(t, err)
 		res.Body.Close()
-		require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+		require.Equal(t, http.StatusBadRequest, res.StatusCode)
 	})
 	t.Run("no user agent", func(t *testing.T) {
 		ctx := testlog.SetLogger(t).WithContext(ctx)

--- a/testing/e2e/api_version/client_api_current.go
+++ b/testing/e2e/api_version/client_api_current.go
@@ -1,6 +1,22 @@
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 package api_version
 
@@ -98,25 +114,32 @@ func (tester *ClientAPITester) Enroll(ctx context.Context, apiKey string) (strin
 
 // Checkin tests the checkin endpoint.
 // Returns the new ack token and the list of actions.
-func (tester *ClientAPITester) Checkin(ctx context.Context, apiKey, agentID string, ackToken, dur *string) (*string, []string) {
+func (tester *ClientAPITester) Checkin(ctx context.Context, apiKey, agentID string, ackToken, dur *string, requestBody *api.AgentCheckinJSONRequestBody) (*string, []string, int) {
 	client, err := api.NewClientWithResponses(tester.endpoint, api.WithHTTPClient(tester.Client), api.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
 		req.Header.Set("Authorization", "ApiKey "+apiKey)
 		return nil
 	}))
 	tester.Require().NoError(err)
 
-	resp, err := client.AgentCheckinWithResponse(ctx,
-		agentID,
-		&api.AgentCheckinParams{UserAgent: "elastic agent " + version.DefaultVersion},
-		api.AgentCheckinJSONRequestBody{
+	if requestBody == nil {
+		requestBody = &api.AgentCheckinJSONRequestBody{
 			Status:      api.CheckinRequestStatusOnline,
 			Message:     "test checkin",
-			AckToken:    ackToken,
 			PollTimeout: dur,
-		},
-	)
+		}
+	}
+
+	resp, err := client.AgentCheckinWithResponse(ctx, agentID, &api.AgentCheckinParams{UserAgent: "elastic agent " + version.DefaultVersion}, *requestBody)
 	tester.Require().NoError(err)
-	tester.Require().Equal(http.StatusOK, resp.StatusCode())
+
+	// No need to process the response further if we're testing for a bad request;
+	// just return the status code
+	// For valid requests, process as usual
+	if resp.StatusCode() != http.StatusOK {
+		return nil, nil, resp.StatusCode()
+	}
+
+	// Process a successful check-in response.
 	checkin := resp.JSON200
 	tester.Require().NotNil(checkin.AckToken, "expected to recieve ack token from checkin")
 	tester.Require().NotNil(checkin.Actions, "expected to actions from checkin")
@@ -126,7 +149,7 @@ func (tester *ClientAPITester) Checkin(ctx context.Context, apiKey, agentID stri
 		actionIds[i] = action.Id
 	}
 
-	return checkin.AckToken, actionIds
+	return checkin.AckToken, actionIds, resp.StatusCode()
 }
 
 // Acks tests the acks endpoint
@@ -284,7 +307,8 @@ func (tester *ClientAPITester) TestEnrollCheckinAck() {
 	tester.VerifyAgentInKibana(ctx, agentID)
 
 	tester.T().Logf("test checkin 1: agent %s", agentID)
-	ackToken, actions := tester.Checkin(ctx, agentKey, agentID, nil, nil)
+	ackToken, actions, statusCode := tester.Checkin(ctx, agentKey, agentID, nil, nil, nil)
+	tester.Require().Equal(http.StatusOK, statusCode, "Expected status code 200 for successful checkin")
 	tester.Require().NotEmpty(actions)
 
 	tester.T().Log("test ack")
@@ -293,7 +317,8 @@ func (tester *ClientAPITester) TestEnrollCheckinAck() {
 	tester.T().Logf("test checkin 2: agent %s 3m timout", agentID)
 	dur := "3m"
 
-	tester.Checkin(ctx, agentKey, agentID, ackToken, &dur)
+	_, _, newStatusCode := tester.Checkin(ctx, agentKey, agentID, ackToken, &dur, nil)
+	tester.Require().Equal(http.StatusOK, newStatusCode, "Expected status code 200 for successful checkin with timeout")
 
 	// sanity check agent status in kibana
 	tester.AgentIsOnline(ctx, agentID)

--- a/testing/e2e/api_version/client_api_current.go
+++ b/testing/e2e/api_version/client_api_current.go
@@ -324,6 +324,20 @@ func (tester *ClientAPITester) TestEnrollCheckinAck() {
 	tester.AgentIsOnline(ctx, agentID)
 }
 
+func (tester *ClientAPITester) TestCheckinWithBadRequest() {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+
+	tester.T().Log("test enrollment")
+	agentID, agentKey := tester.Enroll(ctx, tester.enrollmentKey)
+	tester.VerifyAgentInKibana(ctx, agentID)
+
+	tester.T().Logf("test checkin 1: agent %s", agentID)
+
+	_, _, statusCode := tester.Checkin(ctx, agentKey, agentID, nil, nil, &api.CheckinRequest{})
+	tester.Require().Equal(http.StatusBadRequest, statusCode, "Expected status code 400 for bad request")
+}
+
 func (tester *ClientAPITester) TestFullFileUpload() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

Some of the fleet server endpoints return 500 errors when the handler runs into an error while validating the incoming request body. Handler should respond with 400 error code.

## How does this PR solve the problem?

Added a new error type "BadRequestErr" to encapsulate the errors that may occur while validating a request body. Updated the error table to return a 400 status code HTTPErrResp.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
