### PR TITLE
Update version of elastic/ec terraform provider to latest

### DIFF
--- a/dev-tools/cloud/terraform/main.tf
+++ b/dev-tools/cloud/terraform/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.11.0"
+      version = "0.12.1"
     }
   }
 }


### PR DESCRIPTION
What it says on the tin. 

https://registry.terraform.io/providers/elastic/ec/0.12.1