### PR TITLE
Clear agent.upgrade_attempts on upgrade complete

### DIFF
--- a/changelog/fragments/1740760469-Clear-agent-upgrade-attempts-when-upgrade-complete.yaml
+++ b/changelog/fragments/1740760469-Clear-agent-upgrade-attempts-when-upgrade-complete.yaml
@@ -8,7 +8,7 @@
 # - security: impacts on the security of a product or a user’s deployment.
 # - upgrade: important information for someone upgrading from a prior version
 # - other: does not fit into any of the other categories
-kind: feature
+kind: enhancement
 
 # Change summary; a 80ish characters long description of the change.
 summary: Clear agent.upgrade_attempts when upgrade is complete.

--- a/changelog/fragments/1740760469-Clear-agent-upgrade-attempts-when-upgrade-complete.yaml
+++ b/changelog/fragments/1740760469-Clear-agent-upgrade-attempts-when-upgrade-complete.yaml
@@ -31,4 +31,4 @@ pr: https://github.com/elastic/fleet-server/pull/4528
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.
-issue: https://github.com/elastic/ingest-dev/issues/4720
+# issue: 

--- a/changelog/fragments/1740760469-Clear-agent-upgrade-attempts-when-upgrade-complete.yaml
+++ b/changelog/fragments/1740760469-Clear-agent-upgrade-attempts-when-upgrade-complete.yaml
@@ -1,0 +1,34 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# Change summary; a 80ish characters long description of the change.
+summary: Clear agent.upgrade_attempts when upgrade is complete.
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  The new AutomaticAgentUpgradeTask Kibana task sets the upgrade_attempts property in agents it upgrades.
+  This property is used to track upgrade retries and should therefore be cleared when the upgrade is complete.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: fleet-server
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/elastic/fleet-server/pull/4528
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/ingest-dev/issues/4720

--- a/internal/pkg/api/handleAck.go
+++ b/internal/pkg/api/handleAck.go
@@ -619,6 +619,7 @@ func (ack *AckT) handleUpgrade(ctx context.Context, zlog zerolog.Logger, agent *
 			dl.FieldUpgradeStartedAt: nil,
 			dl.FieldUpgradeStatus:    nil,
 			dl.FieldUpgradedAt:       now,
+			dl.FieldUpgradeAttempts:  nil,
 		}
 	}
 

--- a/internal/pkg/api/handleAck.go
+++ b/internal/pkg/api/handleAck.go
@@ -619,7 +619,6 @@ func (ack *AckT) handleUpgrade(ctx context.Context, zlog zerolog.Logger, agent *
 			dl.FieldUpgradeStartedAt: nil,
 			dl.FieldUpgradeStatus:    nil,
 			dl.FieldUpgradedAt:       now,
-			dl.FieldUpgradeAttempts:  nil,
 		}
 	}
 

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -437,6 +437,9 @@ func (ct *CheckinT) processUpgradeDetails(ctx context.Context, agent *model.Agen
 	if err != nil {
 		return err
 	}
+	if action == nil {
+		return nil
+	}
 
 	// link action with APM spans
 	var links []apm.SpanLink

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -219,7 +219,7 @@ func (ct *CheckinT) validateRequest(zlog zerolog.Logger, w http.ResponseWriter, 
 		}
 
 		wTime := pollDuration + time.Minute
-		rc := http.NewResponseController(w) //nolint:bodyclose // we are working with a ResponseWriter not a Respons
+		rc := http.NewResponseController(w) //nolint:nolintlint,bodyclose // we are working with a ResponseWriter not a Respons
 		if err := rc.SetWriteDeadline(start.Add(wTime)); err != nil {
 			zlog.Warn().Err(err).Time("write_deadline", start.Add(wTime)).Msg("Unable to set checkin write deadline.")
 		} else {

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -521,6 +521,7 @@ func (ct *CheckinT) markUpgradeComplete(ctx context.Context, agent *model.Agent)
 		dl.FieldUpgradeStartedAt: nil,
 		dl.FieldUpgradeStatus:    nil,
 		dl.FieldUpgradedAt:       time.Now().UTC().Format(time.RFC3339),
+		dl.FieldUpgradeAttempts:  nil,
 	}
 	body, err := doc.Marshal()
 	if err != nil {

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -219,7 +219,7 @@ func (ct *CheckinT) validateRequest(zlog zerolog.Logger, w http.ResponseWriter, 
 		}
 
 		wTime := pollDuration + time.Minute
-		rc := http.NewResponseController(w) //nolint:nolintlint,bodyclose // we are working with a ResponseWriter not a Respons
+		rc := http.NewResponseController(w)
 		if err := rc.SetWriteDeadline(start.Add(wTime)); err != nil {
 			zlog.Warn().Err(err).Time("write_deadline", start.Add(wTime)).Msg("Unable to set checkin write deadline.")
 		} else {

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -500,6 +500,10 @@ func (ct *CheckinT) processUpgradeDetails(ctx context.Context, agent *model.Agen
 	doc := bulk.UpdateFields{
 		dl.FieldUpgradeDetails: details,
 	}
+	if agent.UpgradeAttempts != nil && details.State == UpgradeDetailsStateUPGWATCHING {
+		doc[dl.FieldUpgradeAttempts] = nil
+	}
+
 	body, err := doc.Marshal()
 	if err != nil {
 		return err
@@ -521,7 +525,6 @@ func (ct *CheckinT) markUpgradeComplete(ctx context.Context, agent *model.Agent)
 		dl.FieldUpgradeStartedAt: nil,
 		dl.FieldUpgradeStatus:    nil,
 		dl.FieldUpgradedAt:       time.Now().UTC().Format(time.RFC3339),
-		dl.FieldUpgradeAttempts:  nil,
 	}
 	body, err := doc.Marshal()
 	if err != nil {

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -344,7 +344,7 @@ func TestProcessUpgradeDetails(t *testing.T) {
 					t.Logf("bulk match unmarshal error: %v", err)
 					return false
 				}
-				return doc.Doc[dl.FieldUpgradeDetails] == nil && doc.Doc[dl.FieldUpgradeStartedAt] == nil && doc.Doc[dl.FieldUpgradeStatus] == nil && doc.Doc[dl.FieldUpgradedAt] != ""
+				return doc.Doc[dl.FieldUpgradeDetails] == nil && doc.Doc[dl.FieldUpgradeStartedAt] == nil && doc.Doc[dl.FieldUpgradeStatus] == nil && doc.Doc[dl.FieldUpgradedAt] != "" && doc.Doc[dl.FieldUpgradeAttempts] == nil
 			}), mock.Anything, mock.Anything).Return(nil)
 			return mBulk
 		},

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -344,7 +344,7 @@ func TestProcessUpgradeDetails(t *testing.T) {
 					t.Logf("bulk match unmarshal error: %v", err)
 					return false
 				}
-				return doc.Doc[dl.FieldUpgradeDetails] == nil && doc.Doc[dl.FieldUpgradeStartedAt] == nil && doc.Doc[dl.FieldUpgradeStatus] == nil && doc.Doc[dl.FieldUpgradedAt] != "" && doc.Doc[dl.FieldUpgradeAttempts] == nil
+				return doc.Doc[dl.FieldUpgradeDetails] == nil && doc.Doc[dl.FieldUpgradeStartedAt] == nil && doc.Doc[dl.FieldUpgradeStatus] == nil && doc.Doc[dl.FieldUpgradedAt] != ""
 			}), mock.Anything, mock.Anything).Return(nil)
 			return mBulk
 		},

--- a/internal/pkg/dl/constants.go
+++ b/internal/pkg/dl/constants.go
@@ -54,6 +54,7 @@ const (
 	FieldUpgradeStartedAt = "upgrade_started_at"
 	FieldUpgradeStatus    = "upgrade_status"
 	FieldUpgradeDetails   = "upgrade_details"
+	FieldUpgradeAttempts  = "upgrade_attempts"
 
 	FieldAuditUnenrolledTime   = "audit_unenrolled_time"
 	FieldAuditUnenrolledReason = "audit_unenrolled_reason"

--- a/internal/pkg/model/schema.go
+++ b/internal/pkg/model/schema.go
@@ -228,6 +228,9 @@ type Agent struct {
 	// Date/time the Elastic Agent was last upgraded
 	UpgradedAt string `json:"upgraded_at,omitempty"`
 
+	// List of timestamps of attempts of Elastic Agent automatic upgrades
+	UpgradeAttempts []string `json:"upgrade_attempts,omitempty"`
+
 	// User provided metadata information for the Elastic Agent
 	UserProvidedMetadata json.RawMessage `json:"user_provided_metadata,omitempty"`
 }

--- a/internal/pkg/model/schema.go
+++ b/internal/pkg/model/schema.go
@@ -216,6 +216,9 @@ type Agent struct {
 	// Date/time the Elastic Agent was last updated
 	UpdatedAt string `json:"updated_at,omitempty"`
 
+	// List of timestamps of attempts of Elastic Agent automatic upgrades
+	UpgradeAttempts []string `json:"upgrade_attempts,omitempty"`
+
 	// Additional upgrade status details.
 	UpgradeDetails *UpgradeDetails `json:"upgrade_details,omitempty"`
 
@@ -227,9 +230,6 @@ type Agent struct {
 
 	// Date/time the Elastic Agent was last upgraded
 	UpgradedAt string `json:"upgraded_at,omitempty"`
-
-	// List of timestamps of attempts of Elastic Agent automatic upgrades
-	UpgradeAttempts []string `json:"upgrade_attempts,omitempty"`
 
 	// User provided metadata information for the Elastic Agent
 	UserProvidedMetadata json.RawMessage `json:"user_provided_metadata,omitempty"`

--- a/model/schema.json
+++ b/model/schema.json
@@ -686,6 +686,13 @@
           "description": "Additional upgrade status details.",
           "type": "object"
         },
+        "upgrade_attempts": {
+          "description": "List of timestamps of attempts of Elastic Agent automatic upgrades",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "replace_token": {
           "description": "hash of token provided during enrollment that allows replacement by another enrollment with same ID",
           "type": "string"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

https://github.com/elastic/kibana/pull/212744 adds retry logic to the task that automatically ugprades agents. Agents that were upgraded through this task have their new `upgrade_attempts` property populated. It is missing a way to clear this property when the upgrade completes successfully.

## How does this PR solve the problem?

The change in this PR clears `upgrade_attempts` when the upgrade details of the agent get into `UPG_WATCHING` state and are processed in `handleCheckin`.

## How to test this PR locally

This should be tested alongside https://github.com/elastic/kibana/pull/212744 (or after it is merged - this is fine, since automatic upgrades are currently behind the `enableAutomaticAgentUpgrades` feature flag). With this change, agents upgraded through the automatic upgrade task should have their `upgrade_attempts` property set to `null` when the upgrade is successful.

Testing should also validate that `upgrade_attempts` stays set if the upgrade failed, e.g. after requesting an upgrade to an invalid version.

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

Relates https://github.com/elastic/ingest-dev/issues/4720