### PR TITLE
Remove Team:Fleet from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     labels:
       - automation
       - dependency
+      - Team:Elastic-Agent-Control-Plane
     allow:
       # Only update internal dependencies for now while we evaluate this workflow.
       - dependency-name: "github.com/elastic/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
     labels:
       - automation
       - dependency
-      - Team:Fleet
     allow:
       # Only update internal dependencies for now while we evaluate this workflow.
       - dependency-name: "github.com/elastic/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,6 @@ updates:
       # Only update internal dependencies for now while we evaluate this workflow.
       - dependency-name: "github.com/elastic/*"
       - dependency-name: "go.elastic.co/*"
-    reviewers:
-      - "elastic/fleet"
     open-pull-requests-limit: 10
     groups:
       elastic-apm:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

Dependabot PR's ping `Team:Fleet` unnecessarily. 

## How does this PR solve the problem?

Removes the `Team:Fleet` label from dependabot config. 

## How to test this PR locally

N/A

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
