### PR TITLE
Bump up version of golangci/golangci-lint-action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,7 +25,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.51.2
+          version: v1.64.5
 
           # Give the job more time to execute.
           args: --timeout=5m


### PR DESCRIPTION
## What is the problem this PR solves?

Bumps up the version of the `golangci/golangci-lint-action` GitHub action that's run as part of CI checks.

## How does this PR solve the problem?

This check is failing without explanation on PRs made to the `7.17` branch while it's passing on the same PRs made to `main` and other newer branches.  These other branches have a newer version of the action, so this PR makes the `7.17` branch have the same version.

