### PR TITLE
Fix version source when making e2e agent image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,7 @@ test-int-set: ## - Run integration tests without setup
 .PHONY: build-e2e-agent-image
 build-e2e-agent-image: docker-cover-e2e-binaries ## - Build a custom elastic-agent image with fleet-server binaries with coverage enabled injected
 	@printf "${CMD_COLOR_ON} Creating test e2e agent image\n${CMD_COLOR_OFF}"
-	FLEET_VERSION=$(VERSION) GOARCH=amd64 ./dev-tools/e2e/build.sh
+	FLEET_VERSION=${DEFAULT_VERSION}-SNAPSHOT GOARCH=amd64 ./dev-tools/e2e/build.sh # force fleet version to be equal to VERSION-SNAPSHOT
 
 .PHONY: e2e-certs
 e2e-certs: ## - Use openssl to create a CA, encrypted private key, and signed fleet-server cert testing purposes

--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,7 @@ test-int-set: ## - Run integration tests without setup
 .PHONY: build-e2e-agent-image
 build-e2e-agent-image: docker-cover-e2e-binaries ## - Build a custom elastic-agent image with fleet-server binaries with coverage enabled injected
 	@printf "${CMD_COLOR_ON} Creating test e2e agent image\n${CMD_COLOR_OFF}"
-	GOARCH=amd64 ./dev-tools/e2e/build.sh
+	FLEET_VERSION=$(VERSION) GOARCH=amd64 ./dev-tools/e2e/build.sh
 
 .PHONY: e2e-certs
 e2e-certs: ## - Use openssl to create a CA, encrypted private key, and signed fleet-server cert testing purposes

--- a/dev-tools/e2e/build.sh
+++ b/dev-tools/e2e/build.sh
@@ -27,7 +27,7 @@ CUSTOM_IMAGE_TAG=${STACK_VERSION}-e2e-${COMMIT}-$(date +%s)
 docker build \
 	-f $REPO_ROOT/dev-tools/e2e/Dockerfile \
 	--build-arg ELASTIC_AGENT_IMAGE=$BASE_IMAGE \
-	--build-arg STACK_VERSION=$STACK_VERSION \
+	--build-arg STACK_VERSION=${FLEET_VERSION} \
 	--build-arg VCS_REF_SHORT=${VCS_REF:0:6} \
 	--platform linux/$GOARCH \
 	-t ${CI_ELASTIC_AGENT_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG} \


### PR DESCRIPTION
## What is the problem this PR solves?

e2e tests fail on version change

## How does this PR solve the problem?

use the version from `version/version.go` instead of the docker image label when searching for the cover enabled binary to replace the fleet-server component in the image.

## Related issues

- Closes #3886 
