### PR TITLE
Use --develop flag for agent install e2e tests

### DIFF
--- a/dev-tools/e2e/kibana.yml
+++ b/dev-tools/e2e/kibana.yml
@@ -54,7 +54,7 @@ xpack.fleet.agentPolicies:
     namespace: default
     package_policies:
       - name: fleet_server-2
-        id: default-fleet-server
+        id: apm-fleet-server
         package:
           name: fleet_server
 xpack.fleet.outputs:

--- a/dev-tools/integration/.env
+++ b/dev-tools/integration/.env
@@ -1,6 +1,6 @@
 # If you use change this version without a pinned one, please update
 # .ci/bump-elastic-stack-snapshot.yml or .github/workflows/bump-golang.yml
-ELASTICSEARCH_VERSION=9.0.0-a38910c2-SNAPSHOT
+ELASTICSEARCH_VERSION=9.1.0-ae17f1a1-SNAPSHOT
 ELASTICSEARCH_USERNAME=elastic
 ELASTICSEARCH_PASSWORD=changeme
 TEST_ELASTICSEARCH_HOSTS=localhost:9200

--- a/testing/e2e/agent_install_test.go
+++ b/testing/e2e/agent_install_test.go
@@ -67,7 +67,7 @@ func (suite *AgentInstallSuite) SetupSuite() {
 		return
 	}
 	// check if agent is installed
-	if _, err := exec.LookPath(agentName); err == nil {
+	if _, err := exec.LookPath(agentDevName); err == nil {
 		suite.installDetected = true
 		return // don't bother with setup, skip all tests
 	}
@@ -277,8 +277,8 @@ func (suite *AgentInstallSuite) TearDownTest() {
 		return
 	}
 
-	out, err := exec.Command("sudo", "elastic-agent", "uninstall", "--force").CombinedOutput()
-	suite.Assert().NoErrorf(err, "elastic-agent uninstall failed. Output: %s", out)
+	out, err := exec.Command("sudo", "elastic-development-agent", "uninstall", "--force").CombinedOutput()
+	suite.Assert().NoErrorf(err, "elastic-development-agent uninstall failed. Output: %s", out)
 }
 
 func (suite *AgentInstallSuite) TestHTTP() {
@@ -286,6 +286,7 @@ func (suite *AgentInstallSuite) TestHTTP() {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "sudo", suite.agentPath, "install",
+		"--develop", "--install-servers",
 		"--fleet-server-es=http://"+suite.ESHosts,
 		"--fleet-server-service-token="+suite.ServiceToken,
 		"--fleet-server-insecure-http=true",
@@ -310,6 +311,7 @@ func (suite *AgentInstallSuite) TestWithSecretFiles() {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "sudo", suite.agentPath, "install",
+		"--develop", "--install-servers",
 		"--url=https://localhost:8220",
 		"--certificate-authorities="+filepath.Join(suite.CertPath, "e2e-test-ca.crt"),
 		"--fleet-server-es=http://"+suite.ESHosts,
@@ -365,6 +367,7 @@ func (suite *AgentInstallSuite) TestAPMInstrumentationFile() {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "sudo", suite.agentPath, "install",
+		"--develop", "--install-servers",
 		"--fleet-server-es=http://"+suite.ESHosts,
 		"--fleet-server-service-token="+suite.ServiceToken,
 		"--fleet-server-insecure-http=true",
@@ -403,6 +406,7 @@ func (suite *AgentInstallSuite) TestAPMInstrumentationPolicy() {
 	})
 
 	cmd := exec.CommandContext(ctx, "sudo", suite.agentPath, "install",
+		"--develop", "--install-servers",
 		"--fleet-server-es=http://"+suite.ESHosts,
 		"--fleet-server-service-token="+suite.ServiceToken,
 		"--fleet-server-insecure-http=true",

--- a/testing/e2e/const.go
+++ b/testing/e2e/const.go
@@ -4,5 +4,6 @@
 
 package e2e
 
-const binaryName = "fleet-server" //nolint:unused // work around to get platform specific binary name for tests
-const agentName = "elastic-agent" //nolint:unused // work around to get platform specific binary name for tests
+const binaryName = "fleet-server"                //nolint:unused // work around to get platform specific binary name for tests
+const agentName = "elastic-agent"                //nolint:unused // work around to get platform specific binary name for tests
+const agentDevName = "elastic-development-agent" //nolint:unused // work around to get platform specific binary name for tests

--- a/testing/e2e/const_windows.go
+++ b/testing/e2e/const_windows.go
@@ -6,3 +6,4 @@ package e2e
 
 const binaryName = "fleet-server.exe"
 const agentName = "elastic-agent.exe"
+const agentDevName = "elastic-development-agent.exe"


### PR DESCRIPTION
## What is the problem this PR solves?

It's hard to run e2e tests on a host that has elastic-agent installed.

## How does this PR solve the problem?

Use the `--develop` flag to install an agent in the development namespace

## How to test this PR locally

Change version in `dev-tools/integration/.env` to `9.1-SNAPSHOT`

`make test-e2e`

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~