### PR TITLE
Call tlscommon.SetInsecureDefaults

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -15,11 +15,16 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/rs/zerolog"
 
+	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 	"github.com/elastic/fleet-server/v7/version"
 	"github.com/elastic/go-ucfg"
 	"github.com/elastic/go-ucfg/flag"
 	"github.com/elastic/go-ucfg/yaml"
 )
+
+func init() {
+	tlscommon.SetInsecureDefaults()
+}
 
 // DefaultOptions defaults options used to read the configuration
 var DefaultOptions = []ucfg.Option{

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -7,11 +7,13 @@
 package config
 
 import (
+	"crypto/tls"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 	testlog "github.com/elastic/fleet-server/v7/internal/pkg/testing/log"
 
 	"github.com/gofrs/uuid"
@@ -620,4 +622,28 @@ func TestDeprecationWarnings(t *testing.T) {
 	_, err := LoadFile(path)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(3), logCount.Load(), "Expected 3 log messages")
+}
+
+func TestTLSDefaults(t *testing.T) {
+	c, err := LoadFile(filepath.Join("testdata", "tls.yml"))
+	require.NoError(t, err)
+	require.NotNil(t, c.Output.Elasticsearch.TLS)
+
+	common, err := tlscommon.LoadTLSConfig(c.Output.Elasticsearch.TLS)
+	require.NoError(t, err)
+	cfg := common.ToConfig()
+	assert.Equal(t, uint16(tls.VersionTLS11), cfg.MinVersion)
+	assert.Equal(t, uint16(tls.VersionTLS13), cfg.MaxVersion)
+}
+
+func TestTLS10(t *testing.T) {
+	c, err := LoadFile(filepath.Join("testdata", "tls10.yml"))
+	require.NoError(t, err)
+	require.NotNil(t, c.Output.Elasticsearch.TLS)
+
+	common, err := tlscommon.LoadTLSConfig(c.Output.Elasticsearch.TLS)
+	require.NoError(t, err)
+	cfg := common.ToConfig()
+	assert.Equal(t, uint16(tls.VersionTLS10), cfg.MinVersion)
+	assert.Equal(t, uint16(tls.VersionTLS10), cfg.MaxVersion)
 }

--- a/internal/pkg/config/testdata/tls.yml
+++ b/internal/pkg/config/testdata/tls.yml
@@ -1,0 +1,10 @@
+output:
+  elasticsearch:
+    hosts: ["localhost:9200"]
+    service_token: "test-token"
+    ssl:
+      enabled: true
+fleet:
+  agent:
+    id: 1e4954ce-af37-4731-9f4a-407b08e69e42
+

--- a/internal/pkg/config/testdata/tls10.yml
+++ b/internal/pkg/config/testdata/tls10.yml
@@ -1,0 +1,11 @@
+output:
+  elasticsearch:
+    hosts: ["localhost:9200"]
+    service_token: "test-token"
+    ssl:
+      enabled: true
+      supported_protocols:
+        - TLSv1.0
+fleet:
+  agent:
+    id: 1e4954ce-af37-4731-9f4a-407b08e69e42


### PR DESCRIPTION
## What is the problem this PR solves?

Avoid a planned breaking change for tlscommon versions

## How does this PR solve the problem?

Call `tlscommon.SetInsecureDefaults` in config init to reset version numbers to currently supported versions.

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)~~

## Related Issues

- Relates https://github.com/elastic/fleet-server/issues/4107