### PR TITLE
Automatically label PRs to `main` with `backport-v8.x`

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -259,3 +259,21 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: notify the backport policy
+    conditions:
+      - -label~=^backport
+      - base=main
+      - -merged
+      - -closed
+    actions:
+      comment:
+        message: |
+          This pull request does not have a backport label. Could you fix it @{{author}}? 🙏
+          To fixup this pull request, you need to add the backport labels for the needed
+          branches, such as:
+          * `backport-v./d./d./d` is the label to automatically backport to the `8./d` branch. `/d` is the digit
+          **NOTE**: `backport-skip` has been added to this pull request.
+          `backport-v8.x` has been added to help with the transition to the new branch 8.x.
+      label:
+        add:
+          - backport-v8.x


### PR DESCRIPTION
When the `main` branch switches over to `9.0`, we will want most PRs that are merged into `main` to also be backported to `8.x`. This PR makes this process easier by automatically adding the `backport-8.x` label to all PRs targeting the `main` branch.

The exceptions will be PRs for changes that should _only_ be present in `9.0`. For such PRs, authors should simply remove the `backport-8.x` label from their PR.
