### PR TITLE
Skip tests that depend on `8.17.1-SNAPSHOT` artifacts being available

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -150,6 +150,7 @@ steps:
 
       - label: ":gcloud: Cloud e2e Test"
         key: "cloud-e2e-test"
+        skip: "8.17.1-SNAPSHOT not available on ESS"
         command: ".buildkite/scripts/cloud_e2e_test.sh"
         agents:
           provider: "gcp"

--- a/testing/e2e/agent_install_test.go
+++ b/testing/e2e/agent_install_test.go
@@ -58,6 +58,7 @@ type Artifact struct {
 }
 
 func TestAgentInstallSuite(t *testing.T) {
+	t.Skip("temporary skip until elastic-agent-8.17.1-SNAPSHOT artifact is available")
 	suite.Run(t, new(AgentInstallSuite))
 }
 


### PR DESCRIPTION
Follow up to https://github.com/elastic/fleet-server/pull/4128

This PR skips the following tests that depend on `8.17.1-SNAPSHOT` artifacts being available:
* `TestAgentInstallSuite` E2E test - depends on `elastic-agent-8.17.1-SNAPSHOT` artifact being available.
* `TestBaseE2ETestSuite` Cloud E2E test - depends on `8.17.1-SNAPSHOT` deployments being available in ESS.

This PR should be reverted as soon as the above artifacts become available.

Similar to https://github.com/elastic/fleet-server/pull/4133