### PR TITLE
Fix fleet-server URL population for cloud test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -465,4 +465,5 @@ test-cloude2e: prepare-test-context  ## - Run cloude2e tests with full setup (sl
 test-cloude2e-set: ## Run cloude2e test
 	$(eval FLEET_SERVER_URL := $(shell make --no-print-directory -C ${CLOUD_TESTING_BASE} cloud-get-fleet-url))
 	make -C ${CLOUD_TESTING_BASE} cloud-get-fleet-url
-	FLEET_SERVER_URL="${FLEET_SERVER_URL}" go test -v -tags=cloude2e -count=1 -race -p 1 ./testing/cloude2e
+	cd testing; \
+	FLEET_SERVER_URL="${FLEET_SERVER_URL}" go test -v -tags=cloude2e -count=1 -race -p 1 ./...

--- a/dev-tools/cloud/terraform/main.tf
+++ b/dev-tools/cloud/terraform/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.12.1"
+      version = "0.12.2"
     }
   }
 }

--- a/dev-tools/cloud/terraform/outputs.tf
+++ b/dev-tools/cloud/terraform/outputs.tf
@@ -26,6 +26,6 @@ output "kibana_url" {
 }
 
 output "fleet_url" {
-  value       = ec_deployment.deployment.integrations_server.endpoints != null ? ec_deployment.deployment.integrations_server.endpoints.fleet : ""
+  value       = ec_deployment.deployment.integrations_server.https_endpoint
   description = "The secure Fleet URL"
 }


### PR DESCRIPTION
## What is the problem this PR solves?

Cloud deployment tests silently fail.

## How does this PR solve the problem?

use `integrations_server.https_endpoint` instead of `integrations_server.endpoints.fleet`

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)~~
