### PR TITLE
Remove PGP endpoint auth requirement

### DIFF
--- a/changelog/fragments/1735593163-Remove-auth-requirement-from-PGP-key-endpoint.yaml
+++ b/changelog/fragments/1735593163-Remove-auth-requirement-from-PGP-key-endpoint.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Remove auth requirement from PGP key endpoint
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: fleet-server
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/fleet-server/issues/4255

--- a/internal/pkg/api/error.go
+++ b/internal/pkg/api/error.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"go.elastic.co/apm/v2"
+
 	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
 	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
 	"github.com/elastic/fleet-server/v7/internal/pkg/es"
@@ -22,7 +24,6 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/file/uploader"
 	"github.com/elastic/fleet-server/v7/internal/pkg/limit"
 	"github.com/elastic/fleet-server/v7/internal/pkg/logger"
-	"go.elastic.co/apm/v2"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/hlog"
@@ -250,15 +251,6 @@ func NewHTTPErrResp(err error) HTTPErrResp {
 				"ErrTLSRequired",
 				"server must run with tls to use this endpoint",
 				zerolog.InfoLevel,
-			},
-		},
-		{
-			ErrPGPPermissions,
-			HTTPErrResp{
-				http.StatusInternalServerError,
-				"ErrPGPPermissions",
-				"fleet-server PGP key has incorrect permissions",
-				zerolog.ErrorLevel,
 			},
 		},
 		// apikey

--- a/internal/pkg/api/handlePGPRequest.go
+++ b/internal/pkg/api/handlePGPRequest.go
@@ -15,11 +15,12 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/rs/zerolog"
+	"go.elastic.co/apm/v2"
+
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/cache"
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
-	"github.com/rs/zerolog"
-	"go.elastic.co/apm/v2"
 )
 
 const (
@@ -52,10 +53,9 @@ func (pt *PGPRetrieverT) handlePGPKey(zlog zerolog.Logger, w http.ResponseWriter
 		return ErrTLSRequired
 	}
 	key, err := authAPIKey(r, pt.bulker, pt.cache)
-	if err != nil {
-		return err
+	if err == nil {
+		zlog = zlog.With().Str(LogEnrollAPIKeyID, key.ID).Logger()
 	}
-	zlog = zlog.With().Str(LogEnrollAPIKeyID, key.ID).Logger()
 	ctx := zlog.WithContext(r.Context())
 
 	p, err := pt.getPGPKey(ctx, zlog)

--- a/internal/pkg/api/handlePGPRequest.go
+++ b/internal/pkg/api/handlePGPRequest.go
@@ -52,10 +52,8 @@ func (pt *PGPRetrieverT) handlePGPKey(zlog zerolog.Logger, w http.ResponseWriter
 	if r.TLS == nil {
 		return ErrTLSRequired
 	}
-	key, err := authAPIKey(r, pt.bulker, pt.cache)
-	if err == nil {
-		zlog = zlog.With().Str(LogEnrollAPIKeyID, key.ID).Logger()
-	}
+	// auth is not required for this endpoint.
+	// we also do not check if an API key is present in order to avoid making a round trip.
 	ctx := zlog.WithContext(r.Context())
 
 	p, err := pt.getPGPKey(ctx, zlog)

--- a/internal/pkg/api/openapi.gen.go
+++ b/internal/pkg/api/openapi.gen.go
@@ -1790,8 +1790,6 @@ func (siw *ServerInterfaceWrapper) GetPGPKey(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	ctx = context.WithValue(ctx, ApiKeyScopes, []string{})
-
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetPGPKeyParams
 

--- a/model/openapi.yml
+++ b/model/openapi.yml
@@ -1764,8 +1764,6 @@ paths:
       operationId: getPGPKey
       summary: retrieve a PGP key from the fleet-server's local storage.
       description: "Get a PGP key that can be used to verify agent upgrades. Key is stored on (fleet-server's) disk."
-      security:
-        - apiKey: []
       parameters:
         - name: major
           in: path
@@ -1802,8 +1800,6 @@ paths:
                 format: binary
         "400":
           $ref: "#/components/responses/badRequest"
-        "401":
-          $ref: "#/components/responses/keyNotEnabled"
         "500":
           description: The server has an error retrieving or reading the local key.
           headers:

--- a/pkg/api/client.gen.go
+++ b/pkg/api/client.gen.go
@@ -1221,7 +1221,6 @@ type GetPGPKeyResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON400      *BadRequest
-	JSON401      *KeyNotEnabled
 }
 
 // Status returns HTTPResponse.Status
@@ -1681,13 +1680,6 @@ func ParseGetPGPKeyResponse(rsp *http.Response) (*GetPGPKeyResponse, error) {
 			return nil, err
 		}
 		response.JSON400 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
-		var dest KeyNotEnabled
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON401 = &dest
 
 	}
 

--- a/testing/e2e/api_version/client_api_current.go
+++ b/testing/e2e/api_version/client_api_current.go
@@ -269,11 +269,8 @@ func (tester *ClientAPITester) Artifact(ctx context.Context, apiKey, id, sha2, e
 	tester.Require().Equal(encodedSHA, fmt.Sprintf("%x", hash[:]))
 }
 
-func (tester *ClientAPITester) GetPGPKey(ctx context.Context, apiKey string) []byte {
-	client, err := api.NewClientWithResponses(tester.endpoint, api.WithHTTPClient(tester.Client), api.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
-		req.Header.Set("Authorization", "ApiKey "+apiKey)
-		return nil
-	}))
+func (tester *ClientAPITester) GetPGPKey(ctx context.Context) []byte {
+	client, err := api.NewClientWithResponses(tester.endpoint, api.WithHTTPClient(tester.Client))
 	tester.Require().NoError(err)
 
 	resp, err := client.GetPGPKeyWithResponse(ctx, 1, 2, 3, nil)
@@ -398,7 +395,7 @@ func (tester *ClientAPITester) TestArtifact() {
 func (tester *ClientAPITester) TestGetPGPKey() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	tester.GetPGPKey(ctx, tester.enrollmentKey)
+	tester.GetPGPKey(ctx)
 }
 
 func (tester *ClientAPITester) TestEnrollAuditUnenroll() {


### PR DESCRIPTION
## What is the problem this PR solves?

Air gapped agents are unable to retreive PGP key from fleet-server.

## How does this PR solve the problem?

Remove auth key requirement from PGP retrieval endpoint

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Closes #4255
