### PR TITLE
Add test collector plugin for Buildkite analytics

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -55,6 +55,13 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server" && "$BUILDKITE_STEP_KEY" == "
   export EC_API_KEY=${EC_API_KEY_SECRET}
 fi
 
+if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server" && "$BUILDKITE_STEP_KEY" == "int-test" ]]; then
+  # BK analytics
+  echo "--- Prepare BK test analytics token :vault:"
+  BUILDKITE_ANALYTICS_TOKEN=$(vault kv get -field token kv/ci-shared/platform-ingest/buildkite_analytics_tokens/fleet-server)
+  export BUILDKITE_ANALYTICS_TOKEN
+fi
+
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server" && "$BUILDKITE_STEP_KEY" == "release-test" ]]; then
   export PRIVATE_CI_GCS_CREDENTIALS_SECRET=$(retry 5 vault kv get -field plaintext -format=json ${PRIVATE_CI_GCS_CREDENTIALS_PATH})
   export JOB_GCS_BUCKET

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -55,11 +55,13 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server" && "$BUILDKITE_STEP_KEY" == "
   export EC_API_KEY=${EC_API_KEY_SECRET}
 fi
 
-if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server" && "$BUILDKITE_STEP_KEY" == "int-test" ]]; then
-  # BK analytics
-  echo "--- Prepare BK test analytics token :vault:"
-  BUILDKITE_ANALYTICS_TOKEN=$(vault kv get -field token kv/ci-shared/platform-ingest/buildkite_fleet_server_analytics_token)
-  export BUILDKITE_ANALYTICS_TOKEN
+# BK analytics
+if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server" ]]; then
+  if [[ "$BUILDKITE_STEP_KEY" == "int-test" || "$BUILDKITE_STEP_KEY" == "e2e-test" ]]; then
+    echo "--- Prepare BK test analytics token :vault:"
+    BUILDKITE_ANALYTICS_TOKEN=$(vault kv get -field token kv/ci-shared/platform-ingest/buildkite_fleet_server_analytics_token)
+    export BUILDKITE_ANALYTICS_TOKEN
+  fi
 fi
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server" && "$BUILDKITE_STEP_KEY" == "release-test" ]]; then

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -58,7 +58,7 @@ fi
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server" && "$BUILDKITE_STEP_KEY" == "int-test" ]]; then
   # BK analytics
   echo "--- Prepare BK test analytics token :vault:"
-  BUILDKITE_ANALYTICS_TOKEN=$(vault kv get -field token kv/ci-shared/platform-ingest/buildkite_analytics_tokens/fleet-server)
+  BUILDKITE_ANALYTICS_TOKEN=$(vault kv get -field token kv/ci-shared/platform-ingest/buildkite_fleet_server_analytics_token)
   export BUILDKITE_ANALYTICS_TOKEN
 fi
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -106,9 +106,10 @@ steps:
         artifact_paths:
           - build/*.xml
         plugins:
-          - test-collector#v1.10.1:
+          - test-collector#v1.10.2:
               files: "build/test-*.xml"
-              format: "xml"
+              format: "junit"
+              # branches: "main"
               debug: true
 
       - label: "E2E Test"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -109,7 +109,7 @@ steps:
           - test-collector#v1.10.2:
               files: "build/test-*.xml"
               format: "junit"
-              # branches: "main"
+              branches: "main"
               debug: true
 
       - label: "E2E Test"
@@ -124,7 +124,7 @@ steps:
           - test-collector#v1.10.2:
               files: "build/test-*.xml"
               format: "junit"
-              # branches: "main"
+              branches: "main"
               debug: true
 
       - label: ":junit: Junit annotate"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -120,6 +120,12 @@ steps:
         artifact_paths:
           - build/*.xml
           - build/e2e-coverage.out
+        plugins:
+          - test-collector#v1.10.2:
+              files: "build/test-*.xml"
+              format: "junit"
+              # branches: "main"
+              debug: true
 
       - label: ":junit: Junit annotate"
         plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -105,6 +105,11 @@ steps:
           provider: "gcp"
         artifact_paths:
           - build/*.xml
+        plugins:
+          - test-collector#v1.10.1:
+              files: "build/test-*.xml"
+              format: "xml"
+              debug: true
 
       - label: "E2E Test"
         key: "e2e-test"


### PR DESCRIPTION
Add the test collector plugin to enable Buildkite test analytics. Test results will be shown here after main branch pipeline runs: https://buildkite.com/organizations/elastic/analytics/suites/fleet-server

Closes https://github.com/elastic/ingest-dev/issues/3916