### PR TITLE
[Integration testing] Remove AltErr and only expect 400 from ES bulk API

### DIFF
--- a/internal/pkg/bulk/bulk_integration_test.go
+++ b/internal/pkg/bulk/bulk_integration_test.go
@@ -28,11 +28,10 @@ func TestBulkCreate(t *testing.T) {
 	index, bulker := SetupIndexWithBulk(ctx, t, testPolicy, WithFlushThresholdCount(1))
 
 	tests := []struct {
-		Name   string
-		Index  string
-		ID     string
-		Err    error
-		AltErr error // FIXME: workaround until https://elasticco.atlassian.net/browse/ES-9711 is resolved
+		Name  string
+		Index string
+		ID    string
+		Err   error
 	}{
 		{
 			Name:  "Empty Id",
@@ -70,12 +69,8 @@ func TestBulkCreate(t *testing.T) {
 			Name:  "Invalid utf-8",
 			Index: string([]byte{0xfe, 0xfe, 0xff, 0xff}),
 			Err: es.ErrElastic{
-				Status: 500,
-				Type:   "json_parse_exception",
-			},
-			AltErr: es.ErrElastic{
 				Status: 400,
-				Type:   "parse_exception",
+				Type:   "json_parse_exception",
 			},
 		},
 		{
@@ -105,9 +100,7 @@ func TestBulkCreate(t *testing.T) {
 			// Create
 			id, err := bulker.Create(ctx, test.Index, test.ID, sampleData)
 			if !EqualElastic(test.Err, err) {
-				if test.AltErr == nil || !EqualElastic(test.AltErr, err) {
-					t.Fatalf("expected error: %+v (alt: %+v), got: %+v", test.Err, test.AltErr, err)
-				}
+				t.Fatalf("expected error: %+v, got: %+v", test.Err, err)
 			}
 			if err != nil {
 				return

--- a/internal/pkg/bulk/bulk_integration_test.go
+++ b/internal/pkg/bulk/bulk_integration_test.go
@@ -70,7 +70,7 @@ func TestBulkCreate(t *testing.T) {
 			Index: string([]byte{0xfe, 0xfe, 0xff, 0xff}),
 			Err: es.ErrElastic{
 				Status: 400,
-				Type:   "json_parse_exception",
+				Type:   "parse_exception",
 			},
 		},
 		{


### PR DESCRIPTION
## What is the problem this PR solves?

This PR expects only a 400 HTTP response code from the Elasticsearch bulk API in integration tests when invalid index name is specified.  Concretely, it removes the `AltErr` field temporarily introduced in https://github.com/elastic/fleet-server/pull/4001 which was allowing the tests to accept an alternate error from Elasticsearch.

Related: https://github.com/elastic/elasticsearch/pull/114869