### PR TITLE
Replace deprecated deployment template ID

### DIFF
--- a/dev-tools/cloud/terraform/main.tf
+++ b/dev-tools/cloud/terraform/main.tf
@@ -47,7 +47,7 @@ resource "ec_deployment" "deployment" {
   name                   = format("fleet server PR %s", random_uuid.name.result)
   region                 = "gcp-us-west2"
   version                = local.stack_version
-  deployment_template_id = "gcp-io-optimized-v2"
+  deployment_template_id = "gcp-general-purpose"
 
   tags = {
     "created_with_terraform" = "true"


### PR DESCRIPTION
This PR updates the deployment template ID used to spin up deployments in ESS for Cloud E2E tests.  The deployment template ID being used has been [deprecated](https://www.elastic.co/guide/en/cloud/current/ec-regions-templates-instances.html) and continuing to use it is making the Cloud E2E tests fail like so:

```
ec_deployment.deployment: Creating...
--
  | ╷
  | │ Error: failed creating deployment
  | │
  | │   with ec_deployment.deployment,
  | │   on main.tf line 46, in resource "ec_deployment" "deployment":
  | │   46: resource "ec_deployment" "deployment" {
  | │
  | │ api error: 10 errors occurred:
  | │ 	* deployments.elasticsearch_using_legacy_dt: The referenced deployment template in elasticsearch plan [gcp-io-optimized-v2] is no longer available.
  | │ 	* deployments.topology_element_using_legacy_ic: The referenced instance configuration [gcp.coordinating.1] in topology element [coordinating] is no longer
  | │ available .
  | │ 	* deployments.topology_element_using_legacy_ic: The referenced instance configuration [gcp.data.highio.1] in topology element [hot_content] is no longer
  | │ available .
  | │ 	* deployments.topology_element_using_legacy_ic: The referenced instance configuration [gcp.data.highstorage.1] in topology element [cold] is no longer
  | │ available .
  | │ 	* deployments.topology_element_using_legacy_ic: The referenced instance configuration [gcp.data.highstorage.1] in topology element [warm] is no longer
  | │ available .
  | │ 	* deployments.topology_element_using_legacy_ic: The referenced instance configuration [gcp.es.datafrozen.n1.64x10x95] in topology element [frozen] is no
  | │ longer available .
  | │ 	* deployments.topology_element_using_legacy_ic: The referenced instance configuration [gcp.integrationsserver.1] in topology element [<unknown>] is no
  | │ longer available .
  | │ 	* deployments.topology_element_using_legacy_ic: The referenced instance configuration [gcp.kibana.1] in topology element [<unknown>] is no longer available
  | │ .
  | │ 	* deployments.topology_element_using_legacy_ic: The referenced instance configuration [gcp.master.1] in topology element [master] is no longer available .
  | │ 	* deployments.topology_element_using_legacy_ic: The referenced instance configuration [gcp.ml.1] in topology element [ml] is no longer available .
  | │
  | │
  | ╵
  | ╷
  | │ Error: failed creating deployment
```

