### PR TITLE
[Release] Update version to 8.16.1

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,4 +6,4 @@ package version
 
 // DefaultVersion is the current release version of Fleet-server, this version must match the
 // Elastic Agent version.
-const DefaultVersion = "8.16.0"
+const DefaultVersion = "8.16.1"


### PR DESCRIPTION
Updates references to the new release 8.16.1.

Merge after the release 8.16.0.