### PR TITLE
CP-7782 - Replace E2E pipeline execution with serverless-quality-gate…

### DIFF
--- a/.buildkite/pipeline.tests-production.yaml
+++ b/.buildkite/pipeline.tests-production.yaml
@@ -2,14 +2,17 @@
 # A failure in this pipeline build will prevent further progression to the subsequent stage.
 
 steps:
-  - label: ":pipeline::rocket::seedling: Trigger control-plane e2e tests"
+
+  - label: ":rocket: Run serverless synthetics check"
     if: build.env("ENVIRONMENT") == "production-canary"
-    trigger: "ess-k8s-production-e2e-tests" # https://buildkite.com/elastic/ess-k8s-production-e2e-tests
+    trigger: "serverless-quality-gates"
     build:
-      env:
-        REGION_ID: aws-us-east-1
-        NAME_PREFIX: ci_test_fleet-promotion_
       message: "${BUILDKITE_MESSAGE} (triggered by pipeline.tests-production-canary.yaml)"
+      env:
+        TARGET_ENV: production
+        SERVICE: fleet
+        CHECK_SYNTHETICS: true
+        CHECK_SYNTHETICS_TAG: serverless-platform-core-validation
 
   - label: ":cookie: 1h bake period before continuing promotion"
     if: build.env("ENVIRONMENT") == "production-canary"


### PR DESCRIPTION
As announced in the [PSA: Serverless E2E tests to synthetics](https://groups.google.com/a/elastic.co/g/dev/c/AH1t5xIqoVA) we will be replacing the calls to the buildkite pipelines that run the E2E tests against an ENV with a serverless-quality-gates CHECK_SYNTHETICS. 

**Important:**
**Please review this PR carefully as here I am mostly just replacing the execution of the E2E with the default config values (and default tag) from the serverless-quality-gates CHECK_SYNTHETICS.**

From the PSA:
> We will no longer execute E2E tests as a quality gate. Instead, the quality gates should be checking for the statuses of some of the synthetics journeys which are constantly running in the overview cluster of each environment.
In fact, the services that rely on a workflow template in the gitops repo to execute E2E as a quality gate were[ migrated](https://github.com/elastic/serverless-gitops/pull/3360) a while ago to the quality gate that checks for the status of synthetics journeys.

>The quality gate in question is CHECK_SYNTHETICS which is part of [elastic/serverless-quality-gates](https://github.com/elastic/serverless-quality-gates#synthetic-monitors-check_synthetics) and it can be configured with the env variables:
> - CHECK_SYNTHETICS: true (to enable this quality gate)
> - CHECK_SYNTHETICS_TAG: the tag of the synthetics monitors to match to evaluate their statuses.

> Example of the synthetics check quality gate configured for the [project-api on QA](https://github.com/elastic/project-api/blob/2067996215a2630544aa6b640ab8301892406840/.buildkite/pipeline.tests-qa.yaml#L13-L16).
The quality gate ensures that it only takes into account results of journeys that were executed after the deployment of the latest version of the service. By default it also waits for at least 2 successful results of each matched journey but this can be configured.

> Notice that this quality gate will take longer than the execution of the E2E tests because it waits for 2 successful results of the matched journeys. Most of our current journeys run at 15 min intervals, which means that it can take about 30 min to succeed.