### PR TITLE
Update default codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Team responsible for Fleet Server
-* @elastic/fleet
+* @elastic/elastic-agent-control-plane
 
 # Allow to auto-merge PRs with Mergify
 dev-tools/integration/.env


### PR DESCRIPTION
This PR updates the default codeowners for this repository to `@elastic/elastic-agent-control-plane` so this team is automatically assigned as the default reviewers for any PRs created in this repository.