### PR TITLE
chore(deps): configure Dependabot to update all dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,6 @@ updates:
       - automation
       - dependency
       - Team:Elastic-Agent-Control-Plane
-    allow:
-      # Only update internal dependencies for now while we evaluate this workflow.
-      - dependency-name: "github.com/elastic/*"
-      - dependency-name: "go.elastic.co/*"
     open-pull-requests-limit: 10
     groups:
       elastic-apm:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,10 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/"
+    directories:
+      - "/"
+      - "/pkg/api/"
+      - "/testing/"
     schedule:
       interval: "daily"
     labels:


### PR DESCRIPTION
## What is the problem this PR solves?

The dependencies in `/pkg/api/go.mod` and `/testing/go.mod` were not updated automatically, resulting in outdated and potentially vulnerable packages being used. As for the `/go.mod` updates, we were only updating Elastic dependencies. 

We should be updating all dependencies (not only Elastic ones) in all go.mod files across the repository.

## How does this PR solve the problem?

Configures Dependabot to update all dependencies in all three `go.mod` files.