### PR TITLE
Add go1.24 GODEBUG=fips140=only test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -87,6 +87,17 @@ steps:
           - build/*.xml
           - build/coverage*.out
 
+      - label: ":smartbear-testexecute: Run FIPS unit tests"
+        key: unit-test-fips
+        command: ".buildkite/scripts/unit_test.sh"
+        env:
+          FIPS: "true"
+        agents:
+          provider: "gcp"
+        artifact_paths:
+          - build/*.xml
+          - build/coverage*.out
+
       - label: ":smartbear-testexecute: Run unit tests: MacOS 13"
         key: unit-test-macos-13
         command: ".buildkite/scripts/unit_test.sh"

--- a/.buildkite/scripts/unit_test.sh
+++ b/.buildkite/scripts/unit_test.sh
@@ -9,4 +9,8 @@ add_bin_path
 with_go
 
 echo "Starting the unit tests..."
-make test-unit junit-report
+if [ ${FIPS} = "true" ]; then
+    make test-unit-fips junit-report
+else
+    make test-unit junit-report
+fi

--- a/.buildkite/scripts/unit_test.sh
+++ b/.buildkite/scripts/unit_test.sh
@@ -9,7 +9,7 @@ add_bin_path
 with_go
 
 echo "Starting the unit tests..."
-if [ ${FIPS} = "true" ]; then
+if [[ ${FIPS:-} == "true" ]]; then
     make test-unit-fips junit-report
 else
     make test-unit junit-report

--- a/Makefile
+++ b/Makefile
@@ -221,9 +221,16 @@ test: prepare-test-context  ## - Run all tests
 test-release:  ## - Check that all release binaries are created
 	./.buildkite/scripts/test-release.sh $(DEFAULT_VERSION)
 
+# If FIPS=true unit tests need microsoft/go + OpenSSL with FIPS
 .PHONY: test-unit
 test-unit: prepare-test-context  ## - Run unit tests only
-	set -o pipefail; go test ${GO_TEST_FLAG} -tags=$(GOBUILDTAGS) -v -race -coverprofile=build/coverage-${OS_NAME}.out ./... | tee build/test-unit-${OS_NAME}.out
+	set -o pipefail; ${GOFIPSEXPERIMENT} go test ${GO_TEST_FLAG} -tags=$(GOBUILDTAGS) -v -race -coverprofile=build/coverage-${OS_NAME}.out ./... | tee build/test-unit-${OS_NAME}.out
+
+# FIPS unit tests are meant to use go v1.24 to check FIPS compliance.
+# This check is very strict, and should be thought of as a static-code analysis tool.
+.PHONY: test-unit-fips
+test-unit-fips: ## - Run unit tests with go 1.24's fips140=only for testing
+	set -o pipefail; GODEBUG=fips140=only go test ${GO_TEST_FLAG} -tags=$(GOBUILDTAGS) -v -race -coverprofile=build/coverage-${OS_NAME}.out ./... | tee build/test-unit-fips-${OS_NAME}.out
 
 .PHONY: benchmark
 benchmark: prepare-test-context install-benchstat  ## - Run benchmark tests only

--- a/Makefile
+++ b/Makefile
@@ -229,8 +229,8 @@ test-unit: prepare-test-context  ## - Run unit tests only
 # FIPS unit tests are meant to use go v1.24 to check FIPS compliance.
 # This check is very strict, and should be thought of as a static-code analysis tool.
 .PHONY: test-unit-fips
-test-unit-fips: ## - Run unit tests with go 1.24's fips140=only for testing
-	set -o pipefail; GODEBUG=fips140=only go test ${GO_TEST_FLAG} -tags=$(GOBUILDTAGS) -v -race -coverprofile=build/coverage-${OS_NAME}.out ./... | tee build/test-unit-fips-${OS_NAME}.out
+test-unit-fips: prepare-test-context  ## - Run unit tests with go 1.24's fips140=only for testing
+	set -o pipefail; GOFIPS140=latest GODEBUG=fips140=only go test ${GO_TEST_FLAG} -tags=$(GOBUILDTAGS) -v -race -coverprofile=build/coverage-${OS_NAME}.out ./... | tee build/test-unit-fips-${OS_NAME}.out
 
 .PHONY: benchmark
 benchmark: prepare-test-context install-benchstat  ## - Run benchmark tests only


### PR DESCRIPTION
## What is the problem this PR solves?

Validate FIPS compliance by using go 1.24's fips features.

## How does this PR solve the problem?

Add a new target that uses [GODEBUG=fips140=only](https://go.dev/doc/security/fips140) to run unit tests.
This target should use the `FIPS=true` flag in order to pass `-tags=requirefips`.

Note that this target assumes golang/go and **NOT** microsoft/go.
In order to use microsoft/go to run these test we would need to install in the environment, and have a FIPS enabled OpenSSL on the system.

## How to test this PR locally

`FIPS=true make test-unit-fips`

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)~~