### PR TITLE
Remove deprecated policy_throttle config

### DIFF
--- a/changelog/fragments/1736277781-Remove-deprecated-policy_throttle.yaml
+++ b/changelog/fragments/1736277781-Remove-deprecated-policy_throttle.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: other
+
+# Change summary; a 80ish characters long description of the change.
+summary: Remove deprecated policy_throttle
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: fleet-server
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/fleet-server.reference.yml
+++ b/fleet-server.reference.yml
@@ -144,9 +144,6 @@ fleet:
 #       # max_agents is the preffered way to set limits
 #       # If specified a set of other limits is automatically loaded.
 #       max_agents: 0
-#       # policy_throttle is the duration that the fleet-server will wait in between attempts to dispatch policy updates to polling agents
-#       # deprecated: replaced by policy_limit settings
-#       policy_throttle: 5ms # 1ms min is forced
 #       # max_header_byte_size is the request header size limit
 #       max_header_byte_size: 8192 # 8Kib
 #       # max_connections is the maximum number of connnections per API endpoint
@@ -165,8 +162,7 @@ fleet:
 #       # As with the action_limit settings this is done to avoid allocating a lot of gzip writers.
 #       # The default settings are to have the interval of 5ms with a burst of 1.
 #       # A min burst value of 1 is always enforced.
-#       # If no interval is specified, the policy_throttle may be used as the interval instead.
-#       # if both interval and policy_throttle are 0, a value of 1ns is used instead.
+#       # If no interval is specified 1ns is used instead.
 #       policy_limit:
 #         interval: 5ms
 #         burst: 1

--- a/internal/pkg/config/limits.go
+++ b/internal/pkg/config/limits.go
@@ -16,10 +16,9 @@ type Limit struct {
 }
 
 type ServerLimits struct {
-	MaxAgents         int           `config:"max_agents"`
-	PolicyThrottle    time.Duration `config:"policy_throttle"` // deprecated: replaced by policy_limit
-	MaxHeaderByteSize int           `config:"max_header_byte_size"`
-	MaxConnections    int           `config:"max_connections"`
+	MaxAgents         int `config:"max_agents"`
+	MaxHeaderByteSize int `config:"max_header_byte_size"`
+	MaxConnections    int `config:"max_connections"`
 
 	ActionLimit        Limit `config:"action_limit"`
 	PolicyLimit        Limit `config:"policy_limit"`
@@ -47,9 +46,6 @@ func (c *ServerLimits) LoadLimits(limits *envLimits) {
 	}
 	if c.MaxConnections == 0 {
 		c.MaxConnections = l.MaxConnections
-	}
-	if c.PolicyThrottle == 0 {
-		c.PolicyThrottle = l.PolicyThrottle
 	}
 
 	c.ActionLimit = mergeEnvLimit(c.ActionLimit, l.ActionLimit)

--- a/internal/pkg/policy/monitor.go
+++ b/internal/pkg/policy/monitor.go
@@ -99,11 +99,7 @@ func NewMonitor(bulker bulk.Bulk, monitor monitor.Monitor, cfg config.ServerLimi
 		burst = 1
 	}
 	if cfg.PolicyLimit.Interval <= 0 {
-		if cfg.PolicyThrottle > 0 { // use the old throttle if it's defined and the limit.Interval is not.
-			interval = rate.Every(cfg.PolicyThrottle)
-		} else {
-			interval = rate.Every(time.Nanosecond) // set minimal spin rate
-		}
+		interval = rate.Every(time.Nanosecond) // set minimal spin rate
 	}
 	return &monitorT{
 		bulker:        bulker,

--- a/internal/pkg/policy/monitor_test.go
+++ b/internal/pkg/policy/monitor_test.go
@@ -55,11 +55,6 @@ func TestNewMonitor(t *testing.T) {
 		cfg:   config.ServerLimits{PolicyLimit: config.Limit{Burst: 2, Interval: time.Second}},
 		burst: 2,
 		rate:  1,
-	}, {
-		name:  "no limit",
-		cfg:   config.ServerLimits{PolicyThrottle: time.Second},
-		burst: 1,
-		rate:  1,
 	}}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## What is the problem this PR solves?

Remove deprecated policy_throttle config.

## How does this PR solve the problem?

policy_limit should be used in 9.x releases

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [x] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)