### PR TITLE
Fix config deprecation warnings

### DIFF
--- a/changelog/fragments/1726166542-Fix-config-deprectation-warnings.yaml
+++ b/changelog/fragments/1726166542-Fix-config-deprectation-warnings.yaml
@@ -1,0 +1,33 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: deprecation
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix config deprectation warnings
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  Fix detection of deprecated config attributes.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component:
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -10,12 +10,13 @@ import (
 	"errors"
 	"sync"
 
+	"github.com/gofrs/uuid"
+	"github.com/rs/zerolog"
+
 	"github.com/elastic/fleet-server/v7/version"
 	"github.com/elastic/go-ucfg"
 	"github.com/elastic/go-ucfg/flag"
 	"github.com/elastic/go-ucfg/yaml"
-	"github.com/gofrs/uuid"
-	"github.com/rs/zerolog"
 )
 
 // DefaultOptions defaults options used to read the configuration
@@ -55,7 +56,9 @@ type Config struct {
 }
 
 var deprecatedConfigOptions = map[string]string{
-	"inputs[0].limits.max_connections": "max_connections has been deprecated and will be removed in a future release. Please configure server limits using max_agents instead.",
+	"inputs[0].server.limits.max_connections": "max_connections has been deprecated and will be removed in a future release. Please configure server limits using max_agents instead.",
+	"fleet.agent.logging.level":               "fleet.agent.logging.level has been deprecated and will be rmoved in a future release. Please set logging level with the root attribute logging.level instead.",
+	"inputs[0].server.limits.policy_throttle": "policy_throttle has been deprecated and will be removed in a future release. Please use policy_limits instead.",
 }
 
 // InitDefaults initializes the defaults for the configuration.

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -8,18 +8,20 @@ package config
 
 import (
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	testlog "github.com/elastic/fleet-server/v7/internal/pkg/testing/log"
 
-	"github.com/elastic/go-ucfg"
 	"github.com/gofrs/uuid"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/go-ucfg"
 )
 
 func TestConfig(t *testing.T) {
@@ -387,4 +389,22 @@ func TestConfigFromEnv(t *testing.T) {
 	c, err := LoadFile(path)
 	require.NoError(t, err)
 	assert.Equal(t, "test-val", c.Output.Elasticsearch.ServiceToken)
+}
+
+func TestDeprecationWarnings(t *testing.T) {
+	var logCount atomic.Uint64
+	log := testlog.SetLogger(t)
+	log = log.Hook(zerolog.HookFunc(func(_ *zerolog.Event, _ zerolog.Level, _ string) {
+		logCount.Add(1)
+	}))
+	oldLog := zerlog.DefaultContextLogger
+	t.Cleanup(func() {
+		zerolog.DefaultContextLogger = oldLog
+	})
+	zerolog.DefaultContextLogger = &log
+
+	path := filepath.Join("testdata", "deprecated-config-attributes.yml")
+	_, err := LoadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, 3, logCount.Load(), "Expected 3 log messages")
 }

--- a/internal/pkg/config/testdata/deprecated-config-attributes.yml
+++ b/internal/pkg/config/testdata/deprecated-config-attributes.yml
@@ -1,0 +1,16 @@
+output:
+  elasticsearch:
+    hosts: ["localhost:9200"]
+    service_token: "test-token"
+fleet:
+  agent:
+    id: 1e4954ce-af37-4731-9f4a-407b08e69e42
+    logging:
+      level: debug
+inputs:
+  - type: fleet-server
+    server:
+      limits:
+        max_connections: 10
+        policy_throttle: 1s
+


### PR DESCRIPTION
## What is the problem this PR solves?

We have deprecated config options throughout the 8.x lifecycle, but no warning are ever displayed

## How does this PR solve the problem?

Specify the correct attributes that should result in a warning.

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)