### PR TITLE
Add ability to enroll with a specific ID

### DIFF
--- a/internal/pkg/api/error.go
+++ b/internal/pkg/api/error.go
@@ -101,6 +101,15 @@ func NewHTTPErrResp(err error) HTTPErrResp {
 			},
 		},
 		{
+			ErrAgentIDInAnotherPolicy,
+			HTTPErrResp{
+				http.StatusBadRequest,
+				"AgentIDInAnotherPolicy",
+				"agent with ID is already enrolled into another policy",
+				zerolog.WarnLevel,
+			},
+		},
+		{
 			ErrInvalidUserAgent,
 			HTTPErrResp{
 				http.StatusBadRequest,

--- a/internal/pkg/api/openapi.gen.go
+++ b/internal/pkg/api/openapi.gen.go
@@ -399,6 +399,12 @@ type EnrollRequest struct {
 	// The existing agent with a matching enrollment_id will be deleted if it never checked in. The new agent will be enrolled with the enrollment_id.
 	EnrollmentId *string `json:"enrollment_id,omitempty"`
 
+	// Id The ID of the agent.
+	// This is the ID that will be used to reference this agent, if no ID is passed one will be generated.
+	// If another agent is enrolled with the same ID the other agent will no longer be able to communicate,
+	// this new agent is considered a replacement of the other agent.
+	Id *string `json:"id,omitempty"`
+
 	// Metadata Metadata associated with the agent that is enrolling to fleet.
 	Metadata EnrollMetadata `json:"metadata"`
 

--- a/internal/pkg/dl/constants.go
+++ b/internal/pkg/dl/constants.go
@@ -46,6 +46,8 @@ const (
 	FieldUnhealthyReason               = "unhealthy_reason"
 
 	FieldActive           = "active"
+	FieldNamespaces       = "namespaces"
+	FieldTags             = "tags"
 	FieldUpdatedAt        = "updated_at"
 	FieldUnenrolledAt     = "unenrolled_at"
 	FieldUpgradedAt       = "upgraded_at"

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -883,6 +883,9 @@ func Test_Agent_Id(t *testing.T) {
 
 	// checking that updated agent has the access key ID from the second agent
 	agent, err := dl.FindAgent(ctx, srv.bulker, dl.QueryAgentByID, dl.FieldID, firstEnroll.Item.Id)
+	if err != nil {
+		t.Fatalf("could not find agent with id %s: %s", firstEnroll.Item.Id, err)
+	}
 	t.Log(agent)
 	if agent.AccessAPIKeyID != secondEnroll.Item.AccessApiKeyId {
 		t.Fatal("saved agent access key ID should be for the second enroll call")

--- a/model/openapi.yml
+++ b/model/openapi.yml
@@ -139,6 +139,13 @@ components:
         - type
         - metadata
       properties:
+        id:
+          type: string
+          description: |
+            The ID of the agent.
+            This is the ID that will be used to reference this agent, if no ID is passed one will be generated.
+            If another agent is enrolled with the same ID the other agent will no longer be able to communicate,
+            this new agent is considered a replacement of the other agent.
         type:
           description: |
             The enrollment type of the agent.

--- a/pkg/api/types.gen.go
+++ b/pkg/api/types.gen.go
@@ -396,6 +396,12 @@ type EnrollRequest struct {
 	// The existing agent with a matching enrollment_id will be deleted if it never checked in. The new agent will be enrolled with the enrollment_id.
 	EnrollmentId *string `json:"enrollment_id,omitempty"`
 
+	// Id The ID of the agent.
+	// This is the ID that will be used to reference this agent, if no ID is passed one will be generated.
+	// If another agent is enrolled with the same ID the other agent will no longer be able to communicate,
+	// this new agent is considered a replacement of the other agent.
+	Id *string `json:"id,omitempty"`
+
 	// Metadata Metadata associated with the agent that is enrolling to fleet.
 	Metadata EnrollMetadata `json:"metadata"`
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

This solves an issue where an Elastic Agent is being replaced with a new Elastic Agent instance for the same host, pod, or workload. This allows the enrolling Elastic Agent to tell the ID that it wants to use, that ID can be currently in-use and this enrollment will take over the record of that Elastic Agent.

## How does this PR solve the problem?

It solves the issue by taking a new `id` field in the enroll HTTP request. That `id` is then used as the Elastic Agent ID and determines if this is a new Elastic Agent or if it should take over an existing Elastic Agent record.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

At the moment the integration tests are the best way to test this, as the ability to use this field has not been exposed yet on the Elastic Agent.

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [x] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc. (already covered by enroll handle)

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~ (no config changes)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #4226 