### PR TITLE
mergify: replace queue action for queue_rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,6 @@
 queue_rules:
   - name: default
+    merge_method: squash
     conditions:
       - check-success=fleet-server/pr-merge
 
@@ -84,7 +85,6 @@ pull_request_rules:
         type: APPROVE
         message: Automatically approving mergify
       queue:
-        method: squash
         name: default
   - name: automatic merge when CI passes and the file dev-tools/integration/.env is modified.
     conditions:
@@ -96,7 +96,6 @@ pull_request_rules:
         type: APPROVE
         message: Automatically approving mergify
       queue:
-        method: squash
         name: default
   - name: delete upstream branch with changes on dev-tools/integration/.env or .go-version after merging/closing it
     conditions:


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

Use queue_rules instead of queue action

## Why

The queue action from workflow automation has deprecated all of its configuration options

https://changelog.mergify.com/changelog/queue-action-options-deprecation
