### PR TITLE
split FIPS unit tests from fips140=only test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -98,6 +98,17 @@ steps:
           - build/*.xml
           - build/coverage*.out
 
+      - label: ":smartbear-testexecute: Run fips140=only unit tests"
+        key: unit-test-fips140-only
+        command: ".buildkite/scripts/fips140_test.sh"
+        env:
+          FIPS: "true"
+        agents:
+          provider: "gcp"
+        artifact_paths:
+          - build/*.xml
+          - build/coverage*.out
+
       - label: ":smartbear-testexecute: Run unit tests: MacOS 13"
         key: unit-test-macos-13
         command: ".buildkite/scripts/unit_test.sh"

--- a/.buildkite/scripts/fips140_test.sh
+++ b/.buildkite/scripts/fips140_test.sh
@@ -9,4 +9,5 @@ add_bin_path
 with_go
 
 echo "Starting the unit tests..."
-make test-unit junit-report
+make test-unit-fips junit-report
+

--- a/Makefile
+++ b/Makefile
@@ -221,10 +221,13 @@ test: prepare-test-context  ## - Run all tests
 test-release:  ## - Check that all release binaries are created
 	./.buildkite/scripts/test-release.sh $(DEFAULT_VERSION)
 
-# If FIPS=true unit tests need microsoft/go + OpenSSL with FIPS
 .PHONY: test-unit
 test-unit: prepare-test-context  ## - Run unit tests only
-	set -o pipefail; ${GOFIPSEXPERIMENT} go test ${GO_TEST_FLAG} -tags=$(GOBUILDTAGS) -v -race -coverprofile=build/coverage-${OS_NAME}.out ./... | tee build/test-unit-${OS_NAME}.out
+	set -o pipefail; go test ${GO_TEST_FLAG} -tags=$(GOBUILDTAGS) -v -race -coverprofile=build/coverage-${OS_NAME}.out ./... | tee build/test-unit-${OS_NAME}.out
+
+.PHONY: test-fips-provider-unit
+test-fips-provider-unit: prepare-test-context  ## - Run unit tests with GOEXPERIMENT=systemcrypto to check that system FIPS provider works
+	set -o pipefail; GOEXPERIMENT=systemcrypto CGO_ENABLED=1 go test ${GO_TEST_FLAG} -tags=$(GOBUILDTAGS) -v -race -coverprofile=build/coverage-${OS_NAME}.out ./... | tee build/test-unit-${OS_NAME}.out
 
 # FIPS unit tests are meant to use go v1.24 to check FIPS compliance.
 # This check is very strict, and should be thought of as a static-code analysis tool.


### PR DESCRIPTION
## What is the problem this PR solves?

Split the single "Run FIPS unit tests" in the buildkite pipeline into two steps,
- "Run FIPS unit tests" - runs unit tests with `-tags=requirefips`
- "Run fips140=only unit tests" - runs unit tests with `-tags=requirefips` and `GODEBUG=fips140=only`

This way it is easier to determine what causes a failure with FIPS functionality.

This also makes fleet-server consistent with the testing approach being implemented in elastic-agent and elastic-agent-libs.