### PR TITLE
Remove WithUsrPwd

### DIFF
--- a/internal/pkg/bulk/setup_test.go
+++ b/internal/pkg/bulk/setup_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Pallinder/go-randomdata"
+	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-ucfg/yaml"
 	"github.com/rs/xid"
 
@@ -133,7 +134,11 @@ func SetupBulk(ctx context.Context, t testing.TB, opts ...BulkOpt) Bulk {
 
 	// Set up the client with username and password since this test is generic for any index and uses it's own index/mapping
 	e := getEnvironment()
-	cli, err := es.NewClient(ctx, &defaultCfg, false, es.WithUsrPwd(e.Username, e.Password))
+	cli, err := es.NewClient(ctx, &defaultCfg, false, func(config *elasticsearch.Config) {
+		config.ServiceToken = "" // reset service token
+		config.Username = e.Username
+		config.Password = e.Password
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pkg/es/client.go
+++ b/internal/pkg/es/client.go
@@ -100,15 +100,6 @@ func WithUserAgent(name string, bi build.Info) ConfigOption {
 	}
 }
 
-// WithUsrPwd is intended to be used by integration tests ONLY!
-func WithUsrPwd(usr, pwd string) ConfigOption {
-	return func(config *elasticsearch.Config) {
-		config.ServiceToken = "" // reset service token
-		config.Username = usr
-		config.Password = pwd
-	}
-}
-
 func InstrumentRoundTripper() ConfigOption {
 	return func(config *elasticsearch.Config) {
 		config.Transport = apmelasticsearch.WrapRoundTripper(


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

Removes the `es.WithUsrPwd` to ensure that it is not used outside of tests.

## How does this PR solve the problem?

Prevents mis-use in production code.
