### PR TITLE
Update elastic-agent-libs to v0.9.4

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -460,11 +460,11 @@ SOFTWARE
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/elastic-agent-libs
-Version: v0.9.3
+Version: v0.9.4
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-libs@v0.9.3/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-libs@v0.9.4/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/dgraph-io/ristretto v0.1.1
 	github.com/elastic/elastic-agent-client/v7 v7.8.1
-	github.com/elastic/elastic-agent-libs v0.9.3
+	github.com/elastic/elastic-agent-libs v0.9.4
 	github.com/elastic/elastic-agent-system-metrics v0.9.2
 	github.com/elastic/go-elasticsearch/v8 v8.13.1
 	github.com/elastic/go-ucfg v0.8.8

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/elastic/elastic-agent-client/v7 v7.8.1 h1:J9wZc/0mUvSEok0X5iR5+n60Jgb+AWooKddb3XgPWqM=
 github.com/elastic/elastic-agent-client/v7 v7.8.1/go.mod h1:axl1nkdqc84YRFkeJGD9jExKNPUrOrzf3DFo2m653nY=
-github.com/elastic/elastic-agent-libs v0.9.3 h1:w1Ykn8aUFxDorUAEGt/7A/NzZtFf74n4OAe1ik8mS80=
-github.com/elastic/elastic-agent-libs v0.9.3/go.mod h1:SkMnpLm+tXybBrIWK6f3rcOhrDIztLbYCV46m8gwc8g=
+github.com/elastic/elastic-agent-libs v0.9.4 h1:I6c1NAj3grJ1YZgo+U04w0csMAWGIn6eZTb23Z5MbAI=
+github.com/elastic/elastic-agent-libs v0.9.4/go.mod h1:SkMnpLm+tXybBrIWK6f3rcOhrDIztLbYCV46m8gwc8g=
 github.com/elastic/elastic-agent-system-metrics v0.9.2 h1:/tvTKOt55EerU0WwGFoDhBlyWLgxyv7d8xCbny0bciw=
 github.com/elastic/elastic-agent-system-metrics v0.9.2/go.mod h1:VfJnKw4Jqrd9ddljXCwaGKJgN+7ADyyGk089NaXVsf0=
 github.com/elastic/elastic-transport-go/v8 v8.5.0 h1:v5membAl7lvQgBTexPRDBO/RdnlQX+FM9fUVDyXxvH0=

--- a/testing/go.mod
+++ b/testing/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/elastic/elastic-agent-libs v0.9.3 // indirect
+	github.com/elastic/elastic-agent-libs v0.9.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/testing/go.sum
+++ b/testing/go.sum
@@ -37,8 +37,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/elastic/elastic-agent-client/v7 v7.8.1 h1:J9wZc/0mUvSEok0X5iR5+n60Jgb+AWooKddb3XgPWqM=
 github.com/elastic/elastic-agent-client/v7 v7.8.1/go.mod h1:axl1nkdqc84YRFkeJGD9jExKNPUrOrzf3DFo2m653nY=
-github.com/elastic/elastic-agent-libs v0.9.3 h1:w1Ykn8aUFxDorUAEGt/7A/NzZtFf74n4OAe1ik8mS80=
-github.com/elastic/elastic-agent-libs v0.9.3/go.mod h1:SkMnpLm+tXybBrIWK6f3rcOhrDIztLbYCV46m8gwc8g=
+github.com/elastic/elastic-agent-libs v0.9.4 h1:I6c1NAj3grJ1YZgo+U04w0csMAWGIn6eZTb23Z5MbAI=
+github.com/elastic/elastic-agent-libs v0.9.4/go.mod h1:SkMnpLm+tXybBrIWK6f3rcOhrDIztLbYCV46m8gwc8g=
 github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
 github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=


### PR DESCRIPTION
## What is the problem this PR solves?

Snapshots deployed have error logs stating:

```
tls renegotation support is an unknown type: int64 accessing 'output.elasticsearch.ssl.renegotiation'
```

## How does this PR solve the problem?

Update elastic-agent-libs to version that supports uint64 and int64 unpacking

- Relates #3465 