### PR TITLE
Audit unenroll should not set unenrolled_at attribute

### DIFF
--- a/changelog/fragments/1734380253-Audit-unenroll-does-not-set-unenrolled_at-attribute.yaml
+++ b/changelog/fragments/1734380253-Audit-unenroll-does-not-set-unenrolled_at-attribute.yaml
@@ -11,12 +11,14 @@
 kind: bug-fix
 
 # Change summary; a 80ish characters long description of the change.
-summary: Audit/unenroll does not set unenrolled_at attribute
+summary: Audit/unenroll should not set unenrolled_at attribute
 
 # Long description; in case the summary is not enough to describe the change
 # this field accommodate a description without length limits.
 # NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
-#description:
+description: |
+  The audit/unenroll endpoint should not set the unenrolled_at attribute as
+  it's used by the UI.
 
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
 component: fleet-server

--- a/changelog/fragments/1734380253-Audit-unenroll-does-not-set-unenrolled_at-attribute.yaml
+++ b/changelog/fragments/1734380253-Audit-unenroll-does-not-set-unenrolled_at-attribute.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Audit/unenroll does not set unenrolled_at attribute
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: fleet-server
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/elastic-agent/issues/6213

--- a/changelog/fragments/1734380253-Audit-unenroll-does-not-set-unenrolled_at-attribute.yaml
+++ b/changelog/fragments/1734380253-Audit-unenroll-does-not-set-unenrolled_at-attribute.yaml
@@ -25,7 +25,7 @@ component: fleet-server
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-#pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/fleet-server/pull/4221
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.

--- a/internal/pkg/api/handleAudit.go
+++ b/internal/pkg/api/handleAudit.go
@@ -103,7 +103,6 @@ func (audit *AuditT) markUnenroll(ctx context.Context, zlog zerolog.Logger, req 
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	doc := bulk.UpdateFields{
-		dl.FieldUnenrolledAt:          now,
 		dl.FieldUpdatedAt:             now,
 		dl.FieldAuditUnenrolledTime:   req.Timestamp,
 		dl.FieldAuditUnenrolledReason: req.Reason,

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -323,7 +323,9 @@ func (ct *CheckinT) ProcessRequest(zlog zerolog.Logger, w http.ResponseWriter, r
 	defer longPoll.Stop()
 
 	// Initial update on checkin, and any user fields that might have changed
-	err = ct.bc.CheckIn(agent.Id, string(req.Status), req.Message, rawMeta, rawComponents, seqno, ver, unhealthyReason, agent.AuditUnenrolledReason != "")
+	// Run a script to remove audit_unenrolled_* and unenrolled_at attributes if one is set on checkin.
+	// 8.16.x releases would incorrectly set unenrolled_at
+	err = ct.bc.CheckIn(agent.Id, string(req.Status), req.Message, rawMeta, rawComponents, seqno, ver, unhealthyReason, agent.AuditUnenrolledReason != "" || agent.UnenrolledAt != "")
 	if err != nil {
 		zlog.Error().Err(err).Str(logger.AgentID, agent.Id).Msg("checkin failed")
 	}

--- a/internal/pkg/checkin/deleteAuditFieldsOnCheckin.painless
+++ b/internal/pkg/checkin/deleteAuditFieldsOnCheckin.painless
@@ -17,4 +17,4 @@ if (params.SeqNoSet) {
 }
 ctx._source.remove('audit_unenrolled_reason');
 ctx._source.remove('audit_unenrolled_time');
-ctx._source.remove('dl.unenrolled_at');
+ctx._source.remove('unenrolled_at'); // audit/unenroll no longer sets this but it did in the 8.16.x releases, so we need to clear it.

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -1526,7 +1526,7 @@ func Test_SmokeTest_AuditUnenroll(t *testing.T) {
 	err = json.Unmarshal(p, &obj)
 	require.NoError(t, err)
 
-	require.Eventually(t, func() bool {
+	require.Eventuallyf(t, func() bool {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:9200/.fleet-agents/_doc/"+id, nil)
 		require.NoError(t, err)
 		req.SetBasicAuth("elastic", "changeme")
@@ -1546,8 +1546,9 @@ func Test_SmokeTest_AuditUnenroll(t *testing.T) {
 		obj, ok := o.(map[string]interface{})
 		require.Truef(t, ok, "expected _source to be an object, was: %T", o)
 		_, ok = obj["audit_unenrolled_reason"]
-		return !ok
-	}, time.Second*20, time.Second, "agent document should not have audit_unenrolled_reason attribute")
+		_, ok2 := obj["unenrolled_at"]
+		return !ok && !ok2
+	}, time.Second*20, time.Second, "agent document should not have the audit_unenrolled_reason or unenrolled_at attributes. agent doc: %v", obj)
 	cancel()
 	srv.waitExit() //nolint:errcheck // test case
 }


### PR DESCRIPTION
## What is the problem this PR solves?

On systems where defend is running and may report as orphaned during an upgrade process, the `unenrolled_at` attribute will be set and will prevent future upgrade commands from being issued through Kibana.

## How does this PR solve the problem?

Do not set the `unenrolled_at` attribute when the audit/unenroll API is called.
Remove the `unenrolled_at` attribute if it's set during checkin.

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/6213
