### PR TITLE
increase synthetic max poll

### DIFF
--- a/.buildkite/pipeline.tests-staging.yaml
+++ b/.buildkite/pipeline.tests-staging.yaml
@@ -26,3 +26,4 @@ steps:
         CHECK_SYNTHETICS_TAG: "fleet-server"
         CHECK_SYNTHETICS_MINIMUM_RUNS: 3
         MAX_FAILURES: 2
+        CHECK_SYNTHETIC_MAX_POLL: 50


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

Synthetic monitor failed because it ran out of max poll: https://buildkite.com/elastic/serverless-quality-gates/builds/8566#018ea08d-fbf3-4e07-b5e4-257b53f9d290

```
2024/04/02 21:29:26 Still running with intermediate results:
========================= MonitorRun Statistics =====================
• serverless - fleet long standing check: {Current:up Checks:531 Up:526 Down:5}
  [up up]
==================================================================
2024/04/02 21:30:56 Need to collect more results of [1] monitors...
2024/04/02 21:32:27 Need to collect more results of [1] monitors...
2024/04/02 21:33:57 Need to collect more results of [1] monitors...
2024/04/02 21:35:27 Need to collect more results of [1] monitors...
2024/04/02 21:36:57 Need to collect more results of [1] monitors...
2024/04/02 21:38:27 Need to collect more results of [1] monitors...
2024/04/02 21:39:57 Need to collect more results of [1] monitors...
2024/04/02 21:41:28 Need to collect more results of [1] monitors...
2024/04/02 21:42:58 Need to collect more results of [1] monitors...
2024/04/02 21:44:28 Still running with intermediate results:
========================= MonitorRun Statistics =====================
• serverless - fleet long standing check: {Current:up Checks:531 Up:526 Down:5}
  [up up]
==================================================================
2024/04/02 21:44:28 FAILED synthetic gate with following reason: run out of poll retries [40]. Consider increasing the budget with 'CHECK_SYNTHETIC_MAX_POLL'. Or by increasing the poll intervall with 'CHECK_SYNTHETIC_POLL_INTERVAL'
🚨 Error: The command exited with status 1
```


## How does this PR solve the problem?

Increasing max retries of synthetic monitor, as the default value was not enough. There doesn't seem anything wrong with the monitor itself, it seems just some flakyness if the synthetic check takes a little longer to run.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
