### PR TITLE
Redact output log lines during bootstrap config

### DIFF
--- a/changelog/fragments/1744046917-Redact-output-in-bootstrap-config-logs.yaml
+++ b/changelog/fragments/1744046917-Redact-output-in-bootstrap-config-logs.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Redact output in bootstrap config logs
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: fleet-server
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/changelog/fragments/1744046917-Redact-output-in-bootstrap-config-logs.yaml
+++ b/changelog/fragments/1744046917-Redact-output-in-bootstrap-config-logs.yaml
@@ -25,7 +25,7 @@ component: fleet-server
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-#pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/fleet-server/pull/4775
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -149,7 +149,7 @@ func (c *Config) Merge(other *Config) (*Config, error) {
 	return cfg, nil
 }
 
-func redactOutput(cfg *Config) Output {
+func RedactOutput(cfg *Config) Output {
 	redacted := cfg.Output
 
 	if redacted.Elasticsearch.ServiceToken != "" {
@@ -241,7 +241,7 @@ func (c *Config) Redact() *Config {
 		HTTP:    c.HTTP,
 	}
 	redacted.Inputs[0].Server = redactServer(c)
-	redacted.Output = redactOutput(c)
+	redacted.Output = RedactOutput(c)
 	return redacted
 }
 

--- a/internal/pkg/server/agent.go
+++ b/internal/pkg/server/agent.go
@@ -705,7 +705,7 @@ func toOutput(data map[string]interface{}) (config.Output, error) {
 func (a *Agent) esOutputCheck(ctx context.Context, cfg map[string]interface{}) error {
 	outCfg, err := toOutput(cfg)
 	if err != nil {
-		return fmt.Errorf("unable to convert map into ouput object: %w", err)
+		return fmt.Errorf("unable to convert map into output object: %w", err)
 	}
 	cli, err := es.NewClient(ctx,
 		&config.Config{

--- a/internal/pkg/server/agent.go
+++ b/internal/pkg/server/agent.go
@@ -475,12 +475,14 @@ func (a *Agent) configFromUnits(ctx context.Context) (*config.Config, error) {
 		injectMissingOutputAttributes(ctx, outMap, bootstrap)
 
 		if err := a.esOutputCheck(ctx, outMap); err != nil {
+			redactedOut, _ := toOutput(outMap)
+			redactedOut = config.RedactOutput(&config.Config{Output: redactedOut})
 			if errors.Is(err, es.ErrElasticVersionConflict) || errors.Is(err, ver.ErrUnsupportedVersion) {
-				zerolog.Ctx(ctx).Error().Err(err).Interface("output", outMap).Msg("Elasticsearch version constraint failed for new output")
+				zerolog.Ctx(ctx).Error().Err(err).Interface("output", redactedOut).Msg("Elasticsearch version constraint failed for new output")
 			} else if errors.Is(err, context.Canceled) {
 				// ignore logging cancelation errors in the output check
 			} else {
-				zerolog.Ctx(ctx).Warn().Err(err).Interface("output", outMap).Msg("Failed Elasticsearch output configuration test, using bootstrap values.")
+				zerolog.Ctx(ctx).Warn().Err(err).Interface("output", redactedOut).Msg("Failed Elasticsearch output configuration test, using bootstrap values.")
 
 				// try to reload periodically
 				outputCtx, canceller := context.WithCancel(ctx)
@@ -674,14 +676,14 @@ func checkForCA(cfg map[string]interface{}) bool {
 	return false
 }
 
-func (a *Agent) esOutputCheck(ctx context.Context, data map[string]interface{}) error {
+func toOutput(data map[string]interface{}) (config.Output, error) {
 	var esOut config.Elasticsearch
 	temp, err := ucfg.NewFrom(data, config.DefaultOptions...)
 	if err != nil {
-		return err
+		return config.Output{}, err
 	}
 	if err := temp.Unpack(&esOut, config.DefaultOptions...); err != nil {
-		return err
+		return config.Output{}, err
 	}
 
 	const httpsSchema = "https"
@@ -695,12 +697,19 @@ func (a *Agent) esOutputCheck(ctx context.Context, data map[string]interface{}) 
 	if isHTTPS {
 		esOut.Protocol = httpsSchema
 	}
+	return config.Output{
+		Elasticsearch: esOut,
+	}, nil
+}
 
+func (a *Agent) esOutputCheck(ctx context.Context, cfg map[string]interface{}) error {
+	outCfg, err := toOutput(cfg)
+	if err != nil {
+		return fmt.Errorf("unable to convert map into ouput object: %w", err)
+	}
 	cli, err := es.NewClient(ctx,
 		&config.Config{
-			Output: config.Output{
-				Elasticsearch: esOut,
-			},
+			Output: outCfg,
 		},
 		false,
 		elasticsearchOptions(false, a.bi)..., // disable instrumentation for output config test
@@ -731,10 +740,11 @@ func (a *Agent) esOutputCheckLoop(ctx context.Context, delay time.Duration, cfg 
 			return
 		}
 		// connected to invalid ES version
+		outCfg, _ := toOutput(cfg)
 		if errors.Is(err, es.ErrElasticVersionConflict) || errors.Is(err, ver.ErrUnsupportedVersion) {
-			zerolog.Ctx(ctx).Error().Err(err).Interface("output", cfg).Msg("Elasticsearch version constraint failed for new output")
+			zerolog.Ctx(ctx).Error().Err(err).Interface("output", config.RedactOutput(&config.Config{Output: outCfg})).Msg("Elasticsearch version constraint failed for new output")
 			return
 		}
-		zerolog.Ctx(ctx).Debug().Err(err).Interface("output", cfg).Msgf("Async output check failed, will retry after %v", delay)
+		zerolog.Ctx(ctx).Debug().Err(err).Interface("output", config.RedactOutput(&config.Config{Output: outCfg})).Msgf("Async output check failed, will retry after %v", delay)
 	}
 }


### PR DESCRIPTION
## What is the problem this PR solves?

Redact output config during bootstrap config handling.

## How does this PR solve the problem?

Unpack map into `config.Output` and use existing redaction mechanisms.

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)