### PR TITLE
mergify: remove backport-8.x enforcement

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -277,20 +277,6 @@ pull_request_rules:
           To fixup this pull request, you need to add the backport labels for the needed
           branches, such as:
           * `backport-./d./d` is the label to automatically backport to the `8./d` branch. `/d` is the digit
-  - name: add backport-8.x label for main only if no skipped or assigned already
-    conditions:
-      - -label~=^(backport-skip|backport-8.x)$
-      - base=main
-      - -merged
-      - -closed
-    actions:
-      comment:
-        message: |
-          `backport-8.x` has been added to help with the transition to the new branch `8.x`.
-          If you don't need it please use `backport-skip` label and remove the `backport-8.x` label.
-      label:
-        add:
-          - backport-8.x
   - name: backport patches to 8.17 branch
     conditions:
       - merged


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?


9.0 branch is now a thing, therefore no more 8.x and main feature parity is needed by default.

 Avoid unneeded backports
## How does this PR solve the problem?

// Explain HOW you solved the problem in your code. It is possible that during PR reviews this changes and then this section should be updated.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
