### PR TITLE
ci: enable 9.* branches

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -45,12 +45,13 @@ spec:
     spec:
       repository: elastic/fleet-server
       pipeline_file: ".buildkite/pipeline.yml"
-      branch_configuration: "main 8.* 7.* v8.* v7.*"
+      branch_configuration: "main 9.* 8.* 7.*"
       provider_settings:
         build_pull_request_forks: false
         build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
-        build_tags: true
+        build_tags: false
         filter_enabled: true
+        # TODO: what's the reason for this filter?
         filter_condition: >-
           build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
       env:
@@ -94,6 +95,7 @@ spec:
         build_tags: false
         build_branches: false
         filter_enabled: true
+        # TODO: what's the reason for this filter?
         filter_condition: >-
           build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
       env:
@@ -102,9 +104,9 @@ spec:
         SLACK_NOTIFICATIONS_ALL_BRANCHES: 'false'
         SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
       cancel_intermediate_builds: true
-      cancel_intermediate_builds_branch_filter: '!main !7.* !8.*'
+      cancel_intermediate_builds_branch_filter: '!main !7.* !8.* !9.*'
       skip_intermediate_builds: true
-      skip_intermediate_builds_branch_filter: '!main !7.* !8.*'
+      skip_intermediate_builds_branch_filter: '!main !7.* !8.* !9.*'
       teams:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ
@@ -175,12 +177,13 @@ spec:
         build_tags: false
         build_branches: false
         filter_enabled: true
+        # TODO: what's the reason for this filter?
         filter_condition: >-
           build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
       cancel_intermediate_builds: true
-      cancel_intermediate_builds_branch_filter: '!main !7.* !8.*'
+      cancel_intermediate_builds_branch_filter: '!main !7.* !8.* !9.*'
       skip_intermediate_builds: true
-      skip_intermediate_builds_branch_filter: '!main !7.* !8.*'
+      skip_intermediate_builds_branch_filter: '!main !7.* !8.* !9.*'
       teams:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
## What is the problem this PR solves?

New minor 9 branches are not running any CI.
No need to build tags, those tags are always coming from a commit that has already ran the CI.
 
## How does this PR solve the problem?


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
