### PR TITLE
fix(6208): set default to https, updated unit tests

### DIFF
--- a/internal/pkg/bulk/setup_test.go
+++ b/internal/pkg/bulk/setup_test.go
@@ -26,16 +26,19 @@ import (
 
 var rand = rnd.New()
 
-var defaultCfg config.Config
-var defaultCfgData = []byte(`
+var (
+	defaultCfg     config.Config
+	defaultCfgData = []byte(`
 output:
   elasticsearch:
     hosts: '${ELASTICSEARCH_HOSTS:localhost:9200}'
     service_token: '${ELASTICSEARCH_SERVICE_TOKEN:test-token}'
+    protocol: http
 fleet:
   agent:
     id: 1e4954ce-af37-4731-9f4a-407b08e69e42
 `)
+)
 
 const testPolicy = `{
 	"properties": {

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -583,7 +583,7 @@ func defaultFleet() Fleet {
 
 func defaultElastic() Elasticsearch {
 	return Elasticsearch{
-		Protocol:         "http",
+		Protocol:         "https",
 		ServiceToken:     "test-token",
 		Hosts:            []string{"localhost:9200"},
 		MaxRetries:       3,

--- a/internal/pkg/config/output.go
+++ b/internal/pkg/config/output.go
@@ -26,8 +26,10 @@ import (
 
 // The timeout would be driven by the server for long poll.
 // Giving it some sane long value.
-const httpTransportLongPollTimeout = 10 * time.Minute
-const schemeHTTP = "http"
+const (
+	httpTransportLongPollTimeout = 10 * time.Minute
+	schemeHTTP                   = "https"
+)
 
 var hasScheme = regexp.MustCompile(`^([a-z][a-z0-9+\-.]*)://`)
 

--- a/internal/pkg/config/output_test.go
+++ b/internal/pkg/config/output_test.go
@@ -204,7 +204,7 @@ func TestToESConfig(t *testing.T) {
 			require.NoError(t, err)
 
 			// cmp.Diff can't handle function pointers.
-			res.Transport.(*http.Transport).Proxy = nil
+			res.Transport.(*http.Transport).Proxy = nil //nolint:errcheck // skipping error check in test
 
 			test.result.Header.Set("X-elastic-product-origin", "fleet")
 			assert.True(t, cmp.Equal(test.result, res, copts...), "mismatch (-want +got)\n%s", cmp.Diff(test.result, res, copts...))
@@ -225,7 +225,7 @@ func TestToESConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		expect := elasticsearch.Config{
-			Addresses:    []string{"http://localhost:9200"},
+			Addresses:    []string{"https://localhost:9200"},
 			ServiceToken: "test-token",
 			Header:       http.Header{"X-Elastic-Product-Origin": []string{"fleet"}},
 			MaxRetries:   3,
@@ -240,7 +240,7 @@ func TestToESConfig(t *testing.T) {
 			},
 		}
 
-		es.Transport.(*http.Transport).Proxy = nil
+		es.Transport.(*http.Transport).Proxy = nil //nolint:errcheck // skipping error check in test
 		assert.True(t, cmp.Equal(expect, es, copts...), "mismatch (-want +got)\n%s", cmp.Diff(expect, es, copts...))
 	})
 
@@ -258,7 +258,7 @@ func TestToESConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		expect := elasticsearch.Config{
-			Addresses:  []string{"http://localhost:9200"},
+			Addresses:  []string{"https://localhost:9200"},
 			Header:     http.Header{"X-Elastic-Product-Origin": []string{"fleet"}},
 			MaxRetries: 3,
 			Transport: &http.Transport{
@@ -272,7 +272,7 @@ func TestToESConfig(t *testing.T) {
 			},
 		}
 
-		es.Transport.(*http.Transport).Proxy = nil
+		es.Transport.(*http.Transport).Proxy = nil //nolint:errcheck // skipping error check in test
 		assert.True(t, cmp.Equal(expect, es, copts...), "mismatch (-want +got)\n%s", cmp.Diff(expect, es, copts...))
 	})
 
@@ -390,7 +390,7 @@ func Test_Elasticsearch_DiagRequests(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:usetesting // using context.Background not t.Context
 	defer cancel()
 	es := &Elasticsearch{}
 	es.InitDefaults()

--- a/internal/pkg/testing/fleet-server-testing.yml
+++ b/internal/pkg/testing/fleet-server-testing.yml
@@ -1,7 +1,8 @@
 output:
   elasticsearch:
-    hosts: '${ELASTICSEARCH_HOSTS:localhost:9200}'
-    service_token: '${ELASTICSEARCH_SERVICE_TOKEN}'
+    hosts: "${ELASTICSEARCH_HOSTS:localhost:9200}"
+    service_token: "${ELASTICSEARCH_SERVICE_TOKEN}"
+    protocol: http
 
 fleet:
   agent:

--- a/internal/pkg/testing/setup.go
+++ b/internal/pkg/testing/setup.go
@@ -24,16 +24,19 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/testing/esutil"
 )
 
-var defaultCfg config.Config
-var defaultCfgData = []byte(`
+var (
+	defaultCfg     config.Config
+	defaultCfgData = []byte(`
 output:
   elasticsearch:
     hosts: '${ELASTICSEARCH_HOSTS:localhost:9200}'
     service_token: '${ELASTICSEARCH_SERVICE_TOKEN:test-token}'
+    protocol: http
 fleet:
   agent:
     id: 1e4954ce-af37-4731-9f4a-407b08e69e42
 `)
+)
 
 func init() {
 	c, err := yaml.NewConfig(defaultCfgData, config.DefaultOptions...)


### PR DESCRIPTION
- Bug

## What is the problem this PR solves?

Sets default scheme to https

## How does this PR solve the problem?

set the schemeHTTP constant to https in config/output.go

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->


