### PR TITLE
Use centralized version qualifier

### DIFF
--- a/.buildkite/pipeline.package.mbp.yml
+++ b/.buildkite/pipeline.package.mbp.yml
@@ -21,7 +21,9 @@ steps:
 
   - label: "Package x86_64 staging"
     key: "package-x86-64-staging"
-    command: ".buildkite/scripts/package.sh staging"
+    command: |
+      source .buildkite/scripts/version_qualifier.sh
+      .buildkite/scripts/package.sh staging
     agents:
       provider: "gcp"
       image: "${IMAGE_UBUNTU_X86_64}"
@@ -38,7 +40,9 @@ steps:
 
   - label: "Package aarch64 staging"
     key: "package-arm-staging"
-    command: ".buildkite/scripts/package.sh staging"
+    command: |
+      source .buildkite/scripts/version_qualifier.sh
+      .buildkite/scripts/package.sh staging
     agents:
       provider: "aws"
       imagePrefix: "${IMAGE_UBUNTU_ARM_64}"
@@ -63,7 +67,9 @@ steps:
     # details in https://github.com/elastic/ingest-dev/issues/4855
     if: "${FILE_EXISTS_IN_REPO} == true && (build.env('BUILDKITE_BRANCH') != 'main' || build.env('VERSION_QUALIFIER') != null)"
     key: "dra-staging"
-    command: ".buildkite/scripts/dra_release.sh staging"
+    command: |
+      source .buildkite/scripts/version_qualifier.sh
+      .buildkite/scripts/dra_release.sh staging
     agents:
       provider: "gcp"
       image: "${IMAGE_UBUNTU_X86_64}"

--- a/.buildkite/scripts/version_qualifier.sh
+++ b/.buildkite/scripts/version_qualifier.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# An opinionated approach to managing the Elastic Qualifier for the DRA in a Google Bucket
+# instead of using a Buildkite env variable.
+
+if [[ -n "$VERSION_QUALIFIER" ]]; then
+  echo "~~~ VERSION_QUALIFIER externally set to [$VERSION_QUALIFIER]"
+  return 0
+fi
+
+# DRA_BRANCH can be used for manually testing packaging with PRs
+# e.g. define `DRA_BRANCH="main"` under Options/Environment Variables in the Buildkite UI after clicking new Build
+BRANCH="${DRA_BRANCH:="${BUILDKITE_BRANCH:=""}"}"
+
+qualifier=""
+URL="https://storage.googleapis.com/dra-qualifier/${BRANCH}"
+if curl -sf -o /dev/null "$URL" ; then
+  qualifier=$(curl -s "$URL")
+fi
+
+export VERSION_QUALIFIER="$qualifier"
+echo "~~~ VERSION_QUALIFIER set to [$VERSION_QUALIFIER]"


### PR DESCRIPTION
## What is the problem this PR solves?

To avoid manual invocations specifying the version qualifier for prereleases in this commit we leverage a centralized version of truth for the version qualifier.

## How does this PR solve the problem?

Leverages a centralized source of truth version for the version qualifier.

## How to test this PR locally

Tested in BK only.
Links:

Snapshot build (9.0.0-SNAPSHOT): https://buildkite.com/elastic/fleet-server-package-mbp/builds/1573#0194b7fc-3802-4341-aa12-7d44f88dcdad ✅
Staging build (9.0.0-beta1): https://buildkite.com/elastic/fleet-server-package-mbp/builds/1573#0194b7fc-3803-4fac-960b-af7edc21453f ✅