### PR TITLE
Log filename for package being downloaded

### DIFF
--- a/testing/e2e/agent_install_test.go
+++ b/testing/e2e/agent_install_test.go
@@ -140,7 +140,7 @@ func (suite *AgentInstallSuite) downloadAgent(ctx context.Context) io.ReadCloser
 
 	fileName := fmt.Sprintf("elastic-agent-%s-SNAPSHOT-%s-%s.%s", version.DefaultVersion, runtime.GOOS, arch, fType)
 	pkg, ok := body.Packages[fileName]
-	suite.Require().True(ok, "unable to find package download")
+	suite.Require().Truef(ok, "unable to find package download for fileName = %s", fileName)
 
 	req, err = http.NewRequestWithContext(ctx, "GET", pkg.URL, nil)
 	suite.Require().NoError(err)


### PR DESCRIPTION
When the `TestAgentInstallSuite` E2E test fails with the error, "unable to find package download", this PR adds the filename corresponding to the package being downloaded to the error message.  This should help figure out which package is being downloaded and why it might not be available.