### PR TITLE
Unskip cloud E2E tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -150,7 +150,6 @@ steps:
 
       - label: ":gcloud: Cloud e2e Test"
         key: "cloud-e2e-test"
-        skip: true
         command: ".buildkite/scripts/cloud_e2e_test.sh"
         agents:
           provider: "gcp"


### PR DESCRIPTION
This PR reverts https://github.com/elastic/fleet-server/commit/3750daa2854ba95e37ee8e4842e6fec9d9bc0f67 as it is now possible to create `9.0.0-SNAPSHOT` deployments on ESS prod in the CFT region.

Resolves #3920