### PR TITLE
Redact static tokens and custom http headers

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -169,18 +169,28 @@ func redactOutput(cfg *Config) Output {
 		redacted.Elasticsearch.TLS = &newTLS
 	}
 
-	for k := range redacted.Elasticsearch.Headers {
-		lk := strings.ToLower(k)
-		if strings.Contains(lk, "auth") || strings.Contains(lk, "token") || strings.Contains(lk, "key") || strings.Contains(lk, "bearer") { // best-effort scan to redact sensitive headers
-			redacted.Elasticsearch.Headers[k] = kRedacted
+	if redacted.Elasticsearch.Headers != nil {
+		headers := make(map[string]string)
+		for k, v := range redacted.Elasticsearch.Headers {
+			headers[k] = v
+			lk := strings.ToLower(k)
+			if strings.Contains(lk, "auth") || strings.Contains(lk, "token") || strings.Contains(lk, "key") || strings.Contains(lk, "bearer") { // best-effort scan to redact sensitive headers
+				headers[k] = kRedacted
+			}
 		}
+		redacted.Elasticsearch.Headers = headers
 	}
 
-	for k := range redacted.Elasticsearch.ProxyHeaders {
-		lk := strings.ToLower(k)
-		if strings.Contains(lk, "auth") || strings.Contains(lk, "token") || strings.Contains(lk, "key") || strings.Contains(lk, "bearer") { // best-effort scan to redact sensitive headers
-			redacted.Elasticsearch.ProxyHeaders[k] = kRedacted
+	if redacted.Elasticsearch.ProxyHeaders != nil {
+		proxyHeaders := make(map[string]string)
+		for k, v := range redacted.Elasticsearch.ProxyHeaders {
+			proxyHeaders[k] = v
+			lk := strings.ToLower(k)
+			if strings.Contains(lk, "auth") || strings.Contains(lk, "token") || strings.Contains(lk, "key") || strings.Contains(lk, "bearer") { // best-effort scan to redact sensitive headers
+				proxyHeaders[k] = kRedacted
+			}
 		}
+		redacted.Elasticsearch.ProxyHeaders = proxyHeaders
 	}
 	return redacted
 }
@@ -209,8 +219,15 @@ func redactServer(cfg *Config) Server {
 		redacted.Instrumentation.SecretToken = kRedacted
 	}
 
-	for i := range redacted.StaticPolicyTokens.PolicyTokens {
-		redacted.StaticPolicyTokens.PolicyTokens[i].TokenKey = kRedacted
+	if redacted.StaticPolicyTokens.PolicyTokens != nil {
+		policyTokens := make([]PolicyToken, len(redacted.StaticPolicyTokens.PolicyTokens))
+		for i := range redacted.StaticPolicyTokens.PolicyTokens {
+			policyTokens[i] = PolicyToken{
+				TokenKey: kRedacted,
+				PolicyID: redacted.StaticPolicyTokens.PolicyTokens[i].PolicyID,
+			}
+		}
+		redacted.StaticPolicyTokens.PolicyTokens = policyTokens
 	}
 
 	return redacted

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -170,7 +170,7 @@ func redactOutput(cfg *Config) Output {
 	}
 
 	for k := range redacted.Elasticsearch.Headers {
-		if strings.Contains(strings.ToLower(k), "auth") {
+		if strings.Contains(strings.ToLower(k), "auth") || strings.Contains(strings.ToLower(k), "token") || strings.Contains(strings.ToLower(k), "key") { // best-effort scan to redact sensitive headers
 			redacted.Elasticsearch.Headers[k] = kRedacted
 		}
 	}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -8,6 +8,7 @@ package config
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 
 	"github.com/gofrs/uuid"
@@ -168,6 +169,12 @@ func redactOutput(cfg *Config) Output {
 		redacted.Elasticsearch.TLS = &newTLS
 	}
 
+	for k := range redacted.Elasticsearch.Headers {
+		if strings.Contains(strings.ToLower(k), "auth") {
+			redacted.Elasticsearch.Headers[k] = kRedacted
+		}
+	}
+
 	return redacted
 }
 
@@ -193,6 +200,10 @@ func redactServer(cfg *Config) Server {
 
 	if redacted.Instrumentation.SecretToken != "" {
 		redacted.Instrumentation.SecretToken = kRedacted
+	}
+
+	for i := range redacted.StaticPolicyTokens.PolicyTokens {
+		redacted.StaticPolicyTokens.PolicyTokens[i].TokenKey = kRedacted
 	}
 
 	return redacted

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -170,11 +170,18 @@ func redactOutput(cfg *Config) Output {
 	}
 
 	for k := range redacted.Elasticsearch.Headers {
-		if strings.Contains(strings.ToLower(k), "auth") || strings.Contains(strings.ToLower(k), "token") || strings.Contains(strings.ToLower(k), "key") { // best-effort scan to redact sensitive headers
+		lk := strings.ToLower(k)
+		if strings.Contains(lk, "auth") || strings.Contains(lk, "token") || strings.Contains(lk, "key") || strings.Contains(lk, "bearer") { // best-effort scan to redact sensitive headers
 			redacted.Elasticsearch.Headers[k] = kRedacted
 		}
 	}
 
+	for k := range redacted.Elasticsearch.ProxyHeaders {
+		lk := strings.ToLower(k)
+		if strings.Contains(lk, "auth") || strings.Contains(lk, "token") || strings.Contains(lk, "key") || strings.Contains(lk, "bearer") { // best-effort scan to redact sensitive headers
+			redacted.Elasticsearch.ProxyHeaders[k] = kRedacted
+		}
+	}
 	return redacted
 }
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -170,29 +170,27 @@ func redactOutput(cfg *Config) Output {
 	}
 
 	if redacted.Elasticsearch.Headers != nil {
-		headers := make(map[string]string)
-		for k, v := range redacted.Elasticsearch.Headers {
-			headers[k] = v
-			lk := strings.ToLower(k)
-			if strings.Contains(lk, "auth") || strings.Contains(lk, "token") || strings.Contains(lk, "key") || strings.Contains(lk, "bearer") { // best-effort scan to redact sensitive headers
-				headers[k] = kRedacted
-			}
-		}
-		redacted.Elasticsearch.Headers = headers
+		redacted.Elasticsearch.Headers = redactHeaders(redacted.Elasticsearch.Headers)
 	}
 
 	if redacted.Elasticsearch.ProxyHeaders != nil {
-		proxyHeaders := make(map[string]string)
-		for k, v := range redacted.Elasticsearch.ProxyHeaders {
-			proxyHeaders[k] = v
-			lk := strings.ToLower(k)
-			if strings.Contains(lk, "auth") || strings.Contains(lk, "token") || strings.Contains(lk, "key") || strings.Contains(lk, "bearer") { // best-effort scan to redact sensitive headers
-				proxyHeaders[k] = kRedacted
-			}
-		}
-		redacted.Elasticsearch.ProxyHeaders = proxyHeaders
+		redacted.Elasticsearch.ProxyHeaders = redactHeaders(redacted.Elasticsearch.ProxyHeaders)
 	}
 	return redacted
+}
+
+// redactHeaders returns a copy of the passed headers map.
+// It will do a best-effort attempt to redact sensitive headers based on header names.
+func redactHeaders(headers map[string]string) map[string]string {
+	redactedHeaders := make(map[string]string)
+	for k, v := range headers {
+		redactedHeaders[k] = v
+		lk := strings.ToLower(k)
+		if strings.Contains(lk, "auth") || strings.Contains(lk, "token") || strings.Contains(lk, "key") || strings.Contains(lk, "bearer") {
+			redactedHeaders[k] = kRedacted
+		}
+	}
+	return redactedHeaders
 }
 
 func redactServer(cfg *Config) Server {

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -426,6 +426,60 @@ func TestConfigRedact(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Redact custom authorization output header",
+			inputCfg: &Config{
+				Inputs: []Input{{}},
+				Output: Output{
+					Elasticsearch: Elasticsearch{
+						Protocol:         "https",
+						Hosts:            []string{"localhost:9200"},
+						Headers:          map[string]string{"X-Authorization": "secretValue", "X-Custom": "value"},
+						ServiceTokenPath: "path/to/file",
+					},
+				},
+			},
+			redactedCfg: &Config{
+				Inputs: []Input{{}},
+				Output: Output{
+					Elasticsearch: Elasticsearch{
+						Protocol:         "https",
+						Hosts:            []string{"localhost:9200"},
+						Headers:          map[string]string{"X-Authorization": kRedacted, "X-Custom": "value"},
+						ServiceTokenPath: "path/to/file",
+					},
+				},
+			},
+		},
+		{
+			name: "redact static tokens",
+			inputCfg: &Config{
+				Inputs: []Input{{
+					Server: Server{
+						StaticPolicyTokens: StaticPolicyTokens{
+							Enabled: true,
+							PolicyTokens: []PolicyToken{{
+								TokenKey: "secretValue",
+								PolicyID: "testPolicy",
+							}},
+						},
+					},
+				}},
+			},
+			redactedCfg: &Config{
+				Inputs: []Input{{
+					Server: Server{
+						StaticPolicyTokens: StaticPolicyTokens{
+							Enabled: true,
+							PolicyTokens: []PolicyToken{{
+								TokenKey: kRedacted,
+								PolicyID: "testPolicy",
+							}},
+						},
+					},
+				}},
+			},
+		},
 	}
 
 	for _, tt := range testcases {

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -427,14 +427,14 @@ func TestConfigRedact(t *testing.T) {
 			},
 		},
 		{
-			name: "Redact custom authorization output header",
+			name: "Redact custom output headers",
 			inputCfg: &Config{
 				Inputs: []Input{{}},
 				Output: Output{
 					Elasticsearch: Elasticsearch{
 						Protocol:         "https",
 						Hosts:            []string{"localhost:9200"},
-						Headers:          map[string]string{"X-Authorization": "secretValue", "X-Custom": "value"},
+						Headers:          map[string]string{"X-Authorization": "secretValue", "X-Custom": "value", "X-App-Token": "customToken", "X-App-Key": "secretKey", "X-Custom-Bearer": "secretBearer"},
 						ServiceTokenPath: "path/to/file",
 					},
 				},
@@ -445,7 +445,32 @@ func TestConfigRedact(t *testing.T) {
 					Elasticsearch: Elasticsearch{
 						Protocol:         "https",
 						Hosts:            []string{"localhost:9200"},
-						Headers:          map[string]string{"X-Authorization": kRedacted, "X-Custom": "value"},
+						Headers:          map[string]string{"X-Authorization": kRedacted, "X-Custom": "value", "X-App-Token": kRedacted, "X-App-Key": kRedacted, "X-Custom-Bearer": kRedacted},
+						ServiceTokenPath: "path/to/file",
+					},
+				},
+			},
+		},
+		{
+			name: "Redact proxy authorization output header",
+			inputCfg: &Config{
+				Inputs: []Input{{}},
+				Output: Output{
+					Elasticsearch: Elasticsearch{
+						Protocol:         "https",
+						Hosts:            []string{"localhost:9200"},
+						ProxyHeaders:     map[string]string{"X-Proxy-Authorization": "secretValue"},
+						ServiceTokenPath: "path/to/file",
+					},
+				},
+			},
+			redactedCfg: &Config{
+				Inputs: []Input{{}},
+				Output: Output{
+					Elasticsearch: Elasticsearch{
+						Protocol:         "https",
+						Hosts:            []string{"localhost:9200"},
+						ProxyHeaders:     map[string]string{"X-Proxy-Authorization": kRedacted},
 						ServiceTokenPath: "path/to/file",
 					},
 				},


### PR DESCRIPTION
## What is the problem this PR solves?

Static tokens and (potentially) custom http headers can expose secrets in diagnostic bundles.

## How does this PR solve the problem?

Redact sensitive values within the `Config.Redact()` call,

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~