### PR TITLE
Replace most context.TODO calls, comment on other Background and TODOs

### DIFF
--- a/changelog/fragments/1733164018-Replace-use-of-context.TODO.yaml
+++ b/changelog/fragments/1733164018-Replace-use-of-context.TODO.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: other
+
+# Change summary; a 80ish characters long description of the change.
+summary: Replace use of context.TODO
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: fleet-server
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/fleet-server/issues/3087

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/signal"
 	"github.com/elastic/fleet-server/v7/internal/pkg/state"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
@@ -117,12 +118,13 @@ func getRunCommand(bi build.Info) func(cmd *cobra.Command, args []string) error 
 				return err
 			}
 
-			srv, err := server.NewFleet(bi, state.NewLog(), true)
+			ctx := installSignalHandler()
+			srv, err := server.NewFleet(bi, state.NewLog(zerolog.Ctx(ctx)), true)
 			if err != nil {
 				return err
 			}
 
-			if err := srv.Run(installSignalHandler(), cfg); err != nil && !errors.Is(err, context.Canceled) {
+			if err := srv.Run(ctx, cfg); err != nil && !errors.Is(err, context.Canceled) {
 				log.Error().Err(err).Msg("Exiting")
 				l.Sync()
 				return err

--- a/internal/pkg/action/dispatcher.go
+++ b/internal/pkg/action/dispatcher.go
@@ -70,7 +70,7 @@ func (d *Dispatcher) Run(ctx context.Context) error {
 
 // Subscribe generates a new subscription with the Dispatcher using the provided agentID and seqNo.
 // There is no check to ensure that the agentID has not been used; using the same one twice results in undefined behaviour.
-func (d *Dispatcher) Subscribe(agentID string, seqNo sqn.SeqNo) *Sub {
+func (d *Dispatcher) Subscribe(log zerolog.Logger, agentID string, seqNo sqn.SeqNo) *Sub {
 	cbCh := make(chan []model.Action, 1)
 
 	sub := Sub{
@@ -84,14 +84,14 @@ func (d *Dispatcher) Subscribe(agentID string, seqNo sqn.SeqNo) *Sub {
 	sz := len(d.subs)
 	d.mx.Unlock()
 
-	zerolog.Ctx(context.TODO()).Trace().Str(logger.AgentID, agentID).Int("sz", sz).Msg("Subscribed to action dispatcher")
+	log.Trace().Str(logger.AgentID, agentID).Int("sz", sz).Msg("Subscribed to action dispatcher")
 
 	return &sub
 }
 
 // Unsubscribe removes the given subscription from the dispatcher.
 // Note that the channel sub.Ch() provides is not closed in this event.
-func (d *Dispatcher) Unsubscribe(sub *Sub) {
+func (d *Dispatcher) Unsubscribe(log zerolog.Logger, sub *Sub) {
 	if sub == nil {
 		return
 	}
@@ -101,7 +101,7 @@ func (d *Dispatcher) Unsubscribe(sub *Sub) {
 	sz := len(d.subs)
 	d.mx.Unlock()
 
-	zerolog.Ctx(context.TODO()).Trace().Str(logger.AgentID, sub.agentID).Int("sz", sz).Msg("Unsubscribed from action dispatcher")
+	log.Trace().Str(logger.AgentID, sub.agentID).Int("sz", sz).Msg("Unsubscribed from action dispatcher")
 }
 
 // process gathers actions from the monitor and dispatches them to the corresponding subscriptions.

--- a/internal/pkg/api/handleArtifacts.go
+++ b/internal/pkg/api/handleArtifacts.go
@@ -213,10 +213,10 @@ func (at ArtifactT) fetchArtifact(ctx context.Context, zlog zerolog.Logger, iden
 	span, ctx := apm.StartSpan(ctx, "fetchArtifact", "search")
 	defer span.End()
 	// Throttle prevents more than N outstanding requests to elastic globally and per sha2.
-	if token := at.esThrottle.Acquire(sha2, defaultThrottleTTL); token == nil {
+	if token := at.esThrottle.Acquire(zlog, sha2, defaultThrottleTTL); token == nil {
 		return nil, ErrorThrottle
 	} else {
-		defer token.Release()
+		defer token.Release(zlog)
 	}
 
 	start := time.Now()

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -274,8 +274,8 @@ func (ct *CheckinT) ProcessRequest(zlog zerolog.Logger, w http.ResponseWriter, r
 	}
 
 	// Subscribe to actions dispatcher
-	aSub := ct.ad.Subscribe(agent.Id, seqno)
-	defer ct.ad.Unsubscribe(aSub)
+	aSub := ct.ad.Subscribe(zlog, agent.Id, seqno)
+	defer ct.ad.Unsubscribe(zlog, aSub)
 	actCh := aSub.Ch()
 
 	// use revision_idx=0 if the agent has a single output where no API key is defined

--- a/internal/pkg/api/handleFileDelivery.go
+++ b/internal/pkg/api/handleFileDelivery.go
@@ -5,10 +5,11 @@
 package api
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"strconv"
+
+	"github.com/rs/zerolog"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/cache"
@@ -16,7 +17,6 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/file/delivery"
 	"github.com/elastic/fleet-server/v7/internal/pkg/model"
 	"github.com/elastic/go-elasticsearch/v8"
-	"github.com/rs/zerolog"
 )
 
 type FileDeliveryT struct {
@@ -28,11 +28,6 @@ type FileDeliveryT struct {
 }
 
 func NewFileDeliveryT(cfg *config.Server, bulker bulk.Bulk, chunkClient *elasticsearch.Client, cache cache.Cache) *FileDeliveryT {
-	zerolog.Ctx(context.TODO()).Info().
-		Interface("limits", cfg.Limits.ArtifactLimit).
-		Int64("maxFileSize", maxFileSize).
-		Msg("upload limits")
-
 	return &FileDeliveryT{
 		chunkClient: chunkClient,
 		bulker:      bulker,

--- a/internal/pkg/api/handleUpload.go
+++ b/internal/pkg/api/handleUpload.go
@@ -16,6 +16,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rs/zerolog"
+	"go.elastic.co/apm/v2"
+
 	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/cache"
@@ -25,8 +28,6 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/file/uploader"
 	"github.com/elastic/fleet-server/v7/internal/pkg/model"
 	"github.com/elastic/go-elasticsearch/v8"
-	"github.com/rs/zerolog"
-	"go.elastic.co/apm/v2"
 )
 
 const (
@@ -53,11 +54,6 @@ type UploadT struct {
 }
 
 func NewUploadT(cfg *config.Server, bulker bulk.Bulk, chunkClient *elasticsearch.Client, cache cache.Cache) *UploadT {
-	zerolog.Ctx(context.TODO()).Info().
-		Interface("limits", cfg.Limits.ArtifactLimit).
-		Int64("maxFileSize", maxFileSize).
-		Msg("upload limits")
-
 	return &UploadT{
 		chunkClient: chunkClient,
 		bulker:      bulker,

--- a/internal/pkg/api/metrics.go
+++ b/internal/pkg/api/metrics.go
@@ -10,15 +10,16 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/elastic/elastic-agent-libs/api"
-	cfglib "github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/monitoring"
-	"github.com/elastic/elastic-agent-system-metrics/report"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/zerolog"
 	apmprometheus "go.elastic.co/apm/module/apmprometheus/v2"
 	"go.elastic.co/apm/v2"
+
+	"github.com/elastic/elastic-agent-libs/api"
+	cfglib "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+	"github.com/elastic/elastic-agent-system-metrics/report"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/build"
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
@@ -56,7 +57,7 @@ var (
 func init() {
 	err := report.SetupMetrics(logger.NewZapStub("instance-metrics"), build.ServiceName, version.DefaultVersion)
 	if err != nil {
-		zerolog.Ctx(context.TODO()).Error().Err(err).Msg("unable to initialize metrics")
+		zerolog.Ctx(context.TODO()).Error().Err(err).Msg("unable to initialize metrics") // TODO is used because this may logged during the package load
 	}
 
 	registry = newMetricsRegistry("http_server")

--- a/internal/pkg/api/server.go
+++ b/internal/pkg/api/server.go
@@ -13,6 +13,8 @@ import (
 	"net"
 	"net/http"
 
+	"go.elastic.co/apm/v2"
+
 	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 	"github.com/elastic/fleet-server/v7/internal/pkg/build"
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
@@ -20,7 +22,6 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/limit"
 	"github.com/elastic/fleet-server/v7/internal/pkg/logger"
 	"github.com/elastic/fleet-server/v7/internal/pkg/policy"
-	"go.elastic.co/apm/v2"
 
 	"github.com/rs/zerolog"
 )
@@ -74,7 +75,7 @@ func (s *server) Run(ctx context.Context) error {
 		MaxHeaderBytes:    mhbz,
 		BaseContext:       func(net.Listener) context.Context { return ctx },
 		ErrorLog:          errLogger(ctx),
-		ConnState:         diagConn,
+		ConnState:         getDiagConnFunc(ctx),
 	}
 
 	var listenCfg net.ListenConfig
@@ -131,7 +132,7 @@ func (s *server) Run(ctx context.Context) error {
 		}
 	// Do a clean shutdown if the context is cancelled
 	case <-ctx.Done():
-		sCtx, cancel := context.WithTimeout(context.Background(), s.cfg.Timeouts.Drain)
+		sCtx, cancel := context.WithTimeout(context.Background(), s.cfg.Timeouts.Drain) // Background context to allow connections to drain when server context is cancelled.
 		defer cancel()
 		if err := srv.Shutdown(sCtx); err != nil {
 			cErr := srv.Close() // force it closed
@@ -142,24 +143,26 @@ func (s *server) Run(ctx context.Context) error {
 	return nil
 }
 
-func diagConn(c net.Conn, s http.ConnState) {
-	if c == nil {
-		return
-	}
+func getDiagConnFunc(ctx context.Context) func(c net.Conn, s http.ConnState) {
+	return func(c net.Conn, s http.ConnState) {
+		if c == nil {
+			return
+		}
 
-	zerolog.Ctx(context.TODO()).Trace().
-		Str("local", c.LocalAddr().String()).
-		Str("remote", c.RemoteAddr().String()).
-		Str("state", s.String()).
-		Msg("connection state change")
+		zerolog.Ctx(ctx).Trace().
+			Str("local", c.LocalAddr().String()).
+			Str("remote", c.RemoteAddr().String()).
+			Str("state", s.String()).
+			Msg("connection state change")
 
-	switch s {
-	case http.StateNew:
-		cntHTTPNew.Inc()
-		cntHTTPActive.Inc()
-	case http.StateClosed:
-		cntHTTPClose.Inc()
-		cntHTTPActive.Dec()
+		switch s {
+		case http.StateNew:
+			cntHTTPNew.Inc()
+			cntHTTPActive.Inc()
+		case http.StateClosed:
+			cntHTTPClose.Inc()
+			cntHTTPActive.Dec()
+		}
 	}
 }
 
@@ -171,7 +174,7 @@ func wrapConnLimitter(ctx context.Context, ln net.Listener, cfg *config.Server) 
 			Int("hardConnLimit", hardLimit).
 			Msg("server hard connection limiter installed")
 
-		ln = limit.Listener(ln, hardLimit)
+		ln = limit.Listener(ln, hardLimit, zerolog.Ctx(ctx))
 	} else {
 		zerolog.Ctx(ctx).Info().Msg("server hard connection limiter disabled")
 	}

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -21,11 +21,12 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/logger"
 	"github.com/elastic/go-ucfg"
 
-	"github.com/elastic/go-elasticsearch/v8"
-	"github.com/elastic/go-elasticsearch/v8/esapi"
 	"github.com/rs/zerolog"
 	"go.elastic.co/apm/v2"
 	"golang.org/x/sync/semaphore"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/elastic/go-elasticsearch/v8/esapi"
 )
 
 type APIKey = apikey.APIKey
@@ -164,7 +165,7 @@ func (b *Bulker) CreateAndGetBulker(ctx context.Context, zlog zerolog.Logger, ou
 			cancelFn()
 		}
 	}
-	bulkCtx, bulkCancel := context.WithCancel(context.Background())
+	bulkCtx, bulkCancel := context.WithCancel(context.Background()) // background context used to allow bulker to flush on exit, exits when config changes or primary bulker exits.
 	es, err := b.createRemoteEsClient(bulkCtx, outputName, outputMap)
 	if err != nil {
 		defer bulkCancel()

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -13,13 +13,14 @@ import (
 
 	testlog "github.com/elastic/fleet-server/v7/internal/pkg/testing/log"
 
-	"github.com/elastic/go-ucfg"
 	"github.com/gofrs/uuid"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/go-ucfg"
 )
 
 func TestConfig(t *testing.T) {
@@ -179,7 +180,7 @@ func TestConfig(t *testing.T) {
 				}
 			} else {
 				require.NoError(t, err)
-				err = cfg.LoadServerLimits()
+				err = cfg.LoadServerLimits(&l)
 				require.NoError(t, err)
 				skipUnexported := cmpopts.IgnoreUnexported(Config{})
 				if !assert.True(t, cmp.Equal(test.cfg, cfg, skipUnexported)) {
@@ -199,7 +200,7 @@ func TestConfig(t *testing.T) {
 		cfg, err := LoadFile(path)
 		t.Logf("cfg fileread: %+v", cfg.Inputs[0].Server.Limits)
 		require.NoError(t, err)
-		err = cfg.LoadServerLimits()
+		err = cfg.LoadServerLimits(&l)
 		require.NoError(t, err)
 		t.Logf("cfg loaded: %+v", cfg.Inputs[0].Server.Limits)
 
@@ -245,13 +246,15 @@ func TestLoadStandaloneAgentMetadata(t *testing.T) {
 
 func TestLoadServerLimits(t *testing.T) {
 	t.Run("empty loads limits", func(t *testing.T) {
+		l := testlog.SetLogger(t)
 		c := &Config{Inputs: []Input{{}}}
-		err := c.LoadServerLimits()
+		err := c.LoadServerLimits(&l)
 		assert.NoError(t, err)
 		assert.NotZero(t, c.Inputs[0].Server.Limits.CheckinLimit.MaxBody)
 		assert.NotZero(t, c.Inputs[0].Cache.ActionTTL)
 	})
 	t.Run("agent count limits load", func(t *testing.T) {
+		l := testlog.SetLogger(t)
 		c := &Config{Inputs: []Input{{
 			Server: Server{
 				Limits: ServerLimits{
@@ -259,13 +262,14 @@ func TestLoadServerLimits(t *testing.T) {
 				},
 			},
 		}}}
-		err := c.LoadServerLimits()
+		err := c.LoadServerLimits(&l)
 		assert.NoError(t, err)
 		assert.NotZero(t, c.Inputs[0].Server.Limits.CheckinLimit.MaxBody)
 		assert.Equal(t, time.Millisecond*5, c.Inputs[0].Server.Limits.CheckinLimit.Interval)
 
 	})
 	t.Run("agent count limits load does not override", func(t *testing.T) {
+		l := testlog.SetLogger(t)
 		c := &Config{Inputs: []Input{{
 			Server: Server{
 				Limits: ServerLimits{
@@ -276,13 +280,14 @@ func TestLoadServerLimits(t *testing.T) {
 				},
 			},
 		}}}
-		err := c.LoadServerLimits()
+		err := c.LoadServerLimits(&l)
 		assert.NoError(t, err)
 		assert.NotZero(t, c.Inputs[0].Server.Limits.CheckinLimit.MaxBody)
 		assert.Equal(t, time.Millisecond, c.Inputs[0].Server.Limits.ActionLimit.Interval)
 
 	})
 	t.Run("existing values are not overridden", func(t *testing.T) {
+		l := testlog.SetLogger(t)
 		c := &Config{
 			Inputs: []Input{{
 				Server: Server{
@@ -297,7 +302,7 @@ func TestLoadServerLimits(t *testing.T) {
 				},
 			}},
 		}
-		err := c.LoadServerLimits()
+		err := c.LoadServerLimits(&l)
 		assert.NoError(t, err)
 		assert.Equal(t, int64(5*defaultCheckinMaxBody), c.Inputs[0].Server.Limits.CheckinLimit.MaxBody)
 		assert.NotZero(t, c.Inputs[0].Server.Limits.CheckinLimit.Burst)
@@ -435,22 +440,25 @@ func TestConfigRedact(t *testing.T) {
 // Stub out the defaults so that the above is easier to maintain
 
 func defaultCache() Cache {
+	log := zerolog.Nop()
 	var d Cache
 	d.InitDefaults()
-	d.LoadLimits(loadLimits(0))
+	d.LoadLimits(loadLimits(&log, 0))
 	return d
 }
 
 func generateCache(maxAgents int) Cache {
+	log := zerolog.Nop()
 	var d Cache
-	d.LoadLimits(loadLimits(maxAgents))
+	d.LoadLimits(loadLimits(&log, maxAgents))
 	return d
 }
 
 func generateServerLimits(maxAgents int) ServerLimits {
+	log := zerolog.Nop()
 	var d ServerLimits
 	d.MaxAgents = maxAgents
-	d.LoadLimits(loadLimits(maxAgents))
+	d.LoadLimits(loadLimits(&log, maxAgents))
 	return d
 }
 
@@ -500,9 +508,10 @@ func defaultElastic() Elasticsearch {
 }
 
 func defaultServer() Server {
+	log := zerolog.Nop()
 	var d Server
 	d.InitDefaults()
-	d.Limits.LoadLimits(loadLimits(0))
+	d.Limits.LoadLimits(loadLimits(&log, 0))
 	return d
 }
 

--- a/internal/pkg/config/env_defaults.go
+++ b/internal/pkg/config/env_defaults.go
@@ -5,7 +5,6 @@
 package config
 
 import (
-	"context"
 	"embed"
 	"fmt"
 	"io"
@@ -282,13 +281,12 @@ func init() {
 // If agentLimit > 0 the settings from the matching default/*.yml file are used based off agent count.
 // If agentLimit == 0 then the settings from default/*.yml are used based off system memory.
 // If a lookup fails, default settings are used.
-func loadLimits(agentLimit int) *envLimits {
+func loadLimits(log *zerolog.Logger, agentLimit int) *envLimits {
 	if agentLimit < 0 {
 		return defaultEnvLimits()
 	} else if agentLimit == 0 {
-		return memEnvLimits()
+		return memEnvLimits(log)
 	}
-	log := zerolog.Ctx(context.TODO())
 	for _, l := range defaults {
 		// get nearest limits for configured agent numbers
 		if l.Agents.Min <= agentLimit && agentLimit <= l.Agents.Max {
@@ -310,11 +308,10 @@ var memMB func() uint64 = func() uint64 {
 	return memory.TotalMemory() / 1024 / 1024
 }
 
-func memEnvLimits() *envLimits {
+func memEnvLimits(log *zerolog.Logger) *envLimits {
 	mem := memMB()
 	k := 0
 	var recRAM uint64
-	log := zerolog.Ctx(context.TODO())
 	for i, l := range defaults {
 		if mem >= l.RecommendedRAM && l.RecommendedRAM > recRAM {
 			k = i

--- a/internal/pkg/config/env_defaults_test.go
+++ b/internal/pkg/config/env_defaults_test.go
@@ -33,7 +33,7 @@ func TestLoadLimits(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			log := testlog.SetLogger(t)
 			zerolog.DefaultContextLogger = &log
-			l := loadLimits(tc.ConfiguredAgentLimit)
+			l := loadLimits(&log, tc.ConfiguredAgentLimit)
 
 			require.Equal(t, tc.ExpectedAgentLimit, l.Agents.Max)
 		})

--- a/internal/pkg/profile/profile.go
+++ b/internal/pkg/profile/profile.go
@@ -13,8 +13,9 @@ import (
 	"net/http"
 	"net/http/pprof"
 
-	"github.com/elastic/fleet-server/v7/internal/pkg/config"
 	"github.com/rs/zerolog"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/config"
 )
 
 // RunProfiler exposes /debug/pprof on the passed address by staring a server.
@@ -60,7 +61,7 @@ func RunProfiler(ctx context.Context, addr string) error {
 		zerolog.Ctx(ctx).Error().Err(err).Str("bind", addr).Msg("Fail install profiler")
 		return err
 	case <-ctx.Done():
-		sCtx, cancel := context.WithTimeout(context.Background(), cfg.Drain)
+		sCtx, cancel := context.WithTimeout(context.Background(), cfg.Drain) // new context from Background to allow connections to drain when server context is cancelled.
 		defer cancel()
 		if err := server.Shutdown(sCtx); err != nil {
 			cErr := server.Close() // force it closed

--- a/internal/pkg/server/agent.go
+++ b/internal/pkg/server/agent.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog"
+
 	"github.com/elastic/fleet-server/v7/internal/pkg/build"
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
 	"github.com/elastic/fleet-server/v7/internal/pkg/es"
@@ -21,12 +23,12 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/sleep"
 	"github.com/elastic/fleet-server/v7/internal/pkg/state"
 	"github.com/elastic/fleet-server/v7/internal/pkg/ver"
-	"github.com/rs/zerolog"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 	"github.com/elastic/go-ucfg"
-	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -357,7 +359,7 @@ func (a *Agent) start(ctx context.Context) error {
 
 	srvDone := make(chan bool)
 	srvCtx, srvCanceller := context.WithCancel(ctx)
-	srv, err := NewFleet(a.bi, state.NewChained(state.NewLog(), a), false)
+	srv, err := NewFleet(a.bi, state.NewChained(state.NewLog(zerolog.Ctx(ctx)), a), false)
 	if err != nil {
 		close(srvDone)
 		srvCanceller()

--- a/internal/pkg/server/fleet.go
+++ b/internal/pkg/server/fleet.go
@@ -14,9 +14,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"go.elastic.co/apm/v2"
 	apmtransport "go.elastic.co/apm/v2/transport"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/action"
 	"github.com/elastic/fleet-server/v7/internal/pkg/api"
@@ -86,13 +87,13 @@ func (f *Fleet) GetConfig() *config.Config {
 // Run runs the fleet server
 func (f *Fleet) Run(ctx context.Context, initCfg *config.Config) error {
 	log := zerolog.Ctx(ctx)
-	err := initCfg.LoadServerLimits()
+	err := initCfg.LoadServerLimits(log)
 	if err != nil {
 		return fmt.Errorf("encountered error while loading server limits: %w", err)
 	}
 	cacheCfg := config.CopyCache(initCfg)
 	log.Info().Interface("cfg", cacheCfg).Msg("Setting cache config options")
-	cache, err := cache.New(cacheCfg)
+	cache, err := cache.New(cacheCfg, cache.WithLog(log))
 	if err != nil {
 		return err
 	}
@@ -150,7 +151,7 @@ LOOP:
 			f.reporter.UpdateState(client.UnitStateStarting, "Starting", nil) //nolint:errcheck // unclear on what should we do if updating the status fails?
 		}
 
-		err := newCfg.LoadServerLimits()
+		err := newCfg.LoadServerLimits(log)
 		if err != nil {
 			return fmt.Errorf("encountered error while loading server limits: %w", err)
 		}
@@ -219,7 +220,7 @@ LOOP:
 
 	// Server is coming down; wait for the server group to exit cleanly.
 	// Timeout if something is locked up.
-	err = safeWait(srvEg, curCfg.Inputs[0].Server.Timeouts.Drain)
+	err = safeWait(log, srvEg, curCfg.Inputs[0].Server.Timeouts.Drain)
 
 	// Eat cancel error to minimize confusion in logs
 	if errors.Is(err, context.Canceled) {
@@ -277,7 +278,7 @@ func configChangedServer(log zerolog.Logger, curCfg, newCfg *config.Config) bool
 	return changed
 }
 
-func safeWait(g *errgroup.Group, to time.Duration) error {
+func safeWait(log *zerolog.Logger, g *errgroup.Group, to time.Duration) error {
 	var err error
 	waitCh := make(chan error)
 	go func() {
@@ -287,7 +288,7 @@ func safeWait(g *errgroup.Group, to time.Duration) error {
 	select {
 	case err = <-waitCh:
 	case <-time.After(to):
-		zerolog.Ctx(context.TODO()).Warn().Msg("deadlock: goroutine locked up on errgroup.Wait()")
+		log.Warn().Msg("deadlock: goroutine locked up on errgroup.Wait()")
 		err = errors.New("group wait timeout")
 	}
 
@@ -315,12 +316,12 @@ func loggedRunFunc(ctx context.Context, tag string, runfn runFunc) func() error 
 	}
 }
 
-func initRuntime(cfg *config.Config) {
+func initRuntime(log *zerolog.Logger, cfg *config.Config) {
 	gcPercent := cfg.Inputs[0].Server.Runtime.GCPercent
 	if gcPercent != 0 {
 		old := debug.SetGCPercent(gcPercent)
 
-		zerolog.Ctx(context.TODO()).Info().
+		log.Info().
 			Int("old", old).
 			Int("new", gcPercent).
 			Msg("SetGCPercent")
@@ -329,7 +330,7 @@ func initRuntime(cfg *config.Config) {
 	if memoryLimit != 0 {
 		old := debug.SetMemoryLimit(memoryLimit)
 
-		zerolog.Ctx(context.TODO()).Info().
+		log.Info().
 			Int64("old", old).
 			Int64("new", memoryLimit).
 			Msg("SetMemoryLimit")
@@ -352,7 +353,7 @@ func (f *Fleet) initBulker(ctx context.Context, tracer *apm.Tracer, cfg *config.
 }
 
 func (f *Fleet) runServer(ctx context.Context, cfg *config.Config) (err error) {
-	initRuntime(cfg)
+	initRuntime(zerolog.Ctx(ctx), cfg)
 
 	// Create the APM tracer.
 	tracer, err := f.initTracer(ctx, cfg.Inputs[0].Server.Instrumentation)

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-cleanhttp"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -206,7 +207,8 @@ func startTestServer(t *testing.T, ctx context.Context, policyD model.PolicyData
 		}
 	}
 
-	srv, err := NewFleet(build.Info{Version: serverVersion}, state.NewLog(), false)
+	l := zerolog.Nop()
+	srv, err := NewFleet(build.Info{Version: serverVersion}, state.NewLog(&l), false)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create server: %w", err)
 	}

--- a/internal/pkg/state/reporter.go
+++ b/internal/pkg/state/reporter.go
@@ -6,10 +6,9 @@
 package state
 
 import (
-	"context"
+	"github.com/rs/zerolog"
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
-	"github.com/rs/zerolog"
 )
 
 // Reporter is interface that reports updated state on.
@@ -19,16 +18,20 @@ type Reporter interface {
 }
 
 // Log will write state' to log.
-type Log struct{}
+type Log struct {
+	*zerolog.Logger
+}
 
 // NewLog creates a Log.
-func NewLog() *Log {
-	return &Log{}
+func NewLog(l *zerolog.Logger) *Log {
+	return &Log{
+		l,
+	}
 }
 
 // UpdateState triggers updating the state.
 func (l *Log) UpdateState(state client.UnitState, message string, _ map[string]interface{}) error {
-	zerolog.Ctx(context.TODO()).Info().Str("state", state.String()).Msg(message)
+	l.Info().Str("state", state.String()).Msg(message)
 	return nil
 }
 

--- a/internal/pkg/testing/esutil/datastream.go
+++ b/internal/pkg/testing/esutil/datastream.go
@@ -10,8 +10,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/rs/zerolog"
+
+	"github.com/elastic/go-elasticsearch/v8"
 )
 
 func CreateDatastream(ctx context.Context, cli *elasticsearch.Client, name string) error {
@@ -25,7 +26,7 @@ func CreateDatastream(ctx context.Context, cli *elasticsearch.Client, name strin
 
 	defer res.Body.Close()
 
-	err = checkResponseError(res)
+	err = checkResponseError(res, zerolog.Ctx(ctx))
 	if err != nil {
 		if errors.Is(err, ErrResourceAlreadyExists) {
 			zerolog.Ctx(ctx).Info().Str("name", name).Msg("Datastream already exists")

--- a/internal/pkg/testing/esutil/ilm.go
+++ b/internal/pkg/testing/esutil/ilm.go
@@ -12,8 +12,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/rs/zerolog"
+
+	"github.com/elastic/go-elasticsearch/v8"
 )
 
 // Can be cleaner but it's temporary bootstrap until it's moved to the elasticseach system index plugin
@@ -55,7 +56,7 @@ func EnsureILMPolicy(ctx context.Context, cli *elasticsearch.Client, name string
 	if res.StatusCode == http.StatusNotFound {
 		// Got 404. Could be from elastic, could be from the cloud if deployment is not found.
 		// Parse response to figure out the details from JSON body
-		errRes, err := parseResponseError(res)
+		errRes, err := parseResponseError(res, zerolog.Ctx(ctx))
 		if err != nil {
 			lg.Warn().Err(err).Msgf("Failed to parse ILM policy not found response.")
 			return err
@@ -80,7 +81,7 @@ func EnsureILMPolicy(ctx context.Context, cli *elasticsearch.Client, name string
 	}
 
 	// Check for other possible error responses
-	err = checkResponseError(res)
+	err = checkResponseError(res, zerolog.Ctx(ctx))
 	if err != nil {
 		lg.Info().Err(err).Msgf("Error response on fetching ILM Policy")
 		return err
@@ -157,7 +158,7 @@ func createILMPolicy(ctx context.Context, cli *elasticsearch.Client, name string
 		return err
 	}
 	defer res.Body.Close()
-	return checkResponseError(res)
+	return checkResponseError(res, zerolog.Ctx(ctx))
 }
 
 func GetILMPolicyName(name string) string {

--- a/internal/pkg/testing/esutil/index.go
+++ b/internal/pkg/testing/esutil/index.go
@@ -10,8 +10,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/rs/zerolog"
+
+	"github.com/elastic/go-elasticsearch/v8"
 )
 
 func CreateIndex(ctx context.Context, cli *elasticsearch.Client, name string) error {
@@ -25,7 +26,7 @@ func CreateIndex(ctx context.Context, cli *elasticsearch.Client, name string) er
 
 	defer res.Body.Close()
 
-	err = checkResponseError(res)
+	err = checkResponseError(res, zerolog.Ctx(ctx))
 	if err != nil {
 		if errors.Is(err, ErrResourceAlreadyExists) {
 			zerolog.Ctx(ctx).Info().Str("name", name).Msg("Index already exists")
@@ -57,7 +58,7 @@ func DeleteIndices(ctx context.Context, cli *elasticsearch.Client, names ...stri
 
 	defer res.Body.Close()
 
-	err = checkResponseError(res)
+	err = checkResponseError(res, zerolog.Ctx(ctx))
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/testing/esutil/template.go
+++ b/internal/pkg/testing/esutil/template.go
@@ -12,8 +12,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/rs/zerolog"
+
+	"github.com/elastic/go-elasticsearch/v8"
 )
 
 const (
@@ -124,7 +125,7 @@ func createTemplate(ctx context.Context, cli *elasticsearch.Client, name string,
 	}
 	defer res.Body.Close()
 
-	err = checkResponseError(res)
+	err = checkResponseError(res, zerolog.Ctx(ctx))
 	if err != nil {
 		if errors.Is(err, ErrResourceAlreadyExists) {
 			zerolog.Ctx(ctx).Info().Str("name", name).Msg("Index template already exists")

--- a/internal/pkg/throttle/throttle_test.go
+++ b/internal/pkg/throttle/throttle_test.go
@@ -10,8 +10,9 @@ import (
 	"testing"
 	"time"
 
-	testlog "github.com/elastic/fleet-server/v7/internal/pkg/testing/log"
 	"github.com/rs/zerolog"
+
+	testlog "github.com/elastic/fleet-server/v7/internal/pkg/testing/log"
 )
 
 func TestThrottleZero(t *testing.T) {
@@ -30,7 +31,7 @@ func TestThrottleZero(t *testing.T) {
 		key := strconv.Itoa(i)
 
 		// Acquire token for key with long timeout so doesn't trip unit test
-		token1 := throttle.Acquire(key, time.Hour)
+		token1 := throttle.Acquire(l, key, time.Hour)
 		if token1 == nil {
 			t.Fatal("Acquire failed")
 		}
@@ -38,7 +39,7 @@ func TestThrottleZero(t *testing.T) {
 
 		// Second acquire should fail because we have not released the original token,
 		// or possibly if i == N-1 we could max parallel
-		token2 := throttle.Acquire(key, time.Hour)
+		token2 := throttle.Acquire(l, key, time.Hour)
 		if token2 != nil {
 			t.Error("Expected second acquire to fail on conflict")
 		}
@@ -50,7 +51,7 @@ func TestThrottleZero(t *testing.T) {
 		key := strconv.Itoa(i)
 
 		// Acquire should fail because we have not released the original token,
-		token := throttle.Acquire(key, time.Hour)
+		token := throttle.Acquire(l, key, time.Hour)
 		if token != nil {
 			t.Error("Expected acquire to fail on conflict")
 		}
@@ -58,13 +59,13 @@ func TestThrottleZero(t *testing.T) {
 
 	for i, token := range tokens {
 
-		found := token.Release()
+		found := token.Release(l)
 		if !found {
 			t.Error("Expect token to be found")
 		}
 
 		// Second release should return false
-		found = token.Release()
+		found = token.Release(l)
 		if found {
 			t.Error("Expect token to not found on second release")
 		}
@@ -72,12 +73,12 @@ func TestThrottleZero(t *testing.T) {
 		// We should now be able to to acquire
 		key := strconv.Itoa(i)
 
-		token = throttle.Acquire(key, time.Hour)
+		token = throttle.Acquire(l, key, time.Hour)
 		if token == nil {
 			t.Fatal("Acquire failed")
 		}
 
-		found = token.Release()
+		found = token.Release(l)
 		if !found {
 			t.Error("Expect token to be found")
 		}
@@ -98,7 +99,7 @@ func TestThrottleN(t *testing.T) {
 			key := strconv.Itoa(i)
 
 			// Acquire token for key with long timeout so doesn't trip unit test
-			token1 := throttle.Acquire(key, time.Hour)
+			token1 := throttle.Acquire(l, key, time.Hour)
 			if token1 == nil {
 				t.Fatal("Acquire failed")
 			}
@@ -106,7 +107,7 @@ func TestThrottleN(t *testing.T) {
 
 			// Second acquire should fail because we have not released the original token,
 			// or possibly if i == N-1 we could max parallel
-			token2 := throttle.Acquire(key, time.Hour)
+			token2 := throttle.Acquire(l, key, time.Hour)
 			if token2 != nil {
 				t.Error("Expected second acquire to fail on conflict")
 			}
@@ -118,7 +119,7 @@ func TestThrottleN(t *testing.T) {
 
 			key := strconv.Itoa(N + i)
 
-			token1 := throttle.Acquire(key, time.Hour)
+			token1 := throttle.Acquire(l, key, time.Hour)
 			if token1 != nil {
 				t.Fatal("Expect acquire to fail on max tokens")
 			}
@@ -127,13 +128,13 @@ func TestThrottleN(t *testing.T) {
 		// Release one at a time, validate that we can reacquire
 		for i, token := range tokens {
 
-			found := token.Release()
+			found := token.Release(l)
 			if !found {
 				t.Error("Expect token to be found")
 			}
 
 			// Second release should return false
-			found = token.Release()
+			found = token.Release(l)
 			if found {
 				t.Error("Expect token to not found on second release")
 			}
@@ -141,12 +142,12 @@ func TestThrottleN(t *testing.T) {
 			// We should now be able to to acquire
 			key := strconv.Itoa(i)
 
-			token = throttle.Acquire(key, time.Hour)
+			token = throttle.Acquire(l, key, time.Hour)
 			if token == nil {
 				t.Fatal("Acquire failed")
 			}
 
-			found = token.Release()
+			found = token.Release(l)
 			if !found {
 				t.Error("Expect token to be found")
 			}
@@ -161,10 +162,10 @@ func TestThrottleExpireIdentity(t *testing.T) {
 	throttle := NewThrottle(1)
 
 	const key = "xxx"
-	token := throttle.Acquire(key, time.Second)
+	token := throttle.Acquire(l, key, time.Second)
 
 	// Should *NOT* be able to re-acquire until TTL
-	token2 := throttle.Acquire(key, time.Hour)
+	token2 := throttle.Acquire(l, key, time.Hour)
 	if token2 != nil {
 		t.Error("Expected second acquire to fail on conflict")
 	}
@@ -172,19 +173,19 @@ func TestThrottleExpireIdentity(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// Should be able to re-acquire on expiration
-	token3 := throttle.Acquire(key, time.Hour)
+	token3 := throttle.Acquire(l, key, time.Hour)
 	if token3 == nil {
 		t.Fatal("Expected third acquire to succeed")
 	}
 
 	// Original token should fail release
-	found := token.Release()
+	found := token.Release(l)
 	if found {
 		t.Error("Expected token to have expired")
 	}
 
 	// However, third token should release fine
-	found = token3.Release()
+	found = token3.Release(l)
 	if !found {
 		t.Error("Expect recently acquired token to release cleanly")
 	}
@@ -198,11 +199,11 @@ func TestThrottleExpireAtMax(t *testing.T) {
 	throttle := NewThrottle(1)
 
 	key1 := "xxx"
-	token1 := throttle.Acquire(key1, time.Second)
+	token1 := throttle.Acquire(l, key1, time.Second)
 
 	// Should be at max, cannot acquire different key
 	key2 := "yyy"
-	token2 := throttle.Acquire(key2, time.Hour)
+	token2 := throttle.Acquire(l, key2, time.Hour)
 	if token2 != nil {
 		t.Error("Expected second acquire to fail on max")
 	}
@@ -210,19 +211,19 @@ func TestThrottleExpireAtMax(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// Should be able acquire second after timeout
-	token2 = throttle.Acquire(key2, time.Hour)
+	token2 = throttle.Acquire(l, key2, time.Hour)
 	if token2 == nil {
 		t.Fatal("Expected third acquire to succeed")
 	}
 
 	// Original token should fail release
-	found := token1.Release()
+	found := token1.Release(l)
 	if found {
 		t.Error("Expected token to have expired")
 	}
 
 	// However, third token should release fine
-	found = token2.Release()
+	found = token2.Release(l)
 	if !found {
 		t.Error("Expect recently acquired token2 to release cleanly")
 	}


### PR DESCRIPTION
## What is the problem this PR solves?

Replace use of context.TODO and context.Background from most use cases

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

- Closes #3087