### PR TITLE
Add unit test for fips metadata attribute in enroll/checkin

### DIFF
--- a/internal/pkg/api/handleEnroll_test.go
+++ b/internal/pkg/api/handleEnroll_test.go
@@ -15,6 +15,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
 	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/cache"
@@ -24,9 +28,6 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/model"
 	"github.com/elastic/fleet-server/v7/internal/pkg/rollback"
 	ftesting "github.com/elastic/fleet-server/v7/internal/pkg/testing"
-	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestRemoveDuplicateStr(t *testing.T) {
@@ -569,7 +570,15 @@ func TestEnrollerT_retrieveStaticTokenEnrollmentToken(t *testing.T) {
 }
 
 func TestValidateEnrollRequest(t *testing.T) {
-	req, err := validateRequest(context.Background(), strings.NewReader("not a json"))
-	assert.Equal(t, "Bad request: unable to decode enroll request", err.Error())
-	assert.Nil(t, req)
+	t.Run("invalid json", func(t *testing.T) {
+		req, err := validateRequest(context.Background(), strings.NewReader("not a json"))
+		assert.Equal(t, "Bad request: unable to decode enroll request", err.Error())
+		assert.Nil(t, req)
+	})
+	t.Run("fips attribute in local metadata", func(t *testing.T) {
+		req, err := validateRequest(context.Background(), strings.NewReader(`{"type": "PERMANENT", "metadata": {"local": {"elastic": {"agent": {"fips": true, "snapshot": false}}}}}`))
+		assert.NoError(t, err)
+		assert.Equal(t, PERMANENT, req.Type)
+		assert.Equal(t, json.RawMessage(`{"elastic": {"agent": {"fips": true, "snapshot": false}}}`), req.Metadata.Local)
+	})
 }

--- a/internal/pkg/checkin/bulk_test.go
+++ b/internal/pkg/checkin/bulk_test.go
@@ -108,6 +108,17 @@ func TestBulkSimple(t *testing.T) {
 			nil,
 		},
 		{
+			"has meta with fips attribute",
+			"metaCaseID",
+			"online",
+			"message",
+			[]byte(`{"fips":true,"snapshot":false}`),
+			nil,
+			nil,
+			"",
+			nil,
+		},
+		{
 			"Singled field case",
 			"singleFieldId",
 			"online",


### PR DESCRIPTION
## What is the problem this PR solves?

Add unit tests as a sanity check to make sure that fleet-server is able to handle the new `fips` metadata attribute.

fleet-server uses `json.RawMessage` when interacting with local metadata (in the enroll and checkin endpoints) as it just needs to compare byte values to see if the agent doc needs to be changed. The new tests verify that local metadata changes are propagated as expected.

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~