### PR TITLE
2447 fleet improve error message for expired certificate authority

### DIFF
--- a/internal/pkg/api/server_test.go
+++ b/internal/pkg/api/server_test.go
@@ -238,10 +238,8 @@ func Test_server_ClientCert(t *testing.T) {
 		defer rCancel()
 		req, err := http.NewRequestWithContext(rCtx, "GET", "https://"+addr+"/api/status", nil)
 		require.NoError(t, err)
-		resp, err := httpClient.Do(req)
-		require.NoError(t, err)
-		resp.Body.Close()
-		require.Equal(t, http.StatusOK, resp.StatusCode)
+		_, err = httpClient.Do(req)
+		require.Error(t, err)
 
 		select {
 		case err := <-errCh:

--- a/internal/pkg/testing/certs/certs.go
+++ b/internal/pkg/testing/certs/certs.go
@@ -89,8 +89,6 @@ func genCA(t *testing.T, isExpired bool) tls.Certificate {
 			StreetAddress: []string{"testing road"},
 			PostalCode:    []string{"HOH OHO"},
 		},
-		// NotBefore:             time.Now(),
-		// NotAfter:              time.Now().Add(1 * time.Hour),
 		IsCA:                  true,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,


### PR DESCRIPTION
- Enhancement

## What is the problem this PR solves?

This PR does not really solve a problem. It is an attempt at understanding and documenting what happens when the fleet server is provided with an expired CA; we are specifically interested in the error message that is returned. Relates to the following [issue](https://github.com/elastic/fleet-server/issues/2447).

## How does this PR solve the problem?

As stated above, this PR does not solve a problem

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Design Checklist

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues
- Relates #2447 

