### PR TITLE
Allow bulk integration tests to accept alternate errors from Elasticsearch

### DIFF
--- a/internal/pkg/bulk/bulk_integration_test.go
+++ b/internal/pkg/bulk/bulk_integration_test.go
@@ -32,7 +32,7 @@ func TestBulkCreate(t *testing.T) {
 		Index  string
 		ID     string
 		Err    error
-		AltErr error // Hack until https://elasticco.atlassian.net/browse/ES-9711 is resolved
+		AltErr error // FIXME: workaround until https://elasticco.atlassian.net/browse/ES-9711 is resolved
 	}{
 		{
 			Name:  "Empty Id",

--- a/internal/pkg/bulk/bulk_integration_test.go
+++ b/internal/pkg/bulk/bulk_integration_test.go
@@ -28,10 +28,11 @@ func TestBulkCreate(t *testing.T) {
 	index, bulker := SetupIndexWithBulk(ctx, t, testPolicy, WithFlushThresholdCount(1))
 
 	tests := []struct {
-		Name  string
-		Index string
-		ID    string
-		Err   error
+		Name   string
+		Index  string
+		ID     string
+		Err    error
+		AltErr error // Hack until https://elasticco.atlassian.net/browse/ES-9711 is resolved
 	}{
 		{
 			Name:  "Empty Id",
@@ -72,6 +73,10 @@ func TestBulkCreate(t *testing.T) {
 				Status: 500,
 				Type:   "json_parse_exception",
 			},
+			AltErr: es.ErrElastic{
+				Status: 400,
+				Type:   "json_parse_exception",
+			},
 		},
 		{
 			Name:  "Malformed Index Uppercase",
@@ -100,7 +105,9 @@ func TestBulkCreate(t *testing.T) {
 			// Create
 			id, err := bulker.Create(ctx, test.Index, test.ID, sampleData)
 			if !EqualElastic(test.Err, err) {
-				t.Fatalf("expected error: %+v, got: %+v", test.Err, err)
+				if test.AltErr == nil || !EqualElastic(test.AltErr, err) {
+					t.Fatalf("expected error: %+v, got: %+v", test.Err, err)
+				}
 			}
 			if err != nil {
 				return


### PR DESCRIPTION
## What is the problem this PR solves?

// Please do not just reference an issue. Explain WHAT the problem this PR solves here.

As described in https://github.com/elastic/fleet-server/pull/3971#issuecomment-2394723142, Elasticsearch's Bulk API keeps changing the response code from `500` to `400`.  As such, we need to keep updating the `Invalid utf-8` bulk indexing integration test to match.  While the permanent fix to this issue will be done in Elasticsearch (see https://elasticco.atlassian.net/browse/ES-9711), this PR updates the test to accept an alternate error from Elasticsearch as a workaround.

## How does this PR solve the problem?

// Explain HOW you solved the problem in your code. It is possible that during PR reviews this changes and then this section should be updated.

By adding an `AltError` field to the test case struct, allowing the `Invalid utf-8` test case to populate this field with the alternate error from Elasticsearch until we have the permanent fix in Elasticsearch via https://elasticco.atlassian.net/browse/ES-9711.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)~


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/fleet-server/pull/3971#issuecomment-2394723142
