### PR TITLE
POC opamp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	golang.org/x/sync v0.8.0
 	golang.org/x/time v0.5.0
 	google.golang.org/grpc v1.63.2
-	google.golang.org/protobuf v1.33.0
+	google.golang.org/protobuf v1.34.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -64,11 +64,13 @@ require (
 	github.com/golang/glog v1.2.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/open-telemetry/opamp-go v0.15.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,8 @@ require (
 	github.com/mailru/easyjson v0.7.7
 	github.com/miolini/datacounter v1.0.3
 	github.com/oapi-codegen/runtime v1.1.1
+	github.com/oklog/ulid/v2 v2.1.0
+	github.com/open-telemetry/opamp-go v0.15.0
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/prometheus/client_golang v1.19.0
 	github.com/rs/xid v1.5.0
@@ -70,7 +72,6 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/open-telemetry/opamp-go v0.15.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/google/pprof v0.0.0-20230426061923-93006964c1fc h1:AGDHt781oIcL4EFk7c
 github.com/google/pprof v0.0.0-20230426061923-93006964c1fc/go.mod h1:79YE0hCXdHag9sBkw2o+N/YnZtTkXi0UT9Nnixa5eYk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
+github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
@@ -125,6 +127,8 @@ github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6U
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmtpMYro=
 github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
+github.com/open-telemetry/opamp-go v0.15.0 h1:X2TWhEsGQ8GP7Uos3Ic9v/1aFUqoECZXKS7xAF5HqsA=
+github.com/open-telemetry/opamp-go v0.15.0/go.mod h1:QyPeN56JXlcZt5yG5RMdZ50Ju+zMFs1Ihy/hwHyF8Oo=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
@@ -289,6 +293,8 @@ google.golang.org/grpc v1.63.2 h1:MUeiw1B2maTVZthpU5xvASfTh3LDbxHd6IJ6QQVU+xM=
 google.golang.org/grpc v1.63.2/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDomNkRA=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFWg=
+google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6U
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmtpMYro=
 github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
+github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
+github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/open-telemetry/opamp-go v0.15.0 h1:X2TWhEsGQ8GP7Uos3Ic9v/1aFUqoECZXKS7xAF5HqsA=
 github.com/open-telemetry/opamp-go v0.15.0/go.mod h1:QyPeN56JXlcZt5yG5RMdZ50Ju+zMFs1Ihy/hwHyF8Oo=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
@@ -135,6 +137,7 @@ github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrB
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -291,8 +294,6 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20240415180920-8c6c420018be h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240415180920-8c6c420018be/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
 google.golang.org/grpc v1.63.2 h1:MUeiw1B2maTVZthpU5xvASfTh3LDbxHd6IJ6QQVU+xM=
 google.golang.org/grpc v1.63.2/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDomNkRA=
-google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
-google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFWg=
 google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/pkg/api/server.go
+++ b/internal/pkg/api/server.go
@@ -64,6 +64,11 @@ func NewServer(addr string, cfg *config.Server, ct *CheckinT, et *EnrollerT, at 
 		Callbacks: opampserver.CallbacksStruct{
 			OnConnectingFunc: func(request *http.Request) types.ConnectionResponse {
 				// NOTE: We don't have an agent ID at this stage so we can only check if the API key is valid.
+				// TODO enrollment
+				// 1. we should probably here detect if the oamp client use an enrollment token
+				// 2. create the .fleet-agent document
+				// 3. create an access token
+				// 4. return it to the agent with the connection settings flow https://opentelemetry.io/docs/specs/opamp/#opamp-connection-setting-offer-flow
 				agent, err := authAgent(request, nil, bulker, cache)
 				if err != nil {
 					zerolog.Ctx(request.Context()).Warn().Err(err).Msg("Opamp request api key auth failed.")

--- a/internal/pkg/opamp/opamp.go
+++ b/internal/pkg/opamp/opamp.go
@@ -28,6 +28,8 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/sqn"
 )
 
+const DefaultPath = "/v1/opamp"
+
 const (
 	healthy   = "healthy"
 	unhealthy = "unhealthy"
@@ -271,7 +273,7 @@ func (o *opamp) register(ctx context.Context, policyID string, namespaces []stri
 		ConnectionSettings: &protobufs.ConnectionSettingsOffers{
 			Hash: hash.Sum(nil),
 			Opamp: &protobufs.OpAMPConnectionSettings{
-				DestinationEndpoint: fleet.Hosts[0],
+				DestinationEndpoint: fleet.Hosts[0] + DefaultPath,
 				Headers: &protobufs.Headers{
 					Headers: []*protobufs.Header{
 						&protobufs.Header{

--- a/internal/pkg/opamp/opamp.go
+++ b/internal/pkg/opamp/opamp.go
@@ -93,7 +93,7 @@ func WithNamespaces(namespaces []string) Option {
 // Process handles AgentToServer messages
 func (o *opamp) Process(ctx context.Context, message *protobufs.AgentToServer, opts ...Option) (*protobufs.ServerToAgent, error) {
 	if message.GetCapabilities()&0x00000001 == 0 { // ReportsStatus must be set on all agents
-		return nil, fmt.Errorf("capaability: ReportsStatus is unset.")
+		return nil, fmt.Errorf("capaability: ReportsStatus is unset")
 	}
 	args := &processArgs{}
 	for _, opt := range opts {
@@ -398,6 +398,7 @@ func toComponentList(comps map[string]*protobufs.ComponentHealth) []model.Compon
 
 func invalidateAPIKey(ctx context.Context, bulker bulk.Bulk, id string) error {
 	timer := time.NewTimer(time.Minute)
+	defer timer.Stop()
 LOOP:
 	for {
 		_, err := bulker.APIKeyRead(ctx, id, true)

--- a/internal/pkg/opamp/opamp.go
+++ b/internal/pkg/opamp/opamp.go
@@ -1,0 +1,149 @@
+// opamp provides a poc of fleet-server serving the opamp spec
+// It can serve new policies
+
+package opamp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/rs/zerolog"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
+	"github.com/elastic/fleet-server/v7/internal/pkg/cache"
+	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
+	"github.com/elastic/fleet-server/v7/internal/pkg/model"
+	"github.com/elastic/fleet-server/v7/internal/pkg/policy"
+)
+
+const (
+	healthy   = "healthy"
+	unhealthy = "unhealthy"
+)
+
+const serverCapabilities uint64 = 0x00000001 | 0x00000002 | 0x00000004 // status, offers remote config, accepts effective config
+
+type opamp struct {
+	bulk  bulk.Bulk
+	cache cache.Cache
+}
+
+func NewHandler(bulk bulk.Bulk, cache cache.Cache, pm policy.Monitor) *opamp {
+	return &opamp{
+		bulk:  bulk,
+		cache: cache,
+		pm:    pm,
+	}
+}
+
+func (o *opamp) Process(ctx context.Context, agent *model.Agent, message *protobufs.AgentToServer) (*protobufs.ServerToAgent, error) {
+	if agent.Id != string(message.InstanceUid) {
+		return nil, fmt.Errorf("API key's associated agent does not match InstanceUid")
+	}
+	ts := time.Now().Unix()
+	tsStr := ts.Format(time.RFC3339)
+
+	// update the agent description if health status has changed. otherwise just a minimal update
+	updateAgent := false
+	if health := message.GetHealth(); health != nil &&
+		(health.Healthy && agent.LastCheckinStatus != healty) ||
+		(!health.Healthy && agent.LastCheckinStatus != unhealthy) {
+		updateAgent = true
+	}
+	update := bulk.UpdateFields{
+		dl.FieldLastCheckin: tsStr,
+		dl.FieldUpdatedAt:   tsStr,
+	}
+	if updateAgent {
+		if message.GetHealth().Healthy {
+			update[dl.FieldLastCheckinStatus] = healthy
+		} else {
+			update[dl.FieldLastCheckinStatus] = unhealthy
+		}
+		update[dl.FieldLastCheckinMessage] = message.GetHealth().Status
+		// TODO: map ComponentHealthMap to components list
+	}
+	updateBody, err := fields.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal agent update: %w", err)
+	}
+	if err := o.bulk.Update(ctx, dl.FleetAgents, agent.Agent.ID, updateBody); err != nil {
+		return nil, fmt.Errorf("failed to update agent doc: %w", err)
+	}
+
+	rev := agent.PolicyRevisionIdx
+	// use revisionIDx from agent's config if it's sent
+	var cfg protobuf.AgentConfigFile
+	ecfg := message.GetEffectiveConfig()
+	if ecfg != nil {
+		if cm := ecfg.GetConfigMap(); cm != nil {
+			if cfile, ok := cm[""]; ok {
+				cfg = cfile
+			}
+		}
+	}
+	if len(cfg.Body) > 0 {
+		switch cfg.ContentType {
+		case "application/json":
+			var policy model.Policy
+			if err := json.Unmarshal(cfg.Body, &policy); err != nil {
+				return nil, fmt.Errorf("unmarshal effective policy failed: %w", err)
+			}
+			rev = policy.RebisionIdx
+		default:
+			zerolog.Ctx(ctx).Warn().Str("Content-Type", cfg.ContentType).Msg("Unknown content type.")
+		}
+	}
+
+	sub, err := o.pm.Subscribe(agent.Id, agent.PolicyID, rev)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get policy subscription for agent: %w", err)
+	}
+	defer func() {
+		err := o.pm.Unsubscribe(sub)
+		if err != nil {
+			zerolog.Ctx(ctx).Error().Err(err).Msg("Unable to subscribe from policy.")
+		}
+	}()
+	var remoteConfig *protobuf.AgentRemoteConfig
+	select {
+	case pp := sub.Output():
+		zerolog.Ctx(ctx).Debug().Msg("Found policy update.")
+		if len(pp.Policy.Data.Outputs) == 0 {
+			return nil, fmt.Errorf("no outputs defined in policy")
+		}
+		data := model.ClonePolicyData(pp.Policy.Data)
+		for name, output := range data.Outputs {
+			err := policy.ProcessOutputSecret(ctx, output, o.bulk)
+			if err != nil {
+				return nil, fmt.Errorf("failed to process output secrets %q: %w", name, err)
+			}
+		}
+		for _, output := range pp.Outputs {
+			err := output.Prepare(ctx, zerolog.Ctx(ctx), o.bulk, agent, data.Outputs)
+			if err != nil {
+				return nil, fmt.Errorf("failed to pepare output %q: %w", output.Name, err)
+			}
+		}
+		data.Inputs = pp.Inputs
+		body, err := json.Marshal(data)
+		if err != nil {
+			return nil, fmt.Errorf("unable to marshal policy: %w", err)
+		}
+		remoteConfig = &protobuf.AgentRemoteConfig{
+			Body:        p,
+			ContentType: "application/json",
+		}
+	default:
+		zerolog.Ctx(ctx).Debug().Msg("No policy update.")
+	}
+
+	return &protobufs.ServerToAgent{
+		InstanceUid:  message.InstanceUid,
+		RemoteConfig: remoteConfig,
+		Capabilities: serverCapabilities,
+	}, nil
+}

--- a/internal/pkg/server/fleet.go
+++ b/internal/pkg/server/fleet.go
@@ -14,9 +14,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"go.elastic.co/apm/v2"
 	apmtransport "go.elastic.co/apm/v2/transport"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/action"
 	"github.com/elastic/fleet-server/v7/internal/pkg/api"
@@ -543,7 +544,7 @@ func (f *Fleet) runSubsystems(ctx context.Context, cfg *config.Config, g *errgro
 	auditT := api.NewAuditT(&cfg.Inputs[0].Server, bulker, f.cache)
 
 	for _, endpoint := range (&cfg.Inputs[0].Server).BindEndpoints() {
-		apiServer := api.NewServer(endpoint, &cfg.Inputs[0].Server, ct, et, at, ack, st, sm, f.bi, ut, ft, pt, auditT, bulker, tracer)
+		apiServer := api.NewServer(endpoint, &cfg.Inputs[0].Server, ct, et, at, ack, st, sm, f.bi, ut, ft, pt, auditT, bulker, f.cache, pm, tracer)
 		g.Go(loggedRunFunc(ctx, "Http server", func(ctx context.Context) error {
 			return apiServer.Run(ctx)
 		}))


### PR DESCRIPTION
## Description 

Poc to figure and explore how OpAmp work 


Testing with the following otelcol config 
```
extensions:
  opamp:
    instance_uid: 01921fdd-3a15-7b37-9a41-587b4b7901c2
    capabilities:
      reports_effective_config: true
    server:
      http:
        endpoint: http://127.0.0.1:8220/opamp
        polling_interval: 1s
        tls:
          insecure_skip_verify: true

receivers:
  filelog:
    start_at: beginning
    include:
      - ${env:OTEL_WORKSHOP_DIR}/scenarios/simple-logs.log
exporters:
  debug:
    verbosity: detailed

service:
  telemetry:
    metrics:
      level: none
  extensions: [opamp]
  pipelines:
    logs:
      exporters:
        - debug
      receivers:
        - filelog

```

With otelcol-contrib