### PR TITLE
Update golangci-lint version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -38,7 +38,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.55.2
+          version: v1.61.0
 
           # Give the job more time to execute.
           # Regarding `--whole-files`, the linter is supposed to support linting of changed a patch only but,

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ check-headers:  ## - Check copyright headers
 
 .PHONY: check-go
 check-go: ## - Run golangci-lint
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/d58dbde584c801091e74a00940e11ff18c6c68bd/install.sh | sh -s v1.55.2
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/d58dbde584c801091e74a00940e11ff18c6c68bd/install.sh | sh -s v1.61.0
 	@./bin/golangci-lint run -v
 
 .PHONY: notice

--- a/internal/pkg/api/handleAck.go
+++ b/internal/pkg/api/handleAck.go
@@ -135,7 +135,7 @@ func (ack *AckT) processRequest(zlog zerolog.Logger, w http.ResponseWriter, r *h
 		return err
 	}
 
-	cntAcks.bodyOut.Add(uint64(nWritten))
+	cntAcks.bodyOut.Add(uint64(nWritten)) //nolint:gosec // disable G115
 
 	return nil
 }

--- a/internal/pkg/api/handleArtifacts.go
+++ b/internal/pkg/api/handleArtifacts.go
@@ -17,6 +17,8 @@ import (
 	"net/http"
 	"time"
 
+	"go.elastic.co/apm/v2"
+
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/cache"
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
@@ -24,7 +26,6 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/logger"
 	"github.com/elastic/fleet-server/v7/internal/pkg/model"
 	"github.com/elastic/fleet-server/v7/internal/pkg/throttle"
-	"go.elastic.co/apm/v2"
 
 	"github.com/rs/zerolog"
 )
@@ -88,7 +89,7 @@ func (at ArtifactT) handleArtifacts(zlog zerolog.Logger, w http.ResponseWriter, 
 		e = e.Int64(ECSEventDuration, time.Since(ts).Nanoseconds())
 	}
 	e.Msg("artifact response sent")
-	cntArtifacts.bodyOut.Add(uint64(n))
+	cntArtifacts.bodyOut.Add(uint64(n)) //nolint:gosec // disable G115
 	return nil
 }
 
@@ -146,7 +147,7 @@ func (at ArtifactT) processRequest(ctx context.Context, zlog zerolog.Logger, age
 //
 // Initial implementation is dependent on security by obscurity; ie.
 // it should be difficult for an attacker to guess a guid.
-func (at ArtifactT) authorizeArtifact(ctx context.Context, _ *model.Agent, _, _ string) error { //nolint:unparam // remove if this is implemented
+func (at ArtifactT) authorizeArtifact(ctx context.Context, _ *model.Agent, _, _ string) error {
 	span, _ := apm.StartSpan(ctx, "authorizeArtifacts", "auth") // TODO return and use span ctx if this is ever not a nop
 	defer span.End()
 	return nil // TODO

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -600,7 +600,7 @@ func (ct *CheckinT) writeResponse(zlog zerolog.Logger, w http.ResponseWriter, r 
 	} else {
 		var nWritten int
 		nWritten, err = w.Write(payload)
-		cntCheckin.bodyOut.Add(uint64(nWritten))
+		cntCheckin.bodyOut.Add(uint64(nWritten)) //nolint:gosec // disable G115
 
 		if err != nil {
 			err = fmt.Errorf("writeResponse payload: %w", err)
@@ -740,7 +740,6 @@ func convertActionData(aType ActionType, raw json.RawMessage) (ad Action_Data, e
 	}
 }
 
-//nolint:gosec // memory aliasing is used to convert from pointers to values and the other way
 func convertActions(zlog zerolog.Logger, agentID string, actions []model.Action) ([]Action, string) {
 	var ackToken string
 	sz := len(actions)

--- a/internal/pkg/api/handleEnroll.go
+++ b/internal/pkg/api/handleEnroll.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"go.elastic.co/apm/v2"
+
 	"github.com/elastic/elastic-agent-libs/str"
 	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
@@ -24,7 +26,6 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/model"
 	"github.com/elastic/fleet-server/v7/internal/pkg/rollback"
 	"github.com/elastic/fleet-server/v7/internal/pkg/sqn"
-	"go.elastic.co/apm/v2"
 
 	"github.com/gofrs/uuid"
 	"github.com/hashicorp/go-version"
@@ -395,7 +396,7 @@ func writeResponse(ctx context.Context, zlog zerolog.Logger, w http.ResponseWrit
 	}
 
 	numWritten, err := w.Write(data)
-	cntEnroll.bodyOut.Add(uint64(numWritten))
+	cntEnroll.bodyOut.Add(uint64(numWritten)) //nolint:gosec // disable G115
 
 	if err != nil {
 		return fmt.Errorf("fail send enroll response: %w", err)

--- a/internal/pkg/api/handleStatus.go
+++ b/internal/pkg/api/handleStatus.go
@@ -11,8 +11,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"go.elastic.co/apm/v2"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
 	"github.com/elastic/fleet-server/v7/internal/pkg/build"
@@ -120,7 +121,7 @@ func (st StatusT) handleStatus(zlog zerolog.Logger, sm policy.SelfMonitor, bi bu
 		}
 	}
 
-	cntStatus.bodyOut.Add(uint64(nWritten))
+	cntStatus.bodyOut.Add(uint64(nWritten)) //nolint:gosec // disable G115
 	e := zlog.Debug().Int(ECSHTTPResponseBodyBytes, nWritten)
 	if ok {
 		e = e.Int64(ECSEventDuration, time.Since(ts).Nanoseconds())

--- a/internal/pkg/api/openapi_spec_test.go
+++ b/internal/pkg/api/openapi_spec_test.go
@@ -2,7 +2,6 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//nolint:goconst // don't care about repitition for tests
 package api
 
 // Test json encoding/decoding for all req/resp items

--- a/internal/pkg/bulk/opMulti.go
+++ b/internal/pkg/bulk/opMulti.go
@@ -79,7 +79,7 @@ func (b *Bulker) multiWaitBulkOp(ctx context.Context, action actionT, ops []Mult
 
 		bulk := &bulks[i]
 		bulk.ch = ch
-		bulk.idx = int32(i)
+		bulk.idx = int32(i) //nolint:gosec // disable G115
 		bulk.action = action
 		bulk.buf.Set(bodySlice)
 		if opt.Refresh {

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -4,7 +4,6 @@
 
 // Package cache implements an in-memory cache used to track API keys, actions, and artifacts.
 
-//nolint:goconst // easier to read scoped keys if no constants are used
 package cache
 
 import (

--- a/internal/pkg/dl/migration_integration_test.go
+++ b/internal/pkg/dl/migration_integration_test.go
@@ -4,7 +4,6 @@
 
 //go:build integration
 
-//nolint:goconst // disable duplicate checking
 package dl
 
 import (

--- a/internal/pkg/file/cbor/chunk.go
+++ b/internal/pkg/file/cbor/chunk.go
@@ -80,8 +80,8 @@ func encodePreambleToCBOR(final bool, baseID string, chunkHash string, chunkSize
 	preamble[11] = 'p'
 	preamble[12] = 0x1b // uint64 to follow
 	// occupies 8 bytes, indexes 13-20
-	binary.BigEndian.PutUint64(preamble[13:], uint64(time.Now().UnixMilli()))
-	preamble[21] = 0x64 // string with 4 chars (key: last)
+	binary.BigEndian.PutUint64(preamble[13:], uint64(time.Now().UnixMilli())) //nolint:gosec // disable G115
+	preamble[21] = 0x64                                                       // string with 4 chars (key: last)
 	preamble[22] = 'l'
 	preamble[23] = 'a'
 	preamble[24] = 's'
@@ -118,8 +118,8 @@ func encodePreambleToCBOR(final bool, baseID string, chunkHash string, chunkSize
 	}
 	if !final {
 		// byte data should be precisely chunkSize long, otherwise malformed
-		preamble[i] = 0x5A // say length descriptor will be 32-bit int
-		binary.BigEndian.PutUint32(preamble[i+1:], uint32(chunkSize))
+		preamble[i] = 0x5A                                            // say length descriptor will be 32-bit int
+		binary.BigEndian.PutUint32(preamble[i+1:], uint32(chunkSize)) //nolint:gosec // disable G115
 	} else {
 		// final chunk may be less than full size, will need to determine length
 		preamble[i] = 0x5F // indeterminate-length byte sequence
@@ -150,8 +150,8 @@ func (c *ChunkEncoder) Read(buf []byte) (int, error) {
 			return 0, errors.New("buffer too small")
 		}
 		n, err := c.chunk.Read(buf[varLenHeaderSize:])
-		buf[0] = 0x5A // 4-byte length descriptor to follow
-		binary.BigEndian.PutUint32(buf[1:], uint32(n))
+		buf[0] = 0x5A                                  // 4-byte length descriptor to follow
+		binary.BigEndian.PutUint32(buf[1:], uint32(n)) //nolint:gosec // disable G115
 
 		if errors.Is(err, io.EOF) {
 			if n == 0 { // chunk data has been exhausted, write the terminating byte and get out

--- a/internal/pkg/file/cbor/chunk_test.go
+++ b/internal/pkg/file/cbor/chunk_test.go
@@ -38,8 +38,8 @@ func TestChunkWriter(t *testing.T) {
 		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, // contents
 	}
 
-	assert.Equal(t, expected[:13], outbuf[:13]) // up to 0x1b after timestamp
-	assert.WithinDuration(t, time.Now(), time.UnixMilli(int64(binary.BigEndian.Uint64(outbuf[13:]))), time.Second*5)
+	assert.Equal(t, expected[:13], outbuf[:13])                                                                      // up to 0x1b after timestamp
+	assert.WithinDuration(t, time.Now(), time.UnixMilli(int64(binary.BigEndian.Uint64(outbuf[13:]))), time.Second*5) //nolint:gosec // disable G115
 
 	assert.Equal(t, expected[21:], outbuf[21:])
 
@@ -68,7 +68,7 @@ func TestChunkWriterLastChunk(t *testing.T) {
 
 	// assert equality up to the constant set point
 	assert.Equal(t, expected[:13], outbuf[:13])
-	assert.WithinDuration(t, time.Now(), time.UnixMilli(int64(binary.BigEndian.Uint64(outbuf[13:]))), time.Second*5)
+	assert.WithinDuration(t, time.Now(), time.UnixMilli(int64(binary.BigEndian.Uint64(outbuf[13:]))), time.Second*5) //nolint:gosec // disable G115
 	assert.Equal(t, expected[21:], outbuf[21:len(expected)])
 	assert.Equal(t, uint8(0xFF), outbuf[len(outbuf)-1]) // final byte MUST be a 0xFF terminating byte when using indeterminate-length style
 
@@ -116,7 +116,7 @@ func TestChunkWriterLargeLastChunk(t *testing.T) {
 
 	// assert equality up to the constant set point
 	assert.Equal(t, expected[:13], outbuf[:13])
-	assert.WithinDuration(t, time.Now(), time.UnixMilli(int64(binary.BigEndian.Uint64(outbuf[13:]))), time.Second*5)
+	assert.WithinDuration(t, time.Now(), time.UnixMilli(int64(binary.BigEndian.Uint64(outbuf[13:]))), time.Second*5) //nolint:gosec // disable G115
 	assert.Equal(t, expected[21:], outbuf[21:len(expected)])
 	assert.Equal(t, uint8(0xFF), outbuf[len(outbuf)-1]) // final byte MUST be a 0xFF terminating byte when using indeterminate-length style
 

--- a/internal/pkg/file/uploader/upload_test.go
+++ b/internal/pkg/file/uploader/upload_test.go
@@ -2,7 +2,6 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//nolint:goconst // disable contstants checks for tests
 package uploader
 
 import (

--- a/internal/pkg/logger/http.go
+++ b/internal/pkg/logger/http.go
@@ -19,8 +19,9 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/rs/zerolog"
 
-	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
 	"go.elastic.co/apm/module/apmzerolog/v2"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
 )
 
 const (
@@ -41,7 +42,7 @@ func NewReaderCounter(r io.ReadCloser) *ReaderCounter {
 
 func (rd *ReaderCounter) Read(buf []byte) (int, error) {
 	n, err := rd.ReadCloser.Read(buf)
-	atomic.AddUint64(&rd.count, uint64(n))
+	atomic.AddUint64(&rd.count, uint64(n)) //nolint:gosec // disable G115
 	return n, err
 }
 
@@ -67,7 +68,7 @@ func (rc *ResponseCounter) Write(buf []byte) (int, error) {
 	}
 
 	n, err := rc.ResponseWriter.Write(buf)
-	atomic.AddUint64(&rc.count, uint64(n))
+	atomic.AddUint64(&rc.count, uint64(n)) //nolint:gosec // disable G115
 	return n, err
 }
 

--- a/internal/pkg/monitor/monitor.go
+++ b/internal/pkg/monitor/monitor.go
@@ -21,9 +21,10 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/sleep"
 	"github.com/elastic/fleet-server/v7/internal/pkg/sqn"
 
-	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/rs/zerolog"
 	"go.elastic.co/apm/v2"
+
+	"github.com/elastic/go-elasticsearch/v8"
 )
 
 const (
@@ -462,7 +463,7 @@ func (m *simpleMonitorT) prepareCheckQuery() (*dsl.Tmpl, error) {
 // Prepares full documents query
 func (m *simpleMonitorT) prepareQuery() (*dsl.Tmpl, error) {
 	tmpl, root := m.prepareCommon(true)
-	root.Size(uint64(m.fetchSize))
+	root.Size(uint64(m.fetchSize)) //nolint:gosec // disable G115
 	root.Sort().SortOrder(fieldSeqNo, dsl.SortAscend)
 
 	if err := tmpl.Resolve(root); err != nil {

--- a/internal/pkg/policy/policy_output_integration_test.go
+++ b/internal/pkg/policy/policy_output_integration_test.go
@@ -4,7 +4,6 @@
 
 //go:build integration
 
-//nolint:goconst // disable constants checks for tests
 package policy
 
 import (

--- a/internal/pkg/scheduler/scheduler.go
+++ b/internal/pkg/scheduler/scheduler.go
@@ -50,7 +50,7 @@ func WithSplayPercent(splayPercent uint) OptFunc {
 		if splayPercent >= 100 {
 			return errors.New("invalid splay value, expected < 100")
 		}
-		s.splayPercent = int(splayPercent)
+		s.splayPercent = int(splayPercent) //nolint:gosec // disable G115
 		return nil
 	}
 }

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -22,14 +22,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/elastic-agent-client/v7/pkg/client"
-	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/gofrs/uuid"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/client"
+	"github.com/elastic/go-elasticsearch/v8"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/api"
 	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
@@ -236,7 +237,7 @@ func (s *tserver) waitServerUp(ctx context.Context, dur time.Duration) error {
 		}
 		resp, err := cli.Do(req)
 		if err != nil {
-			return false, nil //nolint:nilerr // we want to ignore the error in this case.
+			return false, nil
 		}
 		defer resp.Body.Close()
 

--- a/internal/pkg/testing/port.go
+++ b/internal/pkg/testing/port.go
@@ -18,5 +18,5 @@ func FreePort() (uint16, error) {
 	}
 	defer l.Close()
 
-	return uint16(l.Addr().(*net.TCPAddr).Port), nil
+	return uint16(l.Addr().(*net.TCPAddr).Port), nil //nolint:gosec // disable G115
 }


### PR DESCRIPTION
## What is the problem this PR solves?

Go version update to 1.23.x causes a lot of noise in the linter.

## How does this PR solve the problem?

Update the linter used to 1.65.0, fix new issues.
The most common is a gosec G115 issue that attempts to find where we can have overflows caused by casting to/from int/uint (or int/int32).
Most of these are silenced as they would not be able to occur and there are false positives in the detector, see https://github.com/securego/gosec/issues/1212