### PR TITLE
Add DRA FIPS artifacts to package pipeline

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -26,7 +26,7 @@ check_if_file_exist_in_repo() {
     local response=$(curl --fail -s -H "Authorization: token $GITHUB_REPO_TOKEN" https://api.github.com/repos/elastic/${repoName}/contents/${path_to_file}| grep -c "\"path\"\: \"${path_to_file}\"")
     if [[ ${response} -ge 1 ]]; then
         export FILE_EXISTS_IN_REPO=true
-        echo "FILE_EXIST_IN_REPO = true"        
+        echo "FILE_EXIST_IN_REPO = true"
     else
         export FILE_EXISTS_IN_REPO=false
         echo "FILE_EXIST_IN_REPO = false"
@@ -73,7 +73,7 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server" && "$BUILDKITE_STEP_KEY" == "
 fi
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server-package-mbp" ]]; then
-  if [[ "$BUILDKITE_STEP_KEY" == package-x86-64* || "$BUILDKITE_STEP_KEY" == package-arm* || "$BUILDKITE_STEP_KEY" == "dra-snapshot" || "$BUILDKITE_STEP_KEY" == "dra-staging" ]]; then
+  if [[ "$BUILDKITE_STEP_KEY" == package-x86-64* || "$BUILDKITE_STEP_KEY" == package-fips-x86_64* || "$BUILDKITE_STEP_KEY" == package-arm* || "$BUILDKITE_STEP_KEY" == package-fips-arm* || "$BUILDKITE_STEP_KEY" == "dra-snapshot" || "$BUILDKITE_STEP_KEY" == "dra-staging" ]]; then
     export PRIVATE_CI_GCS_CREDENTIALS_SECRET=$(retry 5 vault kv get -field plaintext -format=json ${PRIVATE_CI_GCS_CREDENTIALS_PATH})
     export JOB_GCS_BUCKET
   fi
@@ -92,7 +92,7 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server-package-mbp" ]]; then
 fi
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server-package-mbp" ]]; then
-  if [[ "$BUILDKITE_STEP_KEY" == package-x86-64* || "$BUILDKITE_STEP_KEY" == package-arm* ]]; then
+  if [[ "$BUILDKITE_STEP_KEY" == package-x86-64* || "$BUILDKITE_STEP_KEY" == package-fips-x86-64* || "$BUILDKITE_STEP_KEY" == package-arm* || "$BUILDKITE_STEP_KEY" == package-fips-arm* ]]; then
     export PRIVATE_CI_GCS_CREDENTIALS_SECRET=$(retry 5 vault kv get -field plaintext -format=json ${PRIVATE_CI_GCS_CREDENTIALS_PATH})
     export JOB_GCS_BUCKET
   fi

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -16,7 +16,7 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server" && "$BUILDKITE_STEP_KEY" == "
 fi
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server-package-mbp" ]]; then
-  if [[ "$BUILDKITE_STEP_KEY" == package-x86-64* || "$BUILDKITE_STEP_KEY" == package-arm* || "$BUILDKITE_STEP_KEY" == "dra-snapshot" && "$BUILDKITE_STEP_KEY" == "dra-staging" ]]; then
+  if [[ "$BUILDKITE_STEP_KEY" == package-x86-64* || "$BUILDKITE_STEP_KEY" == package-fips-x86-64* || "$BUILDKITE_STEP_KEY" == package-arm* || "$BUILDKITE_STEP_KEY" == package-fips-arm* || "$BUILDKITE_STEP_KEY" == "dra-snapshot" && "$BUILDKITE_STEP_KEY" == "dra-staging" ]]; then
     unset GOOGLE_APPLICATION_CREDENTIALS
     unset VAULT_ROLE_ID_SECRET
     unset VAULT_ADDR_SECRET

--- a/.buildkite/pipeline.package.mbp.yml
+++ b/.buildkite/pipeline.package.mbp.yml
@@ -104,21 +104,9 @@ steps:
     depends_on:
       - step: "package-x86-64-snapshot"
         allow_failure: false
-      - step: "package-arm-snapshot"
-        allow_failure: false
-
-  - label: "DRA FIPS snapshot"
-    if: "${FILE_EXISTS_IN_REPO} && build.env('VERSION_QUALIFIER') == null"
-    key: "dra-fips snapshot"
-    command: ".buildkite/scripts/dra_release.sh snapshot"
-    env:
-      FIPS: "true"
-    agents:
-      provider: "gcp"
-      image: "${IMAGE_UBUNTU_X86_64}"
-      machineType: "c2-standard-16"
-    depends_on:
       - step: "package-fips-x86-64-snapshot"
+        allow_failure: false
+      - step: "package-arm-snapshot"
         allow_failure: false
       - step: "package-fips-arm-snapshot"
         allow_failure: false
@@ -138,25 +126,9 @@ steps:
     depends_on:
       - step: "package-x86-64-staging"
         allow_failure: false
-      - step: "package-arm-staging"
-        allow_failure: false
-
-  - label: "DRA FIPS release staging"
-    # we don't usually build staging from the main branch, but we exceptionally allow it for prereleases
-    # details in https://github.com/elastic/ingest-dev/issues/4855
-    if: "${FILE_EXISTS_IN_REPO} == true && (build.env('BUILDKITE_BRANCH') != 'main' || build.env('VERSION_QUALIFIER') != null)"
-    key: "dra-fips-staging"
-    command: |
-      source .buildkite/scripts/version_qualifier.sh
-      .buildkite/scripts/dra_release.sh staging
-    env:
-      FIPS: "true"
-    agents:
-      provider: "gcp"
-      image: "${IMAGE_UBUNTU_X86_64}"
-      machineType: "c2-standard-16"
-    depends_on:
       - step: "package-fips-x86-64-staging"
+        allow_failure: false
+      - step: "package-arm-staging"
         allow_failure: false
       - step: "package-fips-arm-staging"
         allow_failure: false

--- a/.buildkite/pipeline.package.mbp.yml
+++ b/.buildkite/pipeline.package.mbp.yml
@@ -28,6 +28,29 @@ steps:
       image: "${IMAGE_UBUNTU_X86_64}"
       machineType: "c2-standard-16"
 
+  - label: "Package FIPS x86_64 snapshot"
+    if: "build.env('VERSION_QUALIFIER') == null"
+    key: "package-fips-x86-64-snapshot"
+    command: ".buildkite/scripts/package.sh snapshot"
+    env:
+      FIPS: "true"
+    agents:
+      provider: "gcp"
+      image: "${IMAGE_UBUNTU_X86_64}"
+      machineType: "c2-standard-16"
+
+  - label: "Package FIPS x86_64 staging"
+    key: "package-fips-x86-64-staging"
+    command: |
+      source .buildkite/scripts/version_qualifier.sh
+      .buildkite/scripts/package.sh staging
+    env:
+      FIPS: "true"
+    agents:
+      provider: "gcp"
+      image: "${IMAGE_UBUNTU_X86_64}"
+      machineType: "c2-standard-16"
+
   - label: "Package aarch64 snapshot"
     if: "build.env('VERSION_QUALIFIER') == null"
     key: "package-arm-snapshot"
@@ -47,6 +70,29 @@ steps:
       imagePrefix: "${IMAGE_UBUNTU_ARM_64}"
       instanceType: "t4g.2xlarge"
 
+  - label: "Package FIPS aarch64 snapshot"
+    if: "build.env('VERSION_QUALIFIER') == null"
+    key: "package-fips-arm-snapshot"
+    command: ".buildkite/scripts/package.sh snapshot"
+    env:
+      FIPS: "true"
+    agents:
+      provider: "aws"
+      imagePrefix: "${IMAGE_UBUNTU_ARM_64}"
+      instanceType: "t4g.2xlarge"
+
+  - label: "Package FIPS aarch64 staging"
+    key: "package-fips-arm-staging"
+    command: |
+      source .buildkite/scripts/version_qualifier.sh
+      .buildkite/scripts/package.sh staging
+    env:
+      FIPS: "true"
+    agents:
+      provider: "aws"
+      imagePrefix: "${IMAGE_UBUNTU_ARM_64}"
+      instanceType: "t4g.2xlarge"
+
   - label: "DRA snapshot"
     if: "${FILE_EXISTS_IN_REPO} && build.env('VERSION_QUALIFIER') == null"
     key: "dra-snapshot"
@@ -59,6 +105,22 @@ steps:
       - step: "package-x86-64-snapshot"
         allow_failure: false
       - step: "package-arm-snapshot"
+        allow_failure: false
+
+  - label: "DRA FIPS snapshot"
+    if: "${FILE_EXISTS_IN_REPO} && build.env('VERSION_QUALIFIER') == null"
+    key: "dra-fips snapshot"
+    command: ".buildkite/scripts/dra_release.sh snapshot"
+    env:
+      FIPS: "true"
+    agents:
+      provider: "gcp"
+      image: "${IMAGE_UBUNTU_X86_64}"
+      machineType: "c2-standard-16"
+    depends_on:
+      - step: "package-fips-x86-64-snapshot"
+        allow_failure: false
+      - step: "package-fips-arm-snapshot"
         allow_failure: false
 
   - label: "DRA release staging"
@@ -77,4 +139,24 @@ steps:
       - step: "package-x86-64-staging"
         allow_failure: false
       - step: "package-arm-staging"
+        allow_failure: false
+
+  - label: "DRA FIPS release staging"
+    # we don't usually build staging from the main branch, but we exceptionally allow it for prereleases
+    # details in https://github.com/elastic/ingest-dev/issues/4855
+    if: "${FILE_EXISTS_IN_REPO} == true && (build.env('BUILDKITE_BRANCH') != 'main' || build.env('VERSION_QUALIFIER') != null)"
+    key: "dra-fips-staging"
+    command: |
+      source .buildkite/scripts/version_qualifier.sh
+      .buildkite/scripts/dra_release.sh staging
+    env:
+      FIPS: "true"
+    agents:
+      provider: "gcp"
+      image: "${IMAGE_UBUNTU_X86_64}"
+      machineType: "c2-standard-16"
+    depends_on:
+      - step: "package-fips-x86-64-staging"
+        allow_failure: false
+      - step: "package-fips-arm-staging"
         allow_failure: false

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -51,6 +51,18 @@ with_go() {
     export PATH="${PATH}:$(go env GOPATH):$(go env GOPATH)/bin"
 }
 
+with_msft_go() {
+    echo "Setting up microsoft/go"
+    create_workspace
+    check_platform_architeture
+    MSFT_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$(cat .go-version)-1.${platform_type}-${arch_type}.tar.gz
+    retry 5 $(curl -sL -o - $MSFT_DOWNLOAD_URL | tar -xz -f - -C ${WORKSPACE})
+    export PATH="${PATH}:${WORKSPACE}/go/bin"
+    go version
+    which go
+    export PATH="${PATH}:$(go env GOPATH):$(go env GOPATH)/bin"
+}
+
 with_docker_compose() {
     echo "Setting up the Docker-compose environment..."
     create_workspace

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -60,7 +60,7 @@ with_msft_go() {
     export PATH="${PATH}:${WORKSPACE}/go/bin"
     go version
     which go
-    export PATH="${PATH}:$(go env GOPATH):$(go env GOPATH)/bin"
+    export PATH="${PATH}:$(go env GOPATH)/bin"
 }
 
 with_docker_compose() {

--- a/.buildkite/scripts/dra_release.sh
+++ b/.buildkite/scripts/dra_release.sh
@@ -41,10 +41,6 @@ if [[ ${TYPE} == "snapshot" ]]; then
     VERSION="${VERSION}-SNAPSHOT"
 fi
 
-if [[ ${FIPS} == "true" ]]; then
-    export FIPS=true
-fi
-
 mkdir -p ${BASE_DIR}/reports
 ./dev-tools/dependencies-report --csv ${BASE_DIR}/reports/dependencies-${VERSION}.csv
 cd ${BASE_DIR}/reports && shasum -a 512 dependencies-${VERSION}.csv > dependencies-${VERSION}.csv.sha512

--- a/.buildkite/scripts/dra_release.sh
+++ b/.buildkite/scripts/dra_release.sh
@@ -41,6 +41,11 @@ if [[ ${TYPE} == "snapshot" ]]; then
     VERSION="${VERSION}-SNAPSHOT"
 fi
 
+if [[ ${FIPS} == "true" ]]; then
+    export FIPS=true
+    VERSION="${VERSION}-fips" # NOTE: fips artifact naming is fleet-server-fips-VERSION-OS-ARCH, not VERSION-fips
+fi
+
 mkdir -p ${BASE_DIR}/reports
 ./dev-tools/dependencies-report --csv ${BASE_DIR}/reports/dependencies-${VERSION}.csv
 cd ${BASE_DIR}/reports && shasum -a 512 dependencies-${VERSION}.csv > dependencies-${VERSION}.csv.sha512

--- a/.buildkite/scripts/dra_release.sh
+++ b/.buildkite/scripts/dra_release.sh
@@ -43,7 +43,6 @@ fi
 
 if [[ ${FIPS} == "true" ]]; then
     export FIPS=true
-    VERSION="${VERSION}-fips" # NOTE: fips artifact naming is fleet-server-fips-VERSION-OS-ARCH, not VERSION-fips
 fi
 
 mkdir -p ${BASE_DIR}/reports

--- a/.buildkite/scripts/local_build.sh
+++ b/.buildkite/scripts/local_build.sh
@@ -5,6 +5,10 @@ set -euo pipefail
 source .buildkite/scripts/common.sh
 
 add_bin_path
-with_go
+if [[ "${FIPS:-false}" == "true" ]]; then
+    with_msft_go
+else
+    with_go
+fi
 
 make local

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -20,7 +20,7 @@ fi
 
 add_bin_path
 
-if [[ -v FIPS && ${FIPS} == "true" ]]; then
+if [[ ${FIPS:-false} == "true" ]]; then
     with_msft_go
     if [[ ${PLATFORM_TYPE} == "arm" || ${PLATFORM_TYPE} == "aarch64" ]]; then
         export PLATFORMS="linux/arm64"

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -20,6 +20,10 @@ if [[ ${PLATFORM_TYPE} == "arm" || ${PLATFORM_TYPE} == "aarch64" ]]; then
     PACKAGES="docker"
 fi
 
+if [[ ${FIPS} == "true" ]]; then
+    export FIPS=true
+fi
+
 add_bin_path
 with_go
 with_mage

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -20,10 +20,6 @@ if [[ ${PLATFORM_TYPE} == "arm" || ${PLATFORM_TYPE} == "aarch64" ]]; then
     PACKAGES="docker"
 fi
 
-if [[ ${FIPS} == "true" ]]; then
-    export FIPS=true
-fi
-
 add_bin_path
 with_go
 with_mage

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -23,9 +23,9 @@ add_bin_path
 if [[ -v FIPS && ${FIPS} == "true" ]]; then
     with_msft_go
     if [[ ${PLATFORM_TYPE} == "arm" || ${PLATFORM_TYPE} == "aarch64" ]]; then
-        PLATFORMS="linux/arm64"
+        export PLATFORMS="linux/arm64"
     else
-        PLATFORMS="linux/amd64"
+        export PLATFORMS="linux/amd64"
     fi
 else
     with_go

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -21,7 +21,12 @@ if [[ ${PLATFORM_TYPE} == "arm" || ${PLATFORM_TYPE} == "aarch64" ]]; then
 fi
 
 add_bin_path
-with_go
+
+if [[ -v FIPS && ${FIPS} == "true" ]]; then
+    with_msft_go
+else
+    with_go
+fi
 with_mage
 
 case "${TYPE}" in

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -14,16 +14,19 @@ if [[ ${BUILDKITE_BRANCH} == "main" && ${TYPE} == "staging" && -z ${VERSION_QUAL
 fi
 
 PLATFORMS=""
-PACKAGES=""
 if [[ ${PLATFORM_TYPE} == "arm" || ${PLATFORM_TYPE} == "aarch64" ]]; then
     PLATFORMS="linux/arm64"
-    PACKAGES="docker"
 fi
 
 add_bin_path
 
 if [[ -v FIPS && ${FIPS} == "true" ]]; then
     with_msft_go
+    if [[ ${PLATFORM_TYPE} == "arm" || ${PLATFORM_TYPE} == "aarch64" ]]; then
+        PLATFORMS="linux/arm64"
+    else
+        PLATFORMS="linux/amd64"
+    fi
 else
     with_go
 fi

--- a/.buildkite/scripts/test-release.sh
+++ b/.buildkite/scripts/test-release.sh
@@ -6,7 +6,7 @@ FLEET_SERVER_VERSION=${1:?"Fleet Server version is needed"}
 FILE_PREFIX="build/distributions/fleet-server-${FLEET_SERVER_VERSION}-"
 
 PLATFORM_FILES=(darwin-aarch64.tar.gz darwin-x86_64.tar.gz linux-arm64.tar.gz linux-x86_64.tar.gz windows-x86_64.zip)
-if [ "$FIPS" = "true" ] ; then
+if [[ "${FIPS:-false}" == "true" ]] ; then
     PLATFORM_FILES=(linux-arm64.tar.gz linux-x86_64.tar.gz)
     FILE_PREFIX="build/distributions/fleet-server-fips-${FLEET_SERVER_VERSION}-"
 fi

--- a/.buildkite/scripts/test-release.sh
+++ b/.buildkite/scripts/test-release.sh
@@ -3,15 +3,15 @@
 set -euo pipefail
 
 FLEET_SERVER_VERSION=${1:?"Fleet Server version is needed"}
+FILE_PREFIX="build/distributions/fleet-server-${FLEET_SERVER_VERSION}-"
 
 PLATFORM_FILES=(darwin-aarch64.tar.gz darwin-x86_64.tar.gz linux-arm64.tar.gz linux-x86_64.tar.gz windows-x86_64.zip)
 if [ "$FIPS" = "true" ] ; then
     PLATFORM_FILES=(linux-arm64.tar.gz linux-x86_64.tar.gz)
+    FILE_PREFIX="build/distributions/fleet-server-fips-${FLEET_SERVER_VERSION}-"
 fi
 
 #make release
-
-FILE_PREFIX="build/distributions/fleet-server-${FLEET_SERVER_VERSION}-"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/.buildkite/scripts/test-release.sh
+++ b/.buildkite/scripts/test-release.sh
@@ -6,7 +6,7 @@ FLEET_SERVER_VERSION=${1:?"Fleet Server version is needed"}
 
 PLATFORM_FILES=(darwin-aarch64.tar.gz darwin-x86_64.tar.gz linux-arm64.tar.gz linux-x86_64.tar.gz windows-x86_64.zip)
 if [ "$FIPS" = "true" ] ; then
-    PLATFORM_FILES=(linux-arm64-fips.tar.gz linux-x86_64-fips.tar.gz)
+    PLATFORM_FILES=(linux-arm64.tar.gz linux-x86_64.tar.gz)
 fi
 
 #make release

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -40,6 +40,6 @@ USER fleet-server
 COPY --chown=fleet-server:fleet-server --chmod=644 fleet-server.yml /etc/fleet-server.yml
 COPY --chown=fleet-server:fleet-server --chmod=555 --from=builder /go/src/github.com/elastic/fleet-server/build/binaries/fleet-server-fips-${VERSION}-${TARGETOS:-linux}-*/fleet-server /usr/bin/fleet-server
 
-ENV GOFIPS=1
+ENV GODEBUG=fips140=on
 
 CMD [ "/usr/bin/fleet-server", "-c", "/etc/fleet-server.yml" ]

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -38,7 +38,7 @@ RUN addgroup --gid 1000 fleet-server && \
 USER fleet-server
 
 COPY --chown=fleet-server:fleet-server --chmod=644 fleet-server.yml /etc/fleet-server.yml
-COPY --chown=fleet-server:fleet-server --chmod=555 --from=builder /go/src/github.com/elastic/fleet-server/build/binaries/fleet-server-${VERSION}-${TARGETOS:-linux}-*-fips/fleet-server /usr/bin/fleet-server
+COPY --chown=fleet-server:fleet-server --chmod=555 --from=builder /go/src/github.com/elastic/fleet-server/build/binaries/fleet-server-fips-${VERSION}-${TARGETOS:-linux}-*/fleet-server /usr/bin/fleet-server
 
 ENV GOFIPS=1
 

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,18 @@
 SHELL=/usr/bin/env bash
 GO_VERSION=$(shell cat '.go-version')
 DEFAULT_VERSION=$(shell awk '/const DefaultVersion/{print $$NF}' version/version.go | tr -d '"')
+
+# Set FIPS=true to force FIPS compliance when building
+FIPS?=
+
+ifeq "${FIPS}" "true"
+PLATFORMS ?= linux/amd64 linux/arm64
+else
+PLATFORMS ?= darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64
+endif
+
 TARGET_ARCH_amd64=x86_64
 TARGET_ARCH_arm64=arm64
-PLATFORMS ?= darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64
 BUILDMODE_linux_amd64=-buildmode=pie
 BUILDMODE_linux_arm64=-buildmode=pie
 BUILDMODE_windows_amd64=-buildmode=pie
@@ -84,8 +93,6 @@ GOBIN=$(shell go env GOPATH)/bin/
 
 OS_NAME:=$(shell uname -s)
 
-# Set FIPS=true to force FIPS compliance when building
-FIPS?=
 # NOTE: We are assuming that the only GOEXPIREMENT flag will be associated with FIPS
 GOFIPSEXPERIMENT?=
 FIPSSUFFIX=
@@ -93,7 +100,6 @@ ifeq "${FIPS}" "true"
 BUILDER_IMAGE=fleet-server-fips-builder:${GO_VERSION}
 DOCKER_IMAGE:=docker.elastic.co/fleet-server/fleet-server-fips
 STANDALONE_DOCKERFILE=Dockerfile.fips
-PLATFORMS = linux/amd64 linux/arm64
 gobuildtags += requirefips
 GOFIPSEXPERIMENT=GOEXPERIMENT=systemcrypto CGO_ENABLED=1
 FIPSSUFFIX=-fips

--- a/Makefile
+++ b/Makefile
@@ -51,22 +51,18 @@ else
 VERSION=${DEFAULT_VERSION}
 endif
 
+DOCKER_IMAGE?=docker.elastic.co/fleet-server/fleet-server
 DOCKER_PLATFORMS ?= linux/amd64 linux/arm64
 # defing the docker image tag used for stand-alone fleet-server images
 # only want to define the tag if none is specified, this allows an invocation like
 #    FIPS=true make test-e2e
 # to use a tag like X.Y.Z-fips and not X.Y.Z-fips-fips as the test-e2e target calls into make
-# TODO: We should change FIPS stand-alone/e2e images to use fleet-server-fips:TAG instead of fleet-server:TAG-fips
 ifndef DOCKER_IMAGE_TAG
 DOCKER_IMAGE_TAG?=${VERSION}
 ifeq "${DEV}" "true"
 DOCKER_IMAGE_TAG:=${DOCKER_IMAGE_TAG}-dev
 endif
-ifeq "${FIPS}" "true"
-DOCKER_IMAGE_TAG:=${DOCKER_IMAGE_TAG}-fips
 endif
-endif
-DOCKER_IMAGE?=docker.elastic.co/fleet-server/fleet-server
 
 PLATFORM_TARGETS=$(addprefix release-, $(PLATFORMS))
 COVER_TARGETS=$(addprefix cover-, $(PLATFORMS))
@@ -95,6 +91,7 @@ GOFIPSEXPERIMENT?=
 FIPSSUFFIX=
 ifeq "${FIPS}" "true"
 BUILDER_IMAGE=fleet-server-fips-builder:${GO_VERSION}
+DOCKER_IMAGE:=docker.elastic.co/fleet-server/fleet-server-fips
 STANDALONE_DOCKERFILE=Dockerfile.fips
 PLATFORMS = linux/amd64 linux/arm64
 gobuildtags += requirefips

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GO_VERSION=$(shell cat '.go-version')
 DEFAULT_VERSION=$(shell awk '/const DefaultVersion/{print $$NF}' version/version.go | tr -d '"')
 
 # Set FIPS=true to force FIPS compliance when building
-FIPS?=
+FIPS?=false
 
 ifeq "${FIPS}" "true"
 PLATFORMS ?= linux/amd64 linux/arm64

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ BUILDER_IMAGE=fleet-server-fips-builder:${GO_VERSION}
 STANDALONE_DOCKERFILE=Dockerfile.fips
 PLATFORMS = linux/amd64 linux/arm64
 gobuildtags += requirefips
-GOFIPSEXPERIMENT=GOEXPERIMENT=systemcrypto
+GOFIPSEXPERIMENT=GOEXPERIMENT=systemcrypto CGO_ENABLED=1
 FIPSSUFFIX=-fips
 endif
 
@@ -148,7 +148,7 @@ $(COVER_TARGETS): cover-%: ## - Build a binary with the -cover flag for integrat
 	$(eval $@_GO_ARCH := $(lastword $(subst /, ,$(lastword $(subst cover-, ,$@)))))
 	$(eval $@_ARCH := $(TARGET_ARCH_$($@_GO_ARCH)))
 	$(eval $@_BUILDMODE:= $(BUILDMODE_$($@_OS)_$($@_GO_ARCH)))
-	GOOS=$($@_OS) GOARCH=$($@_GO_ARCH) ${GOFIPSEXPERIMENT} go build -tags=${GOBUILDTAGS} -cover -coverpkg=./... -gcflags="${GCFLAGS}" -ldflags="${LDFLAGS}" $($@_BUILDMODE) -o build/cover/fleet-server-$(VERSION)-$($@_OS)-$($@_ARCH)$(FIPSSUFFIX)/fleet-server$(if $(filter windows,$($@_OS)),.exe,) .
+	GOOS=$($@_OS) GOARCH=$($@_GO_ARCH) ${GOFIPSEXPERIMENT} go build -tags=${GOBUILDTAGS} -cover -coverpkg=./... -gcflags="${GCFLAGS}" -ldflags="${LDFLAGS}" $($@_BUILDMODE) -o build/cover/fleet-server$(FIPSSUFFIX)-$(VERSION)-$($@_OS)-$($@_ARCH)/fleet-server$(if $(filter windows,$($@_OS)),.exe,) .
 
 .PHONY: clean
 clean: ## - Clean up build artifacts
@@ -263,7 +263,7 @@ $(PLATFORM_TARGETS): release-%:
 	$(eval $@_GO_ARCH := $(lastword $(subst /, ,$(lastword $(subst release-, ,$@)))))
 	$(eval $@_ARCH := $(TARGET_ARCH_$($@_GO_ARCH)))
 	$(eval $@_BUILDMODE:= $(BUILDMODE_$($@_OS)_$($@_GO_ARCH)))
-	GOOS=$($@_OS) GOARCH=$($@_GO_ARCH) ${GOFIPSEXPERIMENT} go build -tags=${GOBUILDTAGS} -gcflags="${GCFLAGS}" -ldflags="${LDFLAGS}" $($@_BUILDMODE) -o build/binaries/fleet-server-$(VERSION)-$($@_OS)-$($@_ARCH)$(FIPSSUFFIX)/fleet-server .
+	GOOS=$($@_OS) GOARCH=$($@_GO_ARCH) ${GOFIPSEXPERIMENT} go build -tags=${GOBUILDTAGS} -gcflags="${GCFLAGS}" -ldflags="${LDFLAGS}" $($@_BUILDMODE) -o build/binaries/fleet-server$(FIPSSUFFIX)-$(VERSION)-$($@_OS)-$($@_ARCH)/fleet-server .
 	@$(MAKE) OS=$($@_OS) ARCH=$($@_ARCH) package-target
 
 .PHONY: build-docker
@@ -307,8 +307,8 @@ else ifeq ($(OS)-$(ARCH),darwin-arm64)
 	@tar -C build/binaries -zcf build/distributions/fleet-server-$(VERSION)-$(OS)-aarch64.tar.gz fleet-server-$(VERSION)-$(OS)-aarch64
 	@cd build/distributions && sha512sum fleet-server-$(VERSION)-$(OS)-aarch64.tar.gz > fleet-server-$(VERSION)-$(OS)-aarch64.tar.gz.sha512
 else
-	@tar -C build/binaries -zcf build/distributions/fleet-server-$(VERSION)-$(OS)-$(ARCH)$(FIPSSUFFIX).tar.gz fleet-server-$(VERSION)-$(OS)-$(ARCH)$(FIPSSUFFIX)
-	@cd build/distributions && sha512sum fleet-server-$(VERSION)-$(OS)-$(ARCH)$(FIPSSUFFIX).tar.gz > fleet-server-$(VERSION)-$(OS)-$(ARCH)$(FIPSSUFFIX).tar.gz.sha512
+	@tar -C build/binaries -zcf build/distributions/fleet-server$(FIPSSUFFIX)-$(VERSION)-$(OS)-$(ARCH).tar.gz fleet-server$(FIPSSUFFIX)-$(VERSION)-$(OS)-$(ARCH)
+	@cd build/distributions && sha512sum fleet-server$(FIPSSUFFIX)-$(VERSION)-$(OS)-$(ARCH).tar.gz > fleet-server$(FIPSSUFFIX)-$(VERSION)-$(OS)-$(ARCH).tar.gz.sha512
 endif
 
 build-releaser: ## - Build a Docker image to run make package including all build tools

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ DOCKER_PLATFORMS ?= linux/amd64 linux/arm64
 # only want to define the tag if none is specified, this allows an invocation like
 #    FIPS=true make test-e2e
 # to use a tag like X.Y.Z-fips and not X.Y.Z-fips-fips as the test-e2e target calls into make
+# TODO: We should change FIPS stand-alone/e2e images to use fleet-server-fips:TAG instead of fleet-server:TAG-fips
 ifndef DOCKER_IMAGE_TAG
 DOCKER_IMAGE_TAG?=${VERSION}
 ifeq "${DEV}" "true"

--- a/dev-tools/e2e/Dockerfile
+++ b/dev-tools/e2e/Dockerfile
@@ -2,18 +2,16 @@ ARG ELASTIC_AGENT_IMAGE # e.g. docker.elastic.co/cloud-release/elastic-agent-clo
 
 FROM --platform=linux/amd64 ${ELASTIC_AGENT_IMAGE} as elastic_agent_amd64
 ARG STACK_VERSION # e.g. 8.5.0-SNAPSHOT
-ARG FLEET_SUFFIX # e.g. -linux-x86_64
 ARG FLEET_FIPS="" # should be -fips if a fips distribution will be used
 ARG VCS_REF_SHORT # e.g. abc123
-ONBUILD COPY --chmod=0755 --chown=elastic-agent cover/fleet-server${FLEET_FIPS}-${STACK_VERSION}${FLEET_SUFFIX}/fleet-server \
+ONBUILD COPY --chmod=0755 --chown=elastic-agent cover/fleet-server${FLEET_FIPS}-${STACK_VERSION}-linux-x86_64/fleet-server \
              ./data/elastic-agent-${VCS_REF_SHORT}/components/fleet-server
 
 FROM --platform=linux/arm64 ${ELASTIC_AGENT_IMAGE} as elastic_agent_arm64
 ARG STACK_VERSION # e.g. 8.5.0-SNAPSHOT
-ARG FLEET_SUFFIX # e.g. -linux-x86_64
 ARG FLEET_FIPS="" # should be -fips if a fips distribution will be used
 ARG VCS_REF_SHORT # e.g. abc123
-ONBUILD COPY --chmod=0755 --chown=elastic-agent cover/fleet-server${FLEET_FIPS}-${STACK_VERSION}${FLEET_SUFFIX}/fleet-server \
+ONBUILD COPY --chmod=0755 --chown=elastic-agent cover/fleet-server${FLEET_FIPS}-${STACK_VERSION}-linux-arm64/fleet-server \
              ./data/elastic-agent-${VCS_REF_SHORT}/components/fleet-server
 
 FROM elastic_agent_${TARGETARCH}

--- a/dev-tools/e2e/Dockerfile
+++ b/dev-tools/e2e/Dockerfile
@@ -3,15 +3,17 @@ ARG ELASTIC_AGENT_IMAGE # e.g. docker.elastic.co/cloud-release/elastic-agent-clo
 FROM --platform=linux/amd64 ${ELASTIC_AGENT_IMAGE} as elastic_agent_amd64
 ARG STACK_VERSION # e.g. 8.5.0-SNAPSHOT
 ARG FLEET_SUFFIX # e.g. -linux-x86_64
+ARG FLEET_FIPS="" # should be -fips if a fips distribution will be used
 ARG VCS_REF_SHORT # e.g. abc123
-ONBUILD COPY --chmod=0755 --chown=elastic-agent cover/fleet-server-${STACK_VERSION}${FLEET_SUFFIX}/fleet-server \
+ONBUILD COPY --chmod=0755 --chown=elastic-agent cover/fleet-server${FLEET_FIPS}-${STACK_VERSION}${FLEET_SUFFIX}/fleet-server \
              ./data/elastic-agent-${VCS_REF_SHORT}/components/fleet-server
 
 FROM --platform=linux/arm64 ${ELASTIC_AGENT_IMAGE} as elastic_agent_arm64
 ARG STACK_VERSION # e.g. 8.5.0-SNAPSHOT
 ARG FLEET_SUFFIX # e.g. -linux-x86_64
+ARG FLEET_FIPS="" # should be -fips if a fips distribution will be used
 ARG VCS_REF_SHORT # e.g. abc123
-ONBUILD COPY --chmod=0755 --chown=elastic-agent cover/fleet-server-${STACK_VERSION}${FLEET_SUFFIX}/fleet-server \
+ONBUILD COPY --chmod=0755 --chown=elastic-agent cover/fleet-server${FLEET_FIPS}-${STACK_VERSION}${FLEET_SUFFIX}/fleet-server \
              ./data/elastic-agent-${VCS_REF_SHORT}/components/fleet-server
 
 FROM elastic_agent_${TARGETARCH}

--- a/dev-tools/e2e/build.sh
+++ b/dev-tools/e2e/build.sh
@@ -25,7 +25,7 @@ VCS_REF=$(docker inspect -f '{{index .Config.Labels "org.label-schema.vcs-ref"}}
 CUSTOM_IMAGE_TAG=${STACK_VERSION}-e2e-${COMMIT}-$(date +%s)
 
 FLEET_FIPS=""
-if [[ "$FIPS" == "true" ]]; then
+if [[ "${FIPS:-false}" == "true" ]]; then
     FLEET_FIPS="-fips"
 fi
 

--- a/dev-tools/e2e/build.sh
+++ b/dev-tools/e2e/build.sh
@@ -24,10 +24,6 @@ VCS_REF=$(docker inspect -f '{{index .Config.Labels "org.label-schema.vcs-ref"}}
 
 CUSTOM_IMAGE_TAG=${STACK_VERSION}-e2e-${COMMIT}-$(date +%s)
 
-FLEET_SUFFIX="-linux-x86_64"
-if [[ "$GOARCH" == "arm64" ]]; then
-    FLEET_SUFFIX="-linux-arm64"
-fi
 FLEET_FIPS=""
 if [[ "$FIPS" == "true" ]]; then
     FLEET_FIPS="-fips"
@@ -37,7 +33,6 @@ docker build \
 	-f $REPO_ROOT/dev-tools/e2e/Dockerfile \
 	--build-arg ELASTIC_AGENT_IMAGE=$BASE_IMAGE \
 	--build-arg STACK_VERSION=${FLEET_VERSION} \
-	--build-arg FLEET_SUFFIX=${FLEET_SUFFIX} \
 	--build-arg FLEET_FIPS=${FLEET_FIPS} \
 	--build-arg VCS_REF_SHORT=${VCS_REF:0:6} \
 	--platform linux/$GOARCH \

--- a/dev-tools/e2e/build.sh
+++ b/dev-tools/e2e/build.sh
@@ -28,8 +28,9 @@ FLEET_SUFFIX="-linux-x86_64"
 if [[ "$GOARCH" == "arm64" ]]; then
     FLEET_SUFFIX="-linux-arm64"
 fi
+FLEET_FIPS=""
 if [[ "$FIPS" == "true" ]]; then
-    FLEET_SUFFIX="${FLEET_SUFFIX}-fips"
+    FLEET_FIPS="-fips"
 fi
 
 docker build \
@@ -37,6 +38,7 @@ docker build \
 	--build-arg ELASTIC_AGENT_IMAGE=$BASE_IMAGE \
 	--build-arg STACK_VERSION=${FLEET_VERSION} \
 	--build-arg FLEET_SUFFIX=${FLEET_SUFFIX} \
+	--build-arg FLEET_FIPS=${FLEET_FIPS} \
 	--build-arg VCS_REF_SHORT=${VCS_REF:0:6} \
 	--platform linux/$GOARCH \
 	-t ${CI_ELASTIC_AGENT_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG} \

--- a/docs/fips.md
+++ b/docs/fips.md
@@ -36,7 +36,7 @@ The following make commands have different behaviour when FIPS is enabled:
 A Multipass VM created with `FIPS=true make multipass` is able to compile FIPS enabled golang programs, but is not able to run them.
 When you try to run one the following error occurs:
 ```
-GOFIPS=1 ./bin/fleet-server -c fleet-server.yml
+GODEBUG=fips140=on ./bin/fleet-server -c fleet-server.yml
 panic: opensslcrypto: can't enable FIPS mode for OpenSSL 3.0.13 30 Jan 2024: openssl: FIPS mode not supported by any provider
 
 goroutine 1 [running]:
@@ -92,14 +92,14 @@ activate = 1
 default_properties = fips=yes
 ```
 
-4. Run the program with the `OPENSSL_CONF=openssl.cnf` and `GOFIPS=1` env vars, i.e.,
+4. Run the program with the `OPENSSL_CONF=openssl.cnf` and `GODEBUG=fips140=on` env vars, i.e.,
 ```
-OPENSSL_CONF=./openssl.cnf GOFIPS=1 ./bin/fleet-server -c fleet-server.yml
+OPENSSL_CONF=./openssl.cnf GODEBUG=fips140=on ./bin/fleet-server -c fleet-server.yml
 23:48:47.871 INF Boot fleet-server args=["-c","fleet-server.yml"] commit=55104f6f ecs.version=1.6.0 exe=./bin/fleet-server pid=65037 ppid=5642 service.name=fleet-server service.type=fleet-server version=9.0.0
 i...
 ```
 
 ## Usage
 
-A FIPS enabled binary should be ran with the env var `GOFIPS=1` set.
+A FIPS enabled binary should be ran with the env var `GODEBUG=fips140=on` set.
 The system/image is required to have a FIPS compliant provider available.

--- a/testing/e2e/fips_test.go
+++ b/testing/e2e/fips_test.go
@@ -39,7 +39,7 @@ func (suite *FIPSStandAlone) SetupSuite() {
 		arch = "x86_64"
 	}
 	// NOTE the path checked is hardcoded to linux as we currently only support linux for FIPS builds
-	path, err := filepath.Abs(filepath.Join("..", "..", "build", "cover", fmt.Sprintf("fleet-server-%s-SNAPSHOT-linux-%s-fips", version.DefaultVersion, arch), binaryName))
+	path, err := filepath.Abs(filepath.Join("..", "..", "build", "cover", fmt.Sprintf("fleet-server-fips-%s-SNAPSHOT-linux-%s", version.DefaultVersion, arch), binaryName))
 	suite.Require().NoError(err)
 	suite.binaryPath = path
 	_, err = os.Stat(suite.binaryPath)


### PR DESCRIPTION
## What is the problem this PR solves?

Provide FIPS dra artifacts.

## How does this PR solve the problem?

Add `FIPS="true"` env flag to packageing pipeline.
Packaging pipline uses microsoft/go instead of golang/go to build DRA artifacts for FIPS.
Change package name from `fleet-server-*-fips` to `fleet-server-fips-*`.

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)~~


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
