### PR TITLE
Add service-name for Serverless release

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,6 +8,7 @@ metadata:
   description: fleet-server - The control server for managing a fleet of elastic-agents
   annotations:
     sonarqube.org/project-key: elastic_fleet-server_AYpL8BsVaV3I-igkX4hx
+    gitops.elastic.co/service-name: fleet
 
 spec:
   type: tool


### PR DESCRIPTION
Update the catalog-info value in order for fleet-server to show up in the serverless release dashboard.

According to @zenitraM this change is required for fleet-server to show up in our release dashboard.