### PR TITLE
Revert "Skip tests that depend on `8.17.1-SNAPSHOT` artifacts being available"

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -150,7 +150,6 @@ steps:
 
       - label: ":gcloud: Cloud e2e Test"
         key: "cloud-e2e-test"
-        skip: "8.17.1-SNAPSHOT not available on ESS"
         command: ".buildkite/scripts/cloud_e2e_test.sh"
         agents:
           provider: "gcp"

--- a/testing/e2e/agent_install_test.go
+++ b/testing/e2e/agent_install_test.go
@@ -58,7 +58,6 @@ type Artifact struct {
 }
 
 func TestAgentInstallSuite(t *testing.T) {
-	t.Skip("temporary skip until elastic-agent-8.17.1-SNAPSHOT artifact is available")
 	suite.Run(t, new(AgentInstallSuite))
 }
 


### PR DESCRIPTION
Reverts elastic/fleet-server#4214 as:
* `elastic-agent-8.17.1-SNAPSHOT` artifact is now available, and
* it's now possible to create `8.17.1-SNAPSHOT` deployments in the ESS production CFT region.