### PR TITLE
github-action: use oblt-actions/elastic/active-branches

### DIFF
--- a/.github/workflows/bump-elastic-stack-snapshot.yml
+++ b/.github/workflows/bump-elastic-stack-snapshot.yml
@@ -17,7 +17,7 @@ jobs:
       matrix: ${{ steps.generator.outputs.matrix }}
     steps:
       - id: generator
-        uses: elastic/apm-pipeline-library/.github/actions/elastic-stack-snapshot-branches@current
+        uses: elastic/oblt-actions/elastic/active-branches@v1
 
   bump-elastic-stack:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

NOTE: https://github.com/elastic/apm-pipeline-library has been deprecated in favor of 
https://github.com/elastic/oblt-actions.

If there are any questions, please reach out to the @elastic/observablt-ci
