### PR TITLE
Add `/api/fleet/agents/:id/audit/unenroll` endpoint

### DIFF
--- a/changelog/fragments/1723590385-Add-audit-unenroll-API.yaml
+++ b/changelog/fragments/1723590385-Add-audit-unenroll-API.yaml
@@ -1,0 +1,36 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add audit/unenroll API
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  Add the /api/fleet/agents/:id/audit/unenroll API that elastic-agent
+  and Endpoint instances may use to annotate the agent document when
+  the agent is uninstalled or Endpoint detects it is in an orphaned
+  state.
+
+# Affected component; a word indicating the component this changeset affects.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/fleet-server/pull/3818
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/484

--- a/fleet-server.reference.yml
+++ b/fleet-server.reference.yml
@@ -222,6 +222,11 @@ fleet:
 #         burst: 100
 #         max: 50
 #         max_body_byte_size: 0
+#       audit_unenroll_limit:
+#         interval: 10ms
+#         burst: 100
+#         max: 50
+#         max_body_byte_size: 1024
 #
 #     # go runtime limits
 #     runtime:

--- a/internal/pkg/api/api.go
+++ b/internal/pkg/api/api.go
@@ -151,8 +151,8 @@ func (a *apiServer) GetPGPKey(w http.ResponseWriter, r *http.Request, major, min
 
 func (a *apiServer) AuditUnenroll(w http.ResponseWriter, r *http.Request, id string, params AuditUnenrollParams) {
 	zlog := hlog.FromRequest(r).With().Str(LogAgentID, id).Logger()
-	w.Header().Set("Content-Type", "application/json")
 	if err := a.audit.handleUnenroll(zlog, w, r, id); err != nil {
+		w.Header().Set("Content-Type", "application/json")
 		cntAuditUnenroll.IncError(err)
 		ErrorResp(w, r, err)
 	}

--- a/internal/pkg/api/api.go
+++ b/internal/pkg/api/api.go
@@ -28,6 +28,7 @@ type apiServer struct {
 	ut     *UploadT
 	ft     *FileDeliveryT
 	pt     *PGPRetrieverT
+	audit  *AuditT
 	bulker bulk.Bulk
 }
 
@@ -144,6 +145,15 @@ func (a *apiServer) GetPGPKey(w http.ResponseWriter, r *http.Request, major, min
 	if err := a.pt.handlePGPKey(zlog, w, r, major, minor, patch); err != nil {
 		cntGetPGP.IncError(err)
 		w.Header().Set("Content-Type", "application/json")
+		ErrorResp(w, r, err)
+	}
+}
+
+func (a *apiServer) AuditUnenroll(w http.ResponseWriter, r *http.Request, id string, params AuditUnenrollParams) {
+	zlog := hlog.FromRequest(r).With().Str(LogAgentID, id).Logger()
+	w.Header().Set("Content-Type", "application/json")
+	if err := a.audit.handleUnenroll(zlog, w, r, id); err != nil {
+		cntAuditUnenroll.IncError(err)
 		ErrorResp(w, r, err)
 	}
 }

--- a/internal/pkg/api/error.go
+++ b/internal/pkg/api/error.go
@@ -481,6 +481,16 @@ func NewHTTPErrResp(err error) HTTPErrResp {
 				zerolog.InfoLevel,
 			},
 		},
+		// audit unenroll
+		{
+			ErrAuditUnenrollReason,
+			HTTPErrResp{
+				http.StatusConflict,
+				"ErrAuditReasonConflict",
+				"agent document contaiins audit_unenroll_reason",
+				zerolog.InfoLevel,
+			},
+		},
 	}
 
 	for _, e := range errTable {

--- a/internal/pkg/api/error.go
+++ b/internal/pkg/api/error.go
@@ -487,7 +487,7 @@ func NewHTTPErrResp(err error) HTTPErrResp {
 			HTTPErrResp{
 				http.StatusConflict,
 				"ErrAuditReasonConflict",
-				"agent document contaiins audit_unenroll_reason",
+				"agent document contains audit_unenroll_reason",
 				zerolog.InfoLevel,
 			},
 		},

--- a/internal/pkg/api/handleAudit.go
+++ b/internal/pkg/api/handleAudit.go
@@ -5,14 +5,24 @@
 package api
 
 import (
-	"errors"
+	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/cache"
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
+	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
+	"github.com/elastic/fleet-server/v7/internal/pkg/model"
+
+	"github.com/miolini/datacounter"
 	"github.com/rs/zerolog"
+	"go.elastic.co/apm/v2"
 )
+
+var ErrAuditUnenrollReason = fmt.Errorf("agent document contains audit_unenroll_reason attribute")
 
 type AuditT struct {
 	cfg   *config.Server
@@ -29,5 +39,85 @@ func NewAuditT(cfg *config.Server, bulker bulk.Bulk, cache cache.Cache) *AuditT 
 }
 
 func (audit *AuditT) handleUnenroll(zlog zerolog.Logger, w http.ResponseWriter, r *http.Request, id string) error {
-	return errors.ErrUnsupported
+	agent, err := authAgent(r, &id, audit.bulk, audit.cache)
+	if err != nil {
+		return err
+	}
+	zlog = zlog.With().Str(LogAccessAPIKeyID, agent.AccessAPIKeyID).Logger()
+	ctx := zlog.WithContext(r.Context())
+	r = r.WithContext(ctx)
+
+	return audit.unenroll(zlog, w, r, agent)
+}
+
+func (audit *AuditT) unenroll(zlog zerolog.Logger, w http.ResponseWriter, r *http.Request, agent *model.Agent) error {
+	if agent.AuditUnenrolledReason != "" {
+		return ErrAuditUnenrollReason
+	}
+
+	req, err := audit.validateUnenrollRequest(zlog, w, r)
+	if err != nil {
+		return err
+	}
+
+	if err := audit.markUnenroll(r.Context(), zlog, req, agent); err != nil {
+		return err
+	}
+
+	span, _ := apm.StartSpan(r.Context(), "response", "write")
+	defer span.End()
+	w.WriteHeader(http.StatusOK)
+	return nil
+}
+
+func (audit *AuditT) validateUnenrollRequest(zlog zerolog.Logger, w http.ResponseWriter, r *http.Request) (*AuditUnenrollRequest, error) {
+	span, _ := apm.StartSpan(r.Context(), "validateRequest", "validate")
+	defer span.End()
+
+	body := r.Body
+	if audit.cfg.Limits.AuditUnenrollLimit.MaxBody > 0 {
+		body = http.MaxBytesReader(w, body, audit.cfg.Limits.AuditUnenrollLimit.MaxBody)
+	}
+	readCounter := datacounter.NewReaderCounter(body)
+
+	var req AuditUnenrollRequest
+	dec := json.NewDecoder(readCounter)
+	if err := dec.Decode(&req); err != nil {
+		return nil, &BadRequestErr{msg: "unable to decode audit/unenroll request", nextErr: err}
+	}
+
+	switch req.Reason {
+	case Uninstall, Orphaned, KeyRevoked:
+	default:
+		return nil, &BadRequestErr{msg: "audit/unenroll request invalid reason"}
+	}
+
+	cntAuditUnenroll.bodyIn.Add(readCounter.Count())
+	zlog.Trace().Msg("Audit unenroll request")
+	return &req, nil
+}
+
+func (audit *AuditT) markUnenroll(ctx context.Context, zlog zerolog.Logger, req *AuditUnenrollRequest, agent *model.Agent) error {
+	span, ctx := apm.StartSpan(ctx, "auditUnenroll", "process")
+	defer span.End()
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	doc := bulk.UpdateFields{
+		dl.FieldActive:                false,
+		dl.FieldUnenrolledAt:          now,
+		dl.FieldUpdatedAt:             now,
+		dl.FieldAuditUnenrolledTime:   req.Timestamp,
+		dl.FieldAuditUnenrolledReason: req.Reason,
+	}
+	body, err := doc.Marshal()
+	if err != nil {
+		return fmt.Errorf("auditUnenroll marshal: %w", err)
+	}
+
+	if err := audit.bulk.Update(ctx, dl.FleetAgents, agent.Id, body, bulk.WithRefresh(), bulk.WithRetryOnConflict(3)); err != nil {
+		return fmt.Errorf("auditUnenroll update: %w", err)
+	}
+
+	zlog.Info().Msg("audit unenroll successful")
+	return nil
 }

--- a/internal/pkg/api/handleAudit.go
+++ b/internal/pkg/api/handleAudit.go
@@ -103,7 +103,6 @@ func (audit *AuditT) markUnenroll(ctx context.Context, zlog zerolog.Logger, req 
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	doc := bulk.UpdateFields{
-		dl.FieldActive:                false,
 		dl.FieldUnenrolledAt:          now,
 		dl.FieldUpdatedAt:             now,
 		dl.FieldAuditUnenrolledTime:   req.Timestamp,

--- a/internal/pkg/api/handleAudit.go
+++ b/internal/pkg/api/handleAudit.go
@@ -1,0 +1,33 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
+	"github.com/elastic/fleet-server/v7/internal/pkg/cache"
+	"github.com/elastic/fleet-server/v7/internal/pkg/config"
+	"github.com/rs/zerolog"
+)
+
+type AuditT struct {
+	cfg   *config.Server
+	bulk  bulk.Bulk
+	cache cache.Cache
+}
+
+func NewAuditT(cfg *config.Server, bulker bulk.Bulk, cache cache.Cache) *AuditT {
+	return &AuditT{
+		cfg:   cfg,
+		bulk:  bulker,
+		cache: cache,
+	}
+}
+
+func (audit *AuditT) handleUnenroll(zlog zerolog.Logger, w http.ResponseWriter, r *http.Request, id string) error {
+	return errors.ErrUnsupported
+}

--- a/internal/pkg/api/handleAudit_test.go
+++ b/internal/pkg/api/handleAudit_test.go
@@ -1,0 +1,136 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package api
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/config"
+	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
+	"github.com/elastic/fleet-server/v7/internal/pkg/model"
+	ftesting "github.com/elastic/fleet-server/v7/internal/pkg/testing"
+	testlog "github.com/elastic/fleet-server/v7/internal/pkg/testing/log"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Audit_validateUnenrollRequst(t *testing.T) {
+	tests := []struct {
+		name  string
+		req   *http.Request
+		cfg   *config.Server
+		valid *AuditUnenrollRequest
+		err   error
+	}{{
+		name: "ok",
+		req: &http.Request{
+			Body: io.NopCloser(strings.NewReader(`{"reason":"uninstall", "timestamp": "2024-01-01T12:00:00.000Z"}`)),
+		},
+		cfg: &config.Server{},
+		valid: &AuditUnenrollRequest{
+			Reason:    Uninstall,
+			Timestamp: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		},
+		err: nil,
+	}, {
+		name: "not json object",
+		req: &http.Request{
+			Body: io.NopCloser(strings.NewReader(`{"invalidJson":}`)),
+		},
+		cfg:   &config.Server{},
+		valid: nil,
+		err:   &BadRequestErr{msg: "unable to decode audit/unenroll request"},
+	}, {
+		name: "bad reason",
+		req: &http.Request{
+			Body: io.NopCloser(strings.NewReader(`{"reason":"bad reason", "timestamp": "2024-01-01T12:00:00.000Z"}`)),
+		},
+		cfg:   &config.Server{},
+		valid: nil,
+		err:   &BadRequestErr{msg: "audit/unenroll request invalid reason"},
+	}, {
+		name: "too large",
+		req: &http.Request{
+			Body: io.NopCloser(strings.NewReader(`{"reason":"uninstalled", "timestamp": "2024-01-01T12:00:00.000Z"}`)),
+		},
+		cfg: &config.Server{
+			Limits: config.ServerLimits{
+				AuditUnenrollLimit: config.Limit{
+					MaxBody: 10,
+				},
+			},
+		},
+		valid: nil,
+		err:   &BadRequestErr{msg: "unable to decode audit/unenroll request"},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			audit := AuditT{cfg: tc.cfg}
+			w := httptest.NewRecorder()
+
+			r, err := audit.validateUnenrollRequest(testlog.SetLogger(t), w, tc.req)
+			if tc.err != nil {
+				require.EqualError(t, err, tc.err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.valid, r)
+		})
+	}
+}
+
+func Test_Audit_markUnenroll(t *testing.T) {
+	agent := &model.Agent{
+		ESDocument: model.ESDocument{
+			Id: "test-id",
+		},
+	}
+	bulker := ftesting.NewMockBulk()
+	bulker.On("Update", mock.Anything, dl.FleetAgents, agent.Id, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	audit := AuditT{bulk: bulker}
+	logger := testlog.SetLogger(t)
+	err := audit.markUnenroll(context.Background(), logger, &AuditUnenrollRequest{Reason: Uninstall, Timestamp: time.Now().UTC()}, agent)
+	require.NoError(t, err)
+	bulker.AssertExpectations(t)
+}
+
+func Test_Audit_unenroll(t *testing.T) {
+	t.Run("agent has audit_unenroll_reason", func(t *testing.T) {
+		agent := &model.Agent{
+			AuditUnenrolledReason: string(Uninstall),
+		}
+		audit := &AuditT{}
+		err := audit.unenroll(testlog.SetLogger(t), nil, nil, agent)
+		require.EqualError(t, err, ErrAuditUnenrollReason.Error())
+	})
+
+	t.Run("ok", func(t *testing.T) {
+		agent := &model.Agent{
+			ESDocument: model.ESDocument{
+				Id: "test-id",
+			},
+		}
+		bulker := ftesting.NewMockBulk()
+		bulker.On("Update", mock.Anything, dl.FleetAgents, agent.Id, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		audit := &AuditT{
+			bulk: bulker,
+			cfg:  &config.Server{},
+		}
+		req := &http.Request{
+			Body: io.NopCloser(strings.NewReader(`{"reason": "uninstall", "timestamp": "2024-01-01T12:00:00.000Z"}`)),
+		}
+		err := audit.unenroll(testlog.SetLogger(t), httptest.NewRecorder(), req, agent)
+		require.NoError(t, err)
+		bulker.AssertExpectations(t)
+	})
+}

--- a/internal/pkg/api/metrics.go
+++ b/internal/pkg/api/metrics.go
@@ -35,16 +35,17 @@ var (
 	cntHTTPClose  *statsCounter
 	cntHTTPActive *statsGauge
 
-	cntCheckin     routeStats
-	cntEnroll      routeStats
-	cntAcks        routeStats
-	cntStatus      routeStats
-	cntUploadStart routeStats
-	cntUploadChunk routeStats
-	cntUploadEnd   routeStats
-	cntFileDeliv   routeStats
-	cntGetPGP      routeStats
-	cntArtifacts   artifactStats
+	cntCheckin       routeStats
+	cntEnroll        routeStats
+	cntAcks          routeStats
+	cntStatus        routeStats
+	cntUploadStart   routeStats
+	cntUploadChunk   routeStats
+	cntUploadEnd     routeStats
+	cntFileDeliv     routeStats
+	cntGetPGP        routeStats
+	cntAuditUnenroll routeStats
+	cntArtifacts     artifactStats
 
 	infoReg sync.Once
 )
@@ -75,7 +76,7 @@ func init() {
 	cntUploadEnd.Register(routesRegistry.newRegistry("uploadEnd"))
 	cntFileDeliv.Register(routesRegistry.newRegistry("deliverFile"))
 	cntGetPGP.Register(routesRegistry.newRegistry("getPGPKey"))
-
+	cntAuditUnenroll.Register(routesRegistry.newRegistry("auditUnenroll"))
 }
 
 // metricsRegistry wraps libbeat and prometheus registries

--- a/internal/pkg/api/openapi.gen.go
+++ b/internal/pkg/api/openapi.gen.go
@@ -840,6 +840,9 @@ type AgentNotFound = Error
 // BadRequest Error processing request.
 type BadRequest = Error
 
+// Conflict Error processing request.
+type Conflict = Error
+
 // Deadline Error processing request.
 type Deadline = Error
 

--- a/internal/pkg/api/router_test.go
+++ b/internal/pkg/api/router_test.go
@@ -34,6 +34,8 @@ func TestPathToOperation(t *testing.T) {
 		{"/api/fleet/file", ""},
 		{"/api/fleet/file/abc", "deliverFile"},
 		{"/api/fleet/artifacts/some-id/hash", "artifact"},
+		{"/api/fleet/agents/some-id/audit/unenroll", "audit-unenroll"},
+		{"/api/fleet/agents/some-id/other/unenroll", ""},
 		{"/api/fleet/unimplemented/some-id", ""},
 		{"/api/flet/agents/some-id/acks", ""},
 		{"/api/fleet/agents/some-id/other", ""},

--- a/internal/pkg/api/server.go
+++ b/internal/pkg/api/server.go
@@ -35,7 +35,7 @@ type server struct {
 //
 // The server has a listener specific conn limit and endpoint specific rate-limits.
 // The underlying API structs (such as *CheckinT) may be shared between servers.
-func NewServer(addr string, cfg *config.Server, ct *CheckinT, et *EnrollerT, at *ArtifactT, ack *AckT, st *StatusT, sm policy.SelfMonitor, bi build.Info, ut *UploadT, ft *FileDeliveryT, pt *PGPRetrieverT, bulker bulk.Bulk, tracer *apm.Tracer) *server {
+func NewServer(addr string, cfg *config.Server, ct *CheckinT, et *EnrollerT, at *ArtifactT, ack *AckT, st *StatusT, sm policy.SelfMonitor, bi build.Info, ut *UploadT, ft *FileDeliveryT, pt *PGPRetrieverT, audit *AuditT, bulker bulk.Bulk, tracer *apm.Tracer) *server {
 	a := &apiServer{
 		ct:     ct,
 		et:     et,
@@ -47,6 +47,7 @@ func NewServer(addr string, cfg *config.Server, ct *CheckinT, et *EnrollerT, at 
 		ut:     ut,
 		ft:     ft,
 		pt:     pt,
+		audit:  audit,
 		bulker: bulker,
 	}
 	return &server{

--- a/internal/pkg/api/server_test.go
+++ b/internal/pkg/api/server_test.go
@@ -43,7 +43,7 @@ func Test_server_Run(t *testing.T) {
 	cfg.Port = port
 	addr := cfg.BindEndpoints()[0]
 
-	srv := NewServer(addr, cfg, nil, nil, nil, nil, nil, nil, fbuild.Info{}, nil, nil, nil, nil, nil)
+	srv := NewServer(addr, cfg, nil, nil, nil, nil, nil, nil, fbuild.Info{}, nil, nil, nil, nil, nil, nil)
 
 	started := make(chan struct{}, 1)
 	errCh := make(chan error, 1)
@@ -124,7 +124,7 @@ func Test_server_ClientCert(t *testing.T) {
 		cfg.TLS = tlsCFG
 
 		st := NewStatusT(cfg, nil, nil)
-		srv := NewServer(addr, cfg, nil, nil, nil, nil, st, sm, fbuild.Info{}, nil, nil, nil, nil, nil)
+		srv := NewServer(addr, cfg, nil, nil, nil, nil, st, sm, fbuild.Info{}, nil, nil, nil, nil, nil, nil)
 
 		// make http client with no client certs
 		certPool := x509.NewCertPool()
@@ -194,7 +194,7 @@ func Test_server_ClientCert(t *testing.T) {
 		cfg.TLS = tlsCFG
 
 		st := NewStatusT(cfg, nil, nil)
-		srv := NewServer(addr, cfg, nil, nil, nil, nil, st, sm, fbuild.Info{}, nil, nil, nil, nil, nil)
+		srv := NewServer(addr, cfg, nil, nil, nil, nil, st, sm, fbuild.Info{}, nil, nil, nil, nil, nil, nil)
 
 		// make http client with valid client certs
 		clientCert := certs.GenCert(t, ca)
@@ -266,7 +266,7 @@ func Test_server_ClientCert(t *testing.T) {
 		cfg.TLS = tlsCFG
 
 		st := NewStatusT(cfg, nil, nil)
-		srv := NewServer(addr, cfg, nil, nil, nil, nil, st, sm, fbuild.Info{}, nil, nil, nil, nil, nil)
+		srv := NewServer(addr, cfg, nil, nil, nil, nil, st, sm, fbuild.Info{}, nil, nil, nil, nil, nil, nil)
 
 		// make http client with invalid client certs
 		clientCA := certs.GenCA(t)
@@ -349,7 +349,7 @@ key: %s`,
 		cfg.TLS = tlsCFG
 
 		st := NewStatusT(cfg, nil, nil)
-		srv := NewServer(addr, cfg, nil, nil, nil, nil, st, sm, fbuild.Info{}, nil, nil, nil, nil, nil)
+		srv := NewServer(addr, cfg, nil, nil, nil, nil, st, sm, fbuild.Info{}, nil, nil, nil, nil, nil, nil)
 
 		// make http client with valid client certs
 		clientCert := certs.GenCert(t, ca)

--- a/internal/pkg/config/defaults/lte10000_limits.yml
+++ b/internal/pkg/config/defaults/lte10000_limits.yml
@@ -53,3 +53,7 @@ server_limits:
     interval: 1ms
     burst: 2000
     max: 4000
+  audit_unenroll_limit:
+    interval: 1ms
+    burst: 2000
+    max: 4000

--- a/internal/pkg/config/defaults/lte20000_limits.yml
+++ b/internal/pkg/config/defaults/lte20000_limits.yml
@@ -53,3 +53,7 @@ server_limits:
     interval: 0.5ms
     burst: 4000
     max: 8000
+  audit_unenroll_limit:
+    interval: 0.5ms
+    burst: 4000
+    max: 8000

--- a/internal/pkg/config/defaults/lte2500_limite.yml
+++ b/internal/pkg/config/defaults/lte2500_limite.yml
@@ -53,3 +53,7 @@ server_limits:
     interval: 5ms
     burst: 500
     max: 1000
+  audit_unenroll_limit:
+    interval: 4ms
+    burst: 500
+    max: 1000

--- a/internal/pkg/config/defaults/lte40000_limits.yml
+++ b/internal/pkg/config/defaults/lte40000_limits.yml
@@ -52,3 +52,7 @@ server_limits:
     interval: 0.5ms
     burst: 4000
     max: 8000
+  audit_unenroll_limit:
+    interval: 0.5ms
+    burst: 4000
+    max: 8000

--- a/internal/pkg/config/defaults/lte5000_limits.yml
+++ b/internal/pkg/config/defaults/lte5000_limits.yml
@@ -53,3 +53,7 @@ server_limits:
     interval: 2ms
     burst: 1000
     max: 2000
+  audit_unenroll_limit:
+    interval: 2ms
+    burst: 1000
+    max: 2000

--- a/internal/pkg/config/defaults/max_limits.yml
+++ b/internal/pkg/config/defaults/max_limits.yml
@@ -51,3 +51,7 @@ server_limits:
     interval: 0.25ms
     burst: 8000
     max: 16000
+  audit_unenroll_limit:
+    interval: 0.25ms
+    burst: 8000
+    max: 16000

--- a/internal/pkg/config/env_defaults.go
+++ b/internal/pkg/config/env_defaults.go
@@ -81,6 +81,11 @@ const (
 	defaultPGPRetrievalBurst    = 25
 	defaultPGPRetrievalMax      = 50
 	defaultPGPRetrievalMaxBody  = 0
+
+	defaultAuditUnenrollInterval = time.Millisecond * 10
+	defaultAuditUnenrollBurst    = 50
+	defaultAuditUnenrollMax      = 100
+	defaultAuditUnenrollMaxBody  = 1024
 )
 
 type valueRange struct {
@@ -139,18 +144,19 @@ type serverLimitDefaults struct {
 	PolicyThrottle time.Duration `config:"policy_throttle"` // deprecated: replaced by policy_limit
 	MaxConnections int           `config:"max_connections"`
 
-	ActionLimit      limit `config:"action_limit"`
-	PolicyLimit      limit `config:"policy_limit"`
-	CheckinLimit     limit `config:"checkin_limit"`
-	ArtifactLimit    limit `config:"artifact_limit"`
-	EnrollLimit      limit `config:"enroll_limit"`
-	AckLimit         limit `config:"ack_limit"`
-	StatusLimit      limit `config:"status_limit"`
-	UploadStartLimit limit `config:"upload_start_limit"`
-	UploadEndLimit   limit `config:"upload_end_limit"`
-	UploadChunkLimit limit `config:"upload_chunk_limit"`
-	DeliverFileLimit limit `config:"file_delivery_limit"`
-	GetPGPKeyLimit   limit `config:"pgp_retrieval_limit"`
+	ActionLimit        limit `config:"action_limit"`
+	PolicyLimit        limit `config:"policy_limit"`
+	CheckinLimit       limit `config:"checkin_limit"`
+	ArtifactLimit      limit `config:"artifact_limit"`
+	EnrollLimit        limit `config:"enroll_limit"`
+	AckLimit           limit `config:"ack_limit"`
+	StatusLimit        limit `config:"status_limit"`
+	UploadStartLimit   limit `config:"upload_start_limit"`
+	UploadEndLimit     limit `config:"upload_end_limit"`
+	UploadChunkLimit   limit `config:"upload_chunk_limit"`
+	DeliverFileLimit   limit `config:"file_delivery_limit"`
+	GetPGPKeyLimit     limit `config:"pgp_retrieval_limit"`
+	AuditUnenrollLimit limit `config:"audit_unenroll_limit"`
 }
 
 func defaultserverLimitDefaults() *serverLimitDefaults {
@@ -223,6 +229,12 @@ func defaultserverLimitDefaults() *serverLimitDefaults {
 			Burst:    defaultPGPRetrievalBurst,
 			Max:      defaultPGPRetrievalMax,
 			MaxBody:  defaultPGPRetrievalMaxBody,
+		},
+		AuditUnenrollLimit: limit{
+			Interval: defaultAuditUnenrollInterval,
+			Burst:    defaultAuditUnenrollBurst,
+			Max:      defaultAuditUnenrollMax,
+			MaxBody:  defaultAuditUnenrollMaxBody,
 		},
 	}
 }

--- a/internal/pkg/config/limits.go
+++ b/internal/pkg/config/limits.go
@@ -21,18 +21,19 @@ type ServerLimits struct {
 	MaxHeaderByteSize int           `config:"max_header_byte_size"`
 	MaxConnections    int           `config:"max_connections"`
 
-	ActionLimit      Limit `config:"action_limit"`
-	PolicyLimit      Limit `config:"policy_limit"`
-	CheckinLimit     Limit `config:"checkin_limit"`
-	ArtifactLimit    Limit `config:"artifact_limit"`
-	EnrollLimit      Limit `config:"enroll_limit"`
-	AckLimit         Limit `config:"ack_limit"`
-	StatusLimit      Limit `config:"status_limit"`
-	UploadStartLimit Limit `config:"upload_start_limit"`
-	UploadEndLimit   Limit `config:"upload_end_limit"`
-	UploadChunkLimit Limit `config:"upload_chunk_limit"`
-	DeliverFileLimit Limit `config:"file_delivery_limit"`
-	GetPGPKey        Limit `config:"pgp_retrieval_limit"`
+	ActionLimit        Limit `config:"action_limit"`
+	PolicyLimit        Limit `config:"policy_limit"`
+	CheckinLimit       Limit `config:"checkin_limit"`
+	ArtifactLimit      Limit `config:"artifact_limit"`
+	EnrollLimit        Limit `config:"enroll_limit"`
+	AckLimit           Limit `config:"ack_limit"`
+	StatusLimit        Limit `config:"status_limit"`
+	UploadStartLimit   Limit `config:"upload_start_limit"`
+	UploadEndLimit     Limit `config:"upload_end_limit"`
+	UploadChunkLimit   Limit `config:"upload_chunk_limit"`
+	DeliverFileLimit   Limit `config:"file_delivery_limit"`
+	GetPGPKey          Limit `config:"pgp_retrieval_limit"`
+	AuditUnenrollLimit Limit `config:"audit_unenroll_limit"`
 }
 
 // InitDefaults initializes the defaults for the configuration.
@@ -63,6 +64,7 @@ func (c *ServerLimits) LoadLimits(limits *envLimits) {
 	c.UploadChunkLimit = mergeEnvLimit(c.UploadChunkLimit, l.UploadChunkLimit)
 	c.DeliverFileLimit = mergeEnvLimit(c.DeliverFileLimit, l.DeliverFileLimit)
 	c.GetPGPKey = mergeEnvLimit(c.GetPGPKey, l.GetPGPKeyLimit)
+	c.AuditUnenrollLimit = mergeEnvLimit(c.AuditUnenrollLimit, l.AuditUnenrollLimit)
 }
 
 func mergeEnvLimit(L Limit, l limit) Limit {

--- a/internal/pkg/dl/constants.go
+++ b/internal/pkg/dl/constants.go
@@ -53,6 +53,9 @@ const (
 	FieldUpgradeStatus    = "upgrade_status"
 	FieldUpgradeDetails   = "upgrade_details"
 
+	FieldAuditUnenrolledTime   = "audit_unenrolled_time"
+	FieldAuditUnenrolledReason = "audit_unenrolled_reason"
+
 	FieldDecodedSha256 = "decoded_sha256"
 	FieldIdentifier    = "identifier"
 	FieldSharedID      = "shared_id"

--- a/internal/pkg/model/schema.go
+++ b/internal/pkg/model/schema.go
@@ -129,6 +129,12 @@ type Agent struct {
 	Active bool           `json:"active"`
 	Agent  *AgentMetadata `json:"agent,omitempty"`
 
+	// Agent reason for unenroll/uninstall annotation.
+	AuditUnenrolledReason string `json:"audit_unenrolled_reason,omitempty"`
+
+	// Agent timestamp for audit unenroll/uninstall action
+	AuditUnenrolledTime string `json:"audit_unenrolled_time,omitempty"`
+
 	// Elastic Agent components detailed status information
 	Components []ComponentsItems `json:"components,omitempty"`
 

--- a/internal/pkg/server/fleet.go
+++ b/internal/pkg/server/fleet.go
@@ -540,9 +540,10 @@ func (f *Fleet) runSubsystems(ctx context.Context, cfg *config.Config, g *errgro
 	ut := api.NewUploadT(&cfg.Inputs[0].Server, bulker, monCli, f.cache) // uses no-retry client for bufferless chunk upload
 	ft := api.NewFileDeliveryT(&cfg.Inputs[0].Server, bulker, monCli, f.cache)
 	pt := api.NewPGPRetrieverT(&cfg.Inputs[0].Server, bulker, f.cache)
+	auditT := api.NewAuditT(&cfg.Inputs[0].Server, bulker, f.cache)
 
 	for _, endpoint := range (&cfg.Inputs[0].Server).BindEndpoints() {
-		apiServer := api.NewServer(endpoint, &cfg.Inputs[0].Server, ct, et, at, ack, st, sm, f.bi, ut, ft, pt, bulker, tracer)
+		apiServer := api.NewServer(endpoint, &cfg.Inputs[0].Server, ct, et, at, ack, st, sm, f.bi, ut, ft, pt, auditT, bulker, tracer)
 		g.Go(loggedRunFunc(ctx, "Http server", func(ctx context.Context) error {
 			return apiServer.Run(ctx)
 		}))

--- a/internal/pkg/testing/setup.go
+++ b/internal/pkg/testing/setup.go
@@ -29,7 +29,7 @@ var defaultCfgData = []byte(`
 output:
   elasticsearch:
     hosts: '${ELASTICSEARCH_HOSTS:localhost:9200}'
-    service_token: '${ELASTICSEARCH_SERVICE_TOKEN}'
+    service_token: '${ELASTICSEARCH_SERVICE_TOKEN:test-token}'
 fleet:
   agent:
     id: 1e4954ce-af37-4731-9f4a-407b08e69e42

--- a/model/openapi.yml
+++ b/model/openapi.yml
@@ -917,6 +917,26 @@ components:
               type: string
               examples:
                 - 83810fdc61c44290778c212d7829d0c3f0232e81bd551d3943998a920025d14f
+    auditUnenrollRequest:
+      description: Request to add unenroll audit information to an agent document.
+      type: object
+      required:
+        - reason
+        - timestamp
+      properties:
+        reason:
+          description: The unenroll reason
+          type: string
+          enum:
+            - uninstall
+            - orphaned
+            - key_revoked # here for completeness, fleet-ui should set this reason when a FORCE_UNENROLL action is made.
+          examples:
+            - uninstall
+        timestamp:
+          description: Agent timestamp of when the uninstall/unenroll action occured; may differ from fleet-server time due to retries.
+          type: string
+          format: date-time
   parameters:
     requestId:
       name: X-Request-Id
@@ -1774,3 +1794,57 @@ paths:
               $ref: "#/components/headers/apiVersion"
             X-Request-Id:
               $ref: "#/components/headers/requestID"
+  /api/fleet/agents/{id}/audit/unenroll:
+    post:
+      operationId: auditUnenroll
+      summary: Annotate an agent with unenroll attributes.
+      description: |
+        Annotate an agent with unenroll attributes so the UI will show it as uninstalled or orphaned instead of offline.
+        API keys for an agent that is annotated will not be revoked by fleet-server.
+        If an agent checks in after the unenroll attributes are set, the attributes will be removed from the agent document.
+      security:
+        - agentApiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/auditUnenrollRequest"
+            examples:
+              request:
+                description: An uninstall request.
+                value:
+                  reason: uninstall
+                  timestamp: 2024-01-01T12:00:00.000Z
+      parameters:
+        - name: id
+          in: path
+          description: The agent ID.
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/requestId"
+        - $ref: "#/components/parameters/apiVersion"
+      responses:
+        "200":
+          description: Audit attributes set in agent document.
+          headers:
+            Elastic-Api-Version:
+              $ref: "#/components/headers/apiVersion"
+            X-Request-Id:
+              $ref: "#/components/headers/requestID"
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/keyNotEnabled"
+        "409":
+          description: audit_reason attribute already set in agent document
+          headers:
+            Elastic-Api-Version:
+              $ref: "#/components/headers/apiVersion"
+            X-Request-Id:
+              $ref: "#/components/headers/requestID"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+        "503":
+          $ref: "#/components/responses/unavailable"

--- a/model/openapi.yml
+++ b/model/openapi.yml
@@ -1093,6 +1093,25 @@ components:
                 statusCode: 408
                 error: RequestTimeout
                 message: timeout on request
+    conflict:
+      description: 409 conflict response.
+      headers:
+        Elastic-Api-Version:
+          $ref: "#/components/headers/apiVersion"
+        X-Request-Id:
+          $ref: "#/components/headers/requestID"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/error"
+          examples:
+            reasonConflict:
+              description: Audit unenroll endpoint agent already has reason attribute.
+              value:
+                statusCode: 409
+                error: ErrAuditReasonConflict
+                message: agent document contains audit_unenroll_reason
     throttle:
       description: 428 rate limiting request.
       headers:
@@ -1838,12 +1857,7 @@ paths:
         "401":
           $ref: "#/components/responses/keyNotEnabled"
         "409":
-          description: audit_reason attribute already set in agent document
-          headers:
-            Elastic-Api-Version:
-              $ref: "#/components/headers/apiVersion"
-            X-Request-Id:
-              $ref: "#/components/headers/requestID"
+          $ref: "#/components/responses/conflict"
         "500":
           $ref: "#/components/responses/internalServerError"
         "503":

--- a/model/schema.json
+++ b/model/schema.json
@@ -521,6 +521,16 @@
           "type": "string",
           "format": "date-time"
         },
+        "audit_unenrolled_time": {
+          "description": "Agent timestamp for audit unenroll/uninstall action",
+          "type": "string",
+          "format": "date-time"
+        },
+        "audit_unenrolled_reason": {
+          "description": "Agent reason for unenroll/uninstall annotation.",
+          "type": "string",
+          "enum": ["uninstall", "orphaned", "key_revoked"]
+        },
         "upgraded_at": {
           "description": "Date/time the Elastic Agent was last upgraded",
           "type": "string",

--- a/pkg/api/client.gen.go
+++ b/pkg/api/client.gen.go
@@ -1301,6 +1301,7 @@ type AuditUnenrollResponse struct {
 	HTTPResponse *http.Response
 	JSON400      *BadRequest
 	JSON401      *KeyNotEnabled
+	JSON409      *Conflict
 	JSON500      *InternalServerError
 	JSON503      *Unavailable
 }
@@ -1856,6 +1857,13 @@ func ParseAuditUnenrollResponse(rsp *http.Response) (*AuditUnenrollResponse, err
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Conflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerError

--- a/pkg/api/types.gen.go
+++ b/pkg/api/types.gen.go
@@ -837,6 +837,9 @@ type AgentNotFound = Error
 // BadRequest Error processing request.
 type BadRequest = Error
 
+// Conflict Error processing request.
+type Conflict = Error
+
 // Deadline Error processing request.
 type Deadline = Error
 

--- a/pkg/api/types.gen.go
+++ b/pkg/api/types.gen.go
@@ -47,6 +47,13 @@ const (
 	ActionSettingsLogLevelWarning ActionSettingsLogLevel = "warning"
 )
 
+// Defines values for AuditUnenrollRequestReason.
+const (
+	KeyRevoked AuditUnenrollRequestReason = "key_revoked"
+	Orphaned   AuditUnenrollRequestReason = "orphaned"
+	Uninstall  AuditUnenrollRequestReason = "uninstall"
+)
+
 // Defines values for CheckinRequestStatus.
 const (
 	CheckinRequestStatusDegraded CheckinRequestStatus = "degraded"
@@ -257,6 +264,18 @@ type ActionUpgrade struct {
 	// Version The version number that the agent should upgrade to.
 	Version string `json:"version"`
 }
+
+// AuditUnenrollRequest Request to add unenroll audit information to an agent document.
+type AuditUnenrollRequest struct {
+	// Reason The unenroll reason
+	Reason AuditUnenrollRequestReason `json:"reason"`
+
+	// Timestamp Agent timestamp of when the uninstall/unenroll action occured; may differ from fleet-server time due to retries.
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// AuditUnenrollRequestReason The unenroll reason
+type AuditUnenrollRequestReason string
 
 // CheckinRequest defines model for checkinRequest.
 type CheckinRequest struct {
@@ -868,6 +887,15 @@ type AgentAcksParams struct {
 	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
 }
 
+// AuditUnenrollParams defines parameters for AuditUnenroll.
+type AuditUnenrollParams struct {
+	// XRequestId The request tracking ID for APM.
+	XRequestId *RequestId `json:"X-Request-Id,omitempty"`
+
+	// ElasticApiVersion The API version to use, format should be "YYYY-MM-DD"
+	ElasticApiVersion *ApiVersion `json:"elastic-api-version,omitempty"`
+}
+
 // AgentCheckinParams defines parameters for AgentCheckin.
 type AgentCheckinParams struct {
 	// AcceptEncoding If the agent is able to accept encoded responses.
@@ -949,6 +977,9 @@ type AgentEnrollJSONRequestBody = EnrollRequest
 
 // AgentAcksJSONRequestBody defines body for AgentAcks for application/json ContentType.
 type AgentAcksJSONRequestBody = AckRequest
+
+// AuditUnenrollJSONRequestBody defines body for AuditUnenroll for application/json ContentType.
+type AuditUnenrollJSONRequestBody = AuditUnenrollRequest
 
 // AgentCheckinJSONRequestBody defines body for AgentCheckin for application/json ContentType.
 type AgentCheckinJSONRequestBody = CheckinRequest

--- a/testing/e2e/api_version/client_api_current.go
+++ b/testing/e2e/api_version/client_api_current.go
@@ -286,6 +286,19 @@ func (tester *ClientAPITester) GetPGPKey(ctx context.Context, apiKey string) []b
 	return resp.Body
 }
 
+func (tester *ClientAPITester) AuditUnenroll(ctx context.Context, apiKey, id string, reason api.AuditUnenrollRequestReason, timestamp time.Time) int {
+	client, err := api.NewClientWithResponses(tester.endpoint, api.WithHTTPClient(tester.Client), api.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+		req.Header.Set("Authorization", "ApiKey "+apiKey)
+		return nil
+	}))
+	tester.Require().NoError(err)
+
+	resp, err := client.AuditUnenrollWithResponse(ctx, id, nil, api.AuditUnenrollJSONRequestBody{Reason: reason, Timestamp: timestamp})
+	tester.Require().NoError(err)
+	resp.Body.Close()
+	return resp.StatusCode
+}
+
 func (tester *ClientAPITester) TestStatus_Unauthenticated() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -364,4 +377,22 @@ func (tester *ClientAPITester) TestGetPGPKey() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	tester.GetPGPKey(ctx, tester.enrollmentKey)
+}
+
+func (tester *ClientAPITester) TestEnrollAuditUnenroll() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	now := time.Now().UTC()
+
+	tester.T().Log("test enrollment")
+	agentID, agentKey := tester.Enroll(ctx, tester.enrollmentKey)
+	tester.VerifyAgentInKibana(ctx, agentID)
+
+	tester.T().Logf("use audit/unenroll endpoint for agent: %s", agentID)
+	status := tester.AuditUnenroll(ctx, agentKey, agentID, api.Uninstall, now)
+	tester.Require().Equal(t, http.StatusOK, status)
+
+	tester.T().Logf("audit/unenroll endpoint for agent: %s should return conflict", agentID)
+	status = tester.AuditUnenroll(ctx, agentKey, agentID, api.Uninstall, now)
+	tester.Require().Equal(t, http.StatusConflict, status)
 }

--- a/testing/e2e/api_version/client_api_current.go
+++ b/testing/e2e/api_version/client_api_current.go
@@ -295,8 +295,7 @@ func (tester *ClientAPITester) AuditUnenroll(ctx context.Context, apiKey, id str
 
 	resp, err := client.AuditUnenrollWithResponse(ctx, id, nil, api.AuditUnenrollJSONRequestBody{Reason: reason, Timestamp: timestamp})
 	tester.Require().NoError(err)
-	resp.Body.Close()
-	return resp.StatusCode
+	return resp.StatusCode()
 }
 
 func (tester *ClientAPITester) TestStatus_Unauthenticated() {
@@ -390,9 +389,9 @@ func (tester *ClientAPITester) TestEnrollAuditUnenroll() {
 
 	tester.T().Logf("use audit/unenroll endpoint for agent: %s", agentID)
 	status := tester.AuditUnenroll(ctx, agentKey, agentID, api.Uninstall, now)
-	tester.Require().Equal(t, http.StatusOK, status)
+	tester.Require().Equal(http.StatusOK, status)
 
 	tester.T().Logf("audit/unenroll endpoint for agent: %s should return conflict", agentID)
 	status = tester.AuditUnenroll(ctx, agentKey, agentID, api.Uninstall, now)
-	tester.Require().Equal(t, http.StatusConflict, status)
+	tester.Require().Equal(http.StatusConflict, status)
 }


### PR DESCRIPTION
## What is the problem this PR solves?

Uninstalled agents appear as offline in the fleet UI.

## How does this PR solve the problem?

Add `/api/fleet/agents/:id/audit/unenroll` API that an elastic-agent or Endpoint process may use to annotate the agent document so the agent may appear with a different status.

### Changes from RFC

[RFC here](https://docs.google.com/document/d/1gYbsGfvjc7NhbURwYNqEl25ouar81nZ_8bkpsi0Dc6Y/edit#heading=h.pfm1mse74cxb)

Changes are:
- 409 responses will include a JSON body to be consistent with other errors
- Successfull requests will alter the following agent document attributes:
  - `audit_unenrolled_time` - time from request
  - `audit_unenrolled_reason` - reason from request
  - `unenrolled_at` - server current time UTC
  - `updated_at` - server current time UTC (new)
  - ~~`active` - set to `false` (new)~~ removed change, was causing the api key auth to fail breaking integration and e2e tests
 
## How to test this PR locally

`make test-e2e` will run e2e tests as we need to change the elastic-agent or other test tools in order to use the endpoint

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/484
