### PR TITLE
Allow use of version qualifier for staging artifacts

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -73,7 +73,7 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server" && "$BUILDKITE_STEP_KEY" == "
 fi
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server-package-mbp" ]]; then
-  if [[ "$BUILDKITE_STEP_KEY" == "package-x86-64" || "$BUILDKITE_STEP_KEY" == "package-arm" || "$BUILDKITE_STEP_KEY" == "dra-snapshot" || "$BUILDKITE_STEP_KEY" == "dra-staging" ]]; then
+  if [[ "$BUILDKITE_STEP_KEY" == package-x86-64* || "$BUILDKITE_STEP_KEY" == package-arm* || "$BUILDKITE_STEP_KEY" == "dra-snapshot" || "$BUILDKITE_STEP_KEY" == "dra-staging" ]]; then
     export PRIVATE_CI_GCS_CREDENTIALS_SECRET=$(retry 5 vault kv get -field plaintext -format=json ${PRIVATE_CI_GCS_CREDENTIALS_PATH})
     export JOB_GCS_BUCKET
   fi
@@ -92,7 +92,7 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server-package-mbp" ]]; then
 fi
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server-package-mbp" ]]; then
-  if [[ "$BUILDKITE_STEP_KEY" == "package-x86-64" || "$BUILDKITE_STEP_KEY" == "package-arm" ]]; then
+  if [[ "$BUILDKITE_STEP_KEY" == package-x86-64* || "$BUILDKITE_STEP_KEY" == package-arm* ]]; then
     export PRIVATE_CI_GCS_CREDENTIALS_SECRET=$(retry 5 vault kv get -field plaintext -format=json ${PRIVATE_CI_GCS_CREDENTIALS_PATH})
     export JOB_GCS_BUCKET
   fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -38,7 +38,10 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server" ]]; then
 fi
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server-package-mbp" ]]; then
-  check_if_file_exist_in_repo "infra" "${BUILDKITE_BRANCH}"                  #TODO should be changed to "main" for rollback...
+  # TODO remove and replace _branch with BUILDKITE_BRANCH after PR tests
+  _branch="${DRA_BRANCH:="${BUILDKITE_BRANCH:=""}"}"
+
+  check_if_file_exist_in_repo "infra" "${_branch}"                  #TODO should be changed to "main" for rollback...
 fi
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server" || "$BUILDKITE_PIPELINE_SLUG" == "fleet-server-perf-tests" ]]; then

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -16,7 +16,7 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server" && "$BUILDKITE_STEP_KEY" == "
 fi
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server-package-mbp" ]]; then
-  if [[ "$BUILDKITE_STEP_KEY" == "package-x86-64" || "$BUILDKITE_STEP_KEY" == "package-arm" || "$BUILDKITE_STEP_KEY" == "dra-snapshot" && "$BUILDKITE_STEP_KEY" == "dra-staging" ]]; then
+  if [[ "$BUILDKITE_STEP_KEY" == package-x86-64* || "$BUILDKITE_STEP_KEY" == package-arm* || "$BUILDKITE_STEP_KEY" == "dra-snapshot" && "$BUILDKITE_STEP_KEY" == "dra-staging" ]]; then
     unset GOOGLE_APPLICATION_CREDENTIALS
     unset VAULT_ROLE_ID_SECRET
     unset VAULT_ADDR_SECRET

--- a/.buildkite/pipeline.package.mbp.yml
+++ b/.buildkite/pipeline.package.mbp.yml
@@ -9,7 +9,8 @@ env:
 
 steps:
   - label: "Package x86_64 snapshot"
-    # Skip snapshots with prerelease builds. There are flagged by a non-empty VERSION_QUALIFIER env var/BK param.
+    # skip building + packaging snapshot for pre-releases (flagged by a non-empty VERSION_QUALIFIER env var/BK param)
+    # as prereleases are only intended to be used with staging; details in https://github.com/elastic/ingest-dev/issues/4855
     if: "build.env('VERSION_QUALIFIER') == null"
     key: "package-x86-64-snapshot"
     command: ".buildkite/scripts/package.sh snapshot"
@@ -58,6 +59,8 @@ steps:
         allow_failure: false
 
   - label: "DRA release staging"
+    # we don't usually build staging from the main branch, but we exceptionally allow it for prereleases
+    # details in https://github.com/elastic/ingest-dev/issues/4855
     if: "${FILE_EXISTS_IN_REPO} == true && (build.env('BUILDKITE_BRANCH') != 'main' || build.env('VERSION_QUALIFIER') != null)"
     key: "dra-staging"
     command: ".buildkite/scripts/dra_release.sh staging"

--- a/.buildkite/pipeline.package.mbp.yml
+++ b/.buildkite/pipeline.package.mbp.yml
@@ -44,7 +44,7 @@ steps:
       provider: "gcp"
       image: "${IMAGE_UBUNTU_X86_64}"
       machineType: "c2-standard-16"
-    if: ${FILE_EXISTS_IN_REPO}
+    if: ${FILE_EXISTS_IN_REPO} && build.env('VERSION_QUALIFIER') == null)
     depends_on:
       - step: "package-publish"
         allow_failure: false

--- a/.buildkite/pipeline.package.mbp.yml
+++ b/.buildkite/pipeline.package.mbp.yml
@@ -8,58 +8,65 @@ env:
   IMAGE_UBUNTU_ARM_64: "core-ubuntu-2004-aarch64"
 
 steps:
-  - group: "Package and Publish"
-    key: "package-publish"
-    steps:
-    - label: "Package Ubuntu-20 x86_64"
-      key: "package-x86-64"
-      command: ".buildkite/scripts/package.sh {{matrix.type}}"
-      agents:
-        provider: "gcp"
-        image: "${IMAGE_UBUNTU_X86_64}"
-        machineType: "c2-standard-16"
-      matrix:
-        setup:
-          type:
-          - "snapshot"
-          - "staging"
+  - label: "Package x86_64 snapshot"
+    # Skip snapshots with prerelease builds. There are flagged by a non-empty VERSION_QUALIFIER env var/BK param.
+    if: "build.env('VERSION_QUALIFIER') == null"
+    key: "package-x86-64-snapshot"
+    command: ".buildkite/scripts/package.sh snapshot"
+    agents:
+      provider: "gcp"
+      image: "${IMAGE_UBUNTU_X86_64}"
+      machineType: "c2-standard-16"
 
-    - label: "Package Ubuntu-20 aarch64"
-      key: "package-arm"
-      command: ".buildkite/scripts/package.sh {{matrix.type}}"
-      agents:
-        provider: "aws"
-        imagePrefix: "${IMAGE_UBUNTU_ARM_64}"
-        instanceType: "t4g.2xlarge"
-      matrix:
-        setup:
-          type:
-          - "snapshot"
-          - "staging"
+  - label: "Package x86_64 staging"
+    key: "package-x86-64-staging"
+    command: ".buildkite/scripts/package.sh snapshot"
+    agents:
+      provider: "gcp"
+      image: "${IMAGE_UBUNTU_X86_64}"
+      machineType: "c2-standard-16"
+
+  - label: "Package aarch64 snapshot"
+    if: "build.env('VERSION_QUALIFIER') == null"
+    key: "package-arm-snapshot"
+    command: ".buildkite/scripts/package.sh snapshot"
+    agents:
+      provider: "aws"
+      imagePrefix: "${IMAGE_UBUNTU_ARM_64}"
+      instanceType: "t4g.2xlarge"
+
+  - label: "Package aarch64 staging"
+    key: "package-arm-staging"
+    command: ".buildkite/scripts/package.sh staging"
+    agents:
+      provider: "aws"
+      imagePrefix: "${IMAGE_UBUNTU_ARM_64}"
+      instanceType: "t4g.2xlarge"
 
   - label: "DRA snapshot"
+    if: "${FILE_EXISTS_IN_REPO} && build.env('VERSION_QUALIFIER') == null"
     key: "dra-snapshot"
     command: ".buildkite/scripts/dra_release.sh snapshot"
     agents:
       provider: "gcp"
       image: "${IMAGE_UBUNTU_X86_64}"
       machineType: "c2-standard-16"
-    if: "${FILE_EXISTS_IN_REPO} && build.env('VERSION_QUALIFIER') == null"
     depends_on:
-      - step: "package-publish"
+      - step: "package-x86-64-snapshot"
+        allow_failure: false
+      - step: "package-arm-snapshot"
         allow_failure: false
 
   - label: "DRA release staging"
+    if: "${FILE_EXISTS_IN_REPO} == true && (build.env('BUILDKITE_BRANCH') != 'main' || build.env('VERSION_QUALIFIER') != null)"
     key: "dra-staging"
     command: ".buildkite/scripts/dra_release.sh staging"
     agents:
       provider: "gcp"
       image: "${IMAGE_UBUNTU_X86_64}"
       machineType: "c2-standard-16"
-    # TODO remove || build.env('VERSION_QUALIFIER') != null) after prerelease tests using main
-    if: "${FILE_EXISTS_IN_REPO} == true && (build.env('BUILDKITE_BRANCH') != 'main' || build.env('VERSION_QUALIFIER') != null)"
     depends_on:
-      - step: "package-publish"
+      - step: "package-x86-64-staging"
         allow_failure: false
-      - step: "package-arm"
+      - step: "package-arm-staging"
         allow_failure: false

--- a/.buildkite/pipeline.package.mbp.yml
+++ b/.buildkite/pipeline.package.mbp.yml
@@ -56,7 +56,8 @@ steps:
       provider: "gcp"
       image: "${IMAGE_UBUNTU_X86_64}"
       machineType: "c2-standard-16"
-    if: "${FILE_EXISTS_IN_REPO} == true && build.env('BUILDKITE_BRANCH') != 'main'"
+    # TODO remove || build.env('VERSION_QUALIFIER') != null) after prerelease tests using main
+    if: "${FILE_EXISTS_IN_REPO} == true && (build.env('BUILDKITE_BRANCH') != 'main' || build.env('VERSION_QUALIFIER') != null)"
     depends_on:
       - step: "dra-snapshot"
         allow_failure: false

--- a/.buildkite/pipeline.package.mbp.yml
+++ b/.buildkite/pipeline.package.mbp.yml
@@ -44,7 +44,7 @@ steps:
       provider: "gcp"
       image: "${IMAGE_UBUNTU_X86_64}"
       machineType: "c2-standard-16"
-    if: ${FILE_EXISTS_IN_REPO} && build.env('VERSION_QUALIFIER') == null)
+    if: "${FILE_EXISTS_IN_REPO} && build.env('VERSION_QUALIFIER') == null"
     depends_on:
       - step: "package-publish"
         allow_failure: false
@@ -59,5 +59,7 @@ steps:
     # TODO remove || build.env('VERSION_QUALIFIER') != null) after prerelease tests using main
     if: "${FILE_EXISTS_IN_REPO} == true && (build.env('BUILDKITE_BRANCH') != 'main' || build.env('VERSION_QUALIFIER') != null)"
     depends_on:
-      - step: "dra-snapshot"
+      - step: "package-publish"
+        allow_failure: false
+      - step: "package-arm"
         allow_failure: false

--- a/.buildkite/scripts/dra_release.sh
+++ b/.buildkite/scripts/dra_release.sh
@@ -10,7 +10,7 @@ DRA_OUTPUT="release-manager.out"
 export PROJECT="fleet-server"
 export TYPE=${1}
 # DRA_BRANCH can be used for manually testing packaging with PRs
-# e.g. define `DRA_BRANCH="main"` and `RUN_SNAPSHOT="true"` under Options/Environment Variables in the Buildkite UI after clicking new Build
+# e.g. define `DRA_BRANCH="main"` under Options/Environment Variables in the Buildkite UI after clicking new Build
 export BRANCH="${DRA_BRANCH:="${BUILDKITE_BRANCH:=""}"}"
 export VERSION="$(make get-version)"
 
@@ -39,11 +39,6 @@ export RM_VERSION="${VERSION}"
 if [[ ${TYPE} == "snapshot" ]]; then
     export SNAPSHOT=true
     VERSION="${VERSION}-SNAPSHOT"
-fi
-
-readonly VERSION_QUALIFIER="${VERSION_QUALIFIER:-""}"
-if [[ -n "$VERSION_QUALIFIER" ]]; then
-  VERSION="${VERSION}-${VERSION_QUALIFIER}"
 fi
 
 mkdir -p ${BASE_DIR}/reports

--- a/.buildkite/scripts/dra_release.sh
+++ b/.buildkite/scripts/dra_release.sh
@@ -9,7 +9,9 @@ BASE_DIR="${WORKSPACE}/${FOLDER_PATH}"
 DRA_OUTPUT="release-manager.out"
 export PROJECT="fleet-server"
 export TYPE=${1}
-export BRANCH="${BUILDKITE_BRANCH}"
+# DRA_BRANCH can be used for manually testing packaging with PRs
+# e.g. define `DRA_BRANCH="main"` and `RUN_SNAPSHOT="true"` under Options/Environment Variables in the Buildkite UI after clicking new Build
+export BRANCH="${DRA_BRANCH:="${BUILDKITE_BRANCH:=""}"}"
 export VERSION="$(make get-version)"
 
 if [[ "${VERSION}" == *"-SNAPSHOT"* || "${VERSION}" == "" ]]; then
@@ -37,6 +39,11 @@ export RM_VERSION="${VERSION}"
 if [[ ${TYPE} == "snapshot" ]]; then
     export SNAPSHOT=true
     VERSION="${VERSION}-SNAPSHOT"
+fi
+
+readonly VERSION_QUALIFIER="${VERSION_QUALIFIER:-""}"
+if [[ -n "$VERSION_QUALIFIER" ]]; then
+  VERSION="${VERSION}-${VERSION_QUALIFIER}"
 fi
 
 mkdir -p ${BASE_DIR}/reports

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -4,10 +4,8 @@ set -euo pipefail
 
 source .buildkite/scripts/common.sh
 
-VERSION=$(awk '/const DefaultVersion/{print $NF}' version/version.go | tr -d '"')
 PLATFORM_TYPE=$(uname -m)
 TYPE="$1"
-INFRA_REPO="https://github.com/repos/elastic/infra/contents"
 
 if [[ ${BUILDKITE_BRANCH} == "main" && ${TYPE} == "staging" ]]; then
     echo "INFO: staging artifacts for the main branch are not required."


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

This commits adds support for an optional $VERSION_QUALIFIER env var/build option in the packaging pipeline to allow building prerelease artifacts from staging.

## How does this PR solve the problem?

* Support VERSION_QUALIFIER optional env var for prerelease builds
* Refactor packaging pipeline to allow staging builds from main (that indirectly allow testing this PR too with the additional `DRA_BRANCH` env var and skip snapshot builds when VERSION_QUALIFIER is present
* Remove unused VERSION and INFRA_REPO variables.

## How to test this PR locally

Using this PR and the pipeline https://buildkite.com/elastic/fleet-server-package-mbp with `pull/4328/merge` and options: 

```
DRA_BRANCH="main"
VERSION_QUALIFIER="alpha1"
```

results in a successful 9.0.0-alpha1 artifacts, example: https://buildkite.com/elastic/fleet-server-package-mbp/builds/1526

![image](https://github.com/user-attachments/assets/8a368d0a-5a97-45ee-b9bd-232c552be457)

Also a test without VERSION_QUALIFIER https://buildkite.com/elastic/fleet-server-package-mbp/builds/1525 produces the expected artifacts (note that when branch is main, i.e. not when testing using this PR, **and** there is no version qualifier defined, the staging dra publish is skipped, per design).

## Related issues

Closes:

- https://github.com/elastic/fleet-server/issues/4325
- https://github.com/elastic/ingest-dev/issues/4859
