### PR TITLE
Support sampling rate in APM configuration

### DIFF
--- a/internal/pkg/server/agent.go
+++ b/internal/pkg/server/agent.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -556,6 +557,12 @@ func apmConfigToInstrumentation(src *proto.APMConfig) (config.Instrumentation, e
 			Hosts:        apmest.GetHosts(),
 			GlobalLabels: apmest.GetGlobalLabels(),
 		}
+
+		if apmest.SamplingRate != nil {
+			// set the sampling rate in config
+			cfg.TransactionSampleRate = strconv.FormatFloat(float64(*apmest.SamplingRate), 'f', -1, 32)
+		}
+
 		return cfg, nil
 	}
 	return config.Instrumentation{}, fmt.Errorf("unable to transform APMConfig to instrumentation")

--- a/internal/pkg/server/agent_test.go
+++ b/internal/pkg/server/agent_test.go
@@ -262,6 +262,8 @@ func Test_Agent_configFromUnits(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
+
+		samplingRate := float32(0.5)
 		mockInClient := &mockClientUnit{}
 		mockInClient.On("Expected").Return(
 			client.Expected{
@@ -279,6 +281,7 @@ func Test_Agent_configFromUnits(t *testing.T) {
 						SecretToken:  "secretToken",
 						Hosts:        []string{"testhost:8080"},
 						GlobalLabels: "test",
+						SamplingRate: &samplingRate,
 					},
 				},
 			})
@@ -315,6 +318,7 @@ func Test_Agent_configFromUnits(t *testing.T) {
 		assert.Equal(t, []string{"testhost:8080"}, cfg.Inputs[0].Server.Instrumentation.Hosts)
 		assert.Equal(t, "test", cfg.Inputs[0].Server.Instrumentation.GlobalLabels)
 		assert.Equal(t, "test-token", cfg.Output.Elasticsearch.ServiceToken)
+		assert.Equal(t, "0.5", cfg.Inputs[0].Server.Instrumentation.TransactionSampleRate)
 	})
 	t.Run("APM config no tls", func(t *testing.T) {
 		outStruct, err := structpb.NewStruct(map[string]interface{}{
@@ -336,6 +340,8 @@ func Test_Agent_configFromUnits(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
+
+		samplingRate := float32(0.01)
 		mockInClient := &mockClientUnit{}
 		mockInClient.On("Expected").Return(
 			client.Expected{
@@ -349,6 +355,7 @@ func Test_Agent_configFromUnits(t *testing.T) {
 						SecretToken:  "secretToken",
 						Hosts:        []string{"testhost:8080"},
 						GlobalLabels: "test",
+						SamplingRate: &samplingRate,
 					},
 				},
 			})
@@ -374,6 +381,7 @@ func Test_Agent_configFromUnits(t *testing.T) {
 		assert.Equal(t, []string{"testhost:8080"}, cfg.Inputs[0].Server.Instrumentation.Hosts)
 		assert.Equal(t, "test", cfg.Inputs[0].Server.Instrumentation.GlobalLabels)
 		assert.Equal(t, "test-token", cfg.Output.Elasticsearch.ServiceToken)
+		assert.Equal(t, "0.01", cfg.Inputs[0].Server.Instrumentation.TransactionSampleRate)
 	})
 	t.Run("APM config and instrumentation is specified", func(t *testing.T) {
 		outStruct, err := structpb.NewStruct(map[string]interface{}{
@@ -398,14 +406,17 @@ func Test_Agent_configFromUnits(t *testing.T) {
 						"skip_verify":        true,
 						"server_certificate": "/path/to/cert.crt",
 					},
-					"environment":  "replace",
-					"api_key":      "replace",
-					"secret_token": "replace",
-					"hosts":        []interface{}{"replace"},
+					"environment":             "replace",
+					"api_key":                 "replace",
+					"secret_token":            "replace",
+					"hosts":                   []interface{}{"replace"},
+					"transaction_sample_rate": "0.75",
 				},
 			},
 		})
 		require.NoError(t, err)
+
+		samplingRate := float32(0.01)
 		mockInClient := &mockClientUnit{}
 		mockInClient.On("Expected").Return(
 			client.Expected{
@@ -423,6 +434,7 @@ func Test_Agent_configFromUnits(t *testing.T) {
 						SecretToken:  "secretToken",
 						Hosts:        []string{"testhost:8080"},
 						GlobalLabels: "test",
+						SamplingRate: &samplingRate,
 					},
 				},
 			})
@@ -449,6 +461,7 @@ func Test_Agent_configFromUnits(t *testing.T) {
 		assert.Equal(t, []string{"testhost:8080"}, cfg.Inputs[0].Server.Instrumentation.Hosts)
 		assert.Equal(t, "test", cfg.Inputs[0].Server.Instrumentation.GlobalLabels)
 		assert.Equal(t, "test-token", cfg.Output.Elasticsearch.ServiceToken)
+		assert.Equal(t, "0.01", cfg.Inputs[0].Server.Instrumentation.TransactionSampleRate)
 	})
 	t.Run("APM config error", func(t *testing.T) {
 		outStruct, err := structpb.NewStruct(map[string]interface{}{


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?
This PR introduces support for APM sample rate using the values provided by elastic-agent though the control protocol
// Please do not just reference an issue. Explain WHAT the problem this PR solves here.

## How does this PR solve the problem?
Added a check for a value of transacton sampling in `apmConfigToInstrumentation` (it's an optional float32) and formatted the vale as a string to be included in the instrumentation copnfig.
// Explain HOW you solved the problem in your code. It is possible that during PR reviews this changes and then this section should be updated.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->