### PR TITLE
Redact APM API key and secret token

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -186,6 +186,14 @@ func redactServer(cfg *Config) Server {
 		redacted.TLS = &newTLS
 	}
 
+	if redacted.Instrumentation.APIKey != "" {
+		redacted.Instrumentation.APIKey = kRedacted
+	}
+
+	if redacted.Instrumentation.SecretToken != "" {
+		redacted.Instrumentation.SecretToken = kRedacted
+	}
+
 	return redacted
 }
 

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -306,6 +306,132 @@ func TestLoadServerLimits(t *testing.T) {
 
 }
 
+func TestConfigRedact(t *testing.T) {
+
+	testcases := []struct {
+		name        string
+		inputCfg    *Config
+		redactedCfg *Config
+	}{
+		{
+			name: "do not modify empty APM secrets",
+			inputCfg: &Config{
+				Inputs: []Input{
+					{
+						Type: "fleet-server",
+						Server: Server{
+							Instrumentation: Instrumentation{
+								SecretToken: "",
+								APIKey:      "",
+							},
+						},
+					},
+				},
+			},
+			redactedCfg: &Config{
+				Inputs: []Input{
+					{
+						Server: Server{
+							Instrumentation: Instrumentation{
+								SecretToken: "",
+								APIKey:      "",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "redact APM secret token",
+			inputCfg: &Config{
+				Inputs: []Input{
+					{
+						Type: "fleet-server",
+						Server: Server{
+							Instrumentation: Instrumentation{
+								SecretToken: "secret value that noone should know",
+							},
+						},
+					},
+				},
+			},
+			redactedCfg: &Config{
+				Inputs: []Input{
+					{
+						Server: Server{
+							Instrumentation: Instrumentation{
+								SecretToken: kRedacted,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "redact APM API key",
+			inputCfg: &Config{
+				Inputs: []Input{
+					{
+						Type: "fleet-server",
+						Server: Server{
+							Instrumentation: Instrumentation{
+								APIKey: "secret value that noone should know",
+							},
+						},
+					},
+				},
+			},
+			redactedCfg: &Config{
+				Inputs: []Input{
+					{
+						Server: Server{
+							Instrumentation: Instrumentation{
+								APIKey: kRedacted,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "redact both APM API key and secret token",
+			inputCfg: &Config{
+				Inputs: []Input{
+					{
+						Type: "fleet-server",
+						Server: Server{
+							Instrumentation: Instrumentation{
+								APIKey:      "secret value that noone should know",
+								SecretToken: "another value that noone should know",
+							},
+						},
+					},
+				},
+			},
+			redactedCfg: &Config{
+				Inputs: []Input{
+					{
+						Server: Server{
+							Instrumentation: Instrumentation{
+								APIKey:      kRedacted,
+								SecretToken: kRedacted,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NotNil(t, tt.inputCfg, "input config cannot be nil")
+			actualRedacted := tt.inputCfg.Redact()
+			assert.Equal(t, tt.redactedCfg, actualRedacted)
+		})
+	}
+}
+
 // Stub out the defaults so that the above is easier to maintain
 
 func defaultCache() Cache {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

APM secrets were visible in elastic-agent diagnostics

## How does this PR solve the problem?
 Included APM API key and secret token to the `redactServer()` function so that any non-empty values are subtituted by `[redacted]`


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->