### PR TITLE
Fix diagnostic requests when scheme is not included in host

### DIFF
--- a/changelog/fragments/1743692296-fix-url-parsing-es-output-diagnostics.yaml
+++ b/changelog/fragments/1743692296-fix-url-parsing-es-output-diagnostics.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Fix host parsing in Elasticsearch output diagnostics
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: fleet-server
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/changelog/fragments/1743692296-fix-url-parsing-es-output-diagnostics.yaml
+++ b/changelog/fragments/1743692296-fix-url-parsing-es-output-diagnostics.yaml
@@ -25,7 +25,7 @@ component: fleet-server
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/fleet-server/pull/4765
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.

--- a/internal/pkg/config/output.go
+++ b/internal/pkg/config/output.go
@@ -256,16 +256,13 @@ func (c *Elasticsearch) DiagRequests(ctx context.Context) []byte {
 
 	var res bytes.Buffer
 	for _, host := range c.Hosts {
-		u, err := url.Parse(host)
+		hostURL, err := makeURL(c.Protocol, "", host, 9200)
 		if err != nil {
 			zerolog.Ctx(ctx).Warn().Err(err).Str("host", host).Msg("Unable to transform host to url.URL")
 			res.WriteString(fmt.Sprintf("Unable to transform host %q to url.URL: %v\n", host, err))
 			continue
 		}
-		if u.Scheme == "" {
-			u.Scheme = c.Protocol
-		}
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, hostURL, nil)
 		if err != nil {
 			zerolog.Ctx(ctx).Warn().Err(err).Str("host", host).Msg("Unable to create request to host")
 			res.WriteString(fmt.Sprintf("Unable to create request to host %q: %v\n", host, err))

--- a/internal/pkg/config/output_test.go
+++ b/internal/pkg/config/output_test.go
@@ -10,8 +10,10 @@ package config
 import (
 	"context"
 	"crypto/tls"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -392,11 +394,28 @@ func Test_Elasticsearch_DiagRequests(t *testing.T) {
 	defer srv.Close()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	es := &Elasticsearch{}
-	es.InitDefaults()
-	es.Hosts = []string{srv.URL}
 
-	p := es.DiagRequests(ctx)
-	require.NotEmpty(t, p)
-	require.Contains(t, string(p), "request 0 successful.")
+	t.Run("scheme included", func(t *testing.T) {
+		es := &Elasticsearch{}
+		es.InitDefaults()
+		es.Hosts = []string{srv.URL}
+
+		p := es.DiagRequests(ctx)
+		require.NotEmpty(t, p)
+		require.Contains(t, string(p), "request 0 successful.")
+	})
+
+	t.Run("split scheme", func(t *testing.T) {
+		es := &Elasticsearch{}
+		es.InitDefaults()
+
+		srvURL, err := url.Parse(srv.URL)
+		require.NoError(t, err)
+		es.Protocol = srvURL.Scheme
+		es.Hosts = []string{net.JoinHostPort(srvURL.Hostname(), srvURL.Port())}
+
+		p := es.DiagRequests(ctx)
+		require.NotEmpty(t, p)
+		require.Contains(t, string(p), "request 0 successful.")
+	})
 }


### PR DESCRIPTION
## What is the problem this PR solves?

Hosts in the Elasticsearch output are usually set without their scheme, in that case DiagRequests was not correctly parsing the URL, and errors like the following ones appear in the `fleet-server-output-request.txt` file in diagnostics:

```
2025/03/12 13:02:45.560990 No TLS settings
2025/03/12 13:02:45.560994 Proxy disable=false url=<nil>
2025/03/12 13:02:45.561027 Request 0 to somehost:2143 starting
2025/03/12 13:02:45.561049 request 0 error: unsupported protocol scheme "somehost"
```
```
Unable to transform host "127.0.0.1:37603" to url.URL: parse "127.0.0.1:37603": first path segment in URL cannot contain colon
error: 0 requests
```

## How does this PR solve the problem?

Instead of parsing the URL and try to add the scheme later, use the `makeURL` helper, that already takes these cases into account.

## How to test this PR locally

Check fleet-server diagnostics.

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [x] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)