### PR TITLE
ci(buildkite): exclude files/folders that are not tested in Buildkite

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -10,6 +10,7 @@
         "build_on_comment": true,
         "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$",
         "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$",
+        "skip_ci_on_only_changed": [ "^.ci/", "^.github/", "^.pre-commit-config.yaml", "^.mergify.yml", "\\.md$", "^changelog/", "^docs/"],
         "fail_on_not_mergeable": true
       },
       {


### PR DESCRIPTION
## What is the problem this PR solves?

Run faster builds and avoid waste of CI cycles.

I decided to support the whole .github folder since some other files such as CODEOWNERS or .dependaot.yml and the rest are not actually used by Buildkite.

I took some of the files that we skipped in https://github.com/elastic/elastic-agent/pull/4836. I don't know the reason it was not configured in this repository, too, but I think it's the same case.


## How does this PR solve the problem?

// Explain HOW you solved the problem in your code. It is possible that during PR reviews this changes and then this section should be updated.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

Relates https://github.com/elastic/beats/pull/42404