### PR TITLE
Allow staging build on main with version qualifier

### DIFF
--- a/.buildkite/pipeline.package.mbp.yml
+++ b/.buildkite/pipeline.package.mbp.yml
@@ -21,7 +21,7 @@ steps:
 
   - label: "Package x86_64 staging"
     key: "package-x86-64-staging"
-    command: ".buildkite/scripts/package.sh snapshot"
+    command: ".buildkite/scripts/package.sh staging"
     agents:
       provider: "gcp"
       image: "${IMAGE_UBUNTU_X86_64}"

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -6,8 +6,9 @@ source .buildkite/scripts/common.sh
 
 PLATFORM_TYPE=$(uname -m)
 TYPE="$1"
+readonly VERSION_QUALIFIER="${VERSION_QUALIFIER:-""}"
 
-if [[ ${BUILDKITE_BRANCH} == "main" && ${TYPE} == "staging" ]]; then
+if [[ ${BUILDKITE_BRANCH} == "main" && ${TYPE} == "staging" && -z ${VERSION_QUALIFIER} ]]; then
     echo "INFO: staging artifacts for the main branch are not required."
     exit 0
 fi


### PR DESCRIPTION
## What is the problem this PR solves?

This commit fixes a bug in #4328 running snapshot instead of staging for x86-64 and also ensures staging on main can be build when
 VERSION_QUALIFIER is set.

## Related issues

- Closes https://github.com/elastic/ingest-dev/issues/4859
