### PR TITLE
Clear upgrade_attempts on handleAck

### DIFF
--- a/internal/pkg/api/handleAck.go
+++ b/internal/pkg/api/handleAck.go
@@ -619,6 +619,7 @@ func (ack *AckT) handleUpgrade(ctx context.Context, zlog zerolog.Logger, agent *
 			dl.FieldUpgradeStartedAt: nil,
 			dl.FieldUpgradeStatus:    nil,
 			dl.FieldUpgradedAt:       now,
+			dl.FieldUpgradeAttempts:  nil,
 		}
 	}
 

--- a/internal/pkg/api/handleAck.go
+++ b/internal/pkg/api/handleAck.go
@@ -619,7 +619,9 @@ func (ack *AckT) handleUpgrade(ctx context.Context, zlog zerolog.Logger, agent *
 			dl.FieldUpgradeStartedAt: nil,
 			dl.FieldUpgradeStatus:    nil,
 			dl.FieldUpgradedAt:       now,
-			dl.FieldUpgradeAttempts:  nil,
+		}
+		if agent.UpgradeDetails == nil {
+			doc[dl.FieldUpgradeAttempts] = nil
 		}
 	}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

`upgrade_attempts` were not cleared correctly when agent doesn't have `upgrade_details` (for example in horde or older versions).

## How does this PR solve the problem?

Clear `upgrade_attempts` when upgrade is acked (at the same time when `upgrade_started_at` field is cleared).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

Test with agent policy with auto upgrade config and a few horde agents enrolled. Verify that after the upgrade completed, `upgrade_attempts` is set to `null`.
The `upgrade_attempts` field is only cleared if there is no `upgrade_details`. Tested with a real agent upgraded to a non-existent version, the agent going to `UPG_FAILED` state.

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

Relates https://github.com/elastic/fleet-server/pull/4528
Relates https://github.com/elastic/kibana/pull/212744
