### PR TITLE
Group dependabot updates of apm dependencies in single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
     reviewers:
       - "elastic/fleet"
     open-pull-requests-limit: 10
+    groups:
+      elastic-apm:
+        patterns:
+          - "go.elastic.co/apm/*"


### PR DESCRIPTION
These packages use to be released together, update them also together in single PRs.