### PR TITLE
[8.x] Manually bump 8.x to 8.19.0-SNAPSHOT

### DIFF
--- a/dev-tools/integration/.env
+++ b/dev-tools/integration/.env
@@ -1,6 +1,6 @@
 # If you use change this version without a pinned one, please update
 # .ci/bump-elastic-stack-snapshot.yml or .github/workflows/bump-golang.yml
-ELASTICSEARCH_VERSION=8.18.0-e7e59c26-SNAPSHOT
+ELASTICSEARCH_VERSION=8.19.0-d8910021-SNAPSHOT
 ELASTICSEARCH_USERNAME=elastic
 ELASTICSEARCH_PASSWORD=changeme
 TEST_ELASTICSEARCH_HOSTS=localhost:9200


### PR DESCRIPTION
The automated version bump is stuck on 8.18.x because the artifacts API is out of date. We possibly need to move away from the artifacts API as we have elsewhere, this will at least unstick the tests.

https://storage.googleapis.com/artifacts-api/snapshots/8.x.json