### PR TITLE
Rename buildkite test step to avoid confusion

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -87,8 +87,8 @@ steps:
           - build/*.xml
           - build/coverage*.out
 
-      - label: ":smartbear-testexecute: Run FIPS unit tests"
-        key: unit-test-fips
+      - label: ":smartbear-testexecute: Run unit tests with requirefips build tag"
+        key: unit-test-fips-tag
         command: ".buildkite/scripts/unit_test.sh"
         env:
           FIPS: "true"


### PR DESCRIPTION
Rename the step in buildkite so it is very clear that tests are ran for files (or libraries) that make use of the requirefips build tag.