### PR TITLE
audit/unenroll orphaned reason will replace uninstalled

### DIFF
--- a/internal/pkg/api/handleAudit.go
+++ b/internal/pkg/api/handleAudit.go
@@ -22,7 +22,7 @@ import (
 	"go.elastic.co/apm/v2"
 )
 
-var ErrAuditUnenrollReason = fmt.Errorf("agent document contains audit_unenroll_reason attribute")
+var ErrAuditUnenrollReason = fmt.Errorf("agent document contains audit_unenroll_reason: orphaned")
 
 type AuditT struct {
 	cfg   *config.Server
@@ -51,7 +51,7 @@ func (audit *AuditT) handleUnenroll(zlog zerolog.Logger, w http.ResponseWriter, 
 }
 
 func (audit *AuditT) unenroll(zlog zerolog.Logger, w http.ResponseWriter, r *http.Request, agent *model.Agent) error {
-	if agent.AuditUnenrolledReason != "" {
+	if agent.AuditUnenrolledReason == string(Orphaned) {
 		return ErrAuditUnenrollReason
 	}
 

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -1471,7 +1471,7 @@ func Test_SmokeTest_AuditUnenroll(t *testing.T) {
 	  "timestamp": "2024-01-01T12:00:00.000Z"
 	}`
 	uninstallBody := `{
-          "reason": "orphaned",
+          "reason": "uninstall",
 	  "timestamp": "2024-01-01T12:00:00.000Z"
 	}`
 	req, err := http.NewRequestWithContext(ctx, "POST", srv.baseURL()+"/api/fleet/agents/"+id+"/audit/unenroll", strings.NewReader(uninstallBody))

--- a/testing/e2e/api_version/client_api_current.go
+++ b/testing/e2e/api_version/client_api_current.go
@@ -391,6 +391,10 @@ func (tester *ClientAPITester) TestEnrollAuditUnenroll() {
 	status := tester.AuditUnenroll(ctx, agentKey, agentID, api.Uninstall, now)
 	tester.Require().Equal(http.StatusOK, status)
 
+	tester.T().Logf("use audit/unenroll endpoint to replace uninstalled with orphaned for agent: %s", agentID)
+	status = tester.AuditUnenroll(ctx, agentKey, agentID, api.Orphaned, now)
+	tester.Require().Equal(http.StatusOK, status)
+
 	tester.T().Logf("audit/unenroll endpoint for agent: %s should return conflict", agentID)
 	status = tester.AuditUnenroll(ctx, agentKey, agentID, api.Uninstall, now)
 	tester.Require().Equal(http.StatusConflict, status)


### PR DESCRIPTION
## What is the problem this PR solves?

Fix to unreleased api: allow the `orphaned` reason to replace `uninstall` .
This will allow Endpoint to notify fleet-server if it is still running after the agent has called the api,

## Checklist

- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)~~