### PR TITLE
Remove race condition when accessing remote bulker map

### DIFF
--- a/changelog/fragments/1733181546-Remove-race-in-remote-bulker-access.yaml
+++ b/changelog/fragments/1733181546-Remove-race-in-remote-bulker-access.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Remove race in remote bulker access
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: fleet-server
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/fleet-server/issues/4170

--- a/internal/pkg/bulk/bulk_remote_output_test.go
+++ b/internal/pkg/bulk/bulk_remote_output_test.go
@@ -155,6 +155,7 @@ func Test_CreateAndGetBulkerChanged(t *testing.T) {
 }
 
 func Benchmark_CreateAndGetBulker(b *testing.B) {
+	b.Skip("Crashes on remote runner")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	log := zerolog.Nop()


### PR DESCRIPTION
## What is the problem this PR solves?

Remove a race condition/bug that may occur when remote ES outputs are used.

## How does this PR solve the problem?

Use the `remoteOutputMutex` whenever accessing the `bulkerMap`.
Change `GetBulkerMap` to return a copy of the map so that remote output health will not conflict with adding/removing a bulker from the map.

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Closes #4170