### PR TITLE
Add version metadata to version command

### DIFF
--- a/changelog/fragments/1744831791-Add-version-metadata-to-version-command-output.yaml
+++ b/changelog/fragments/1744831791-Add-version-metadata-to-version-command-output.yaml
@@ -1,0 +1,34 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add version metadata to version command output
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  Add commit, buildtime, and FIPS distribution indicators to output of version command.
+  Add fips-distribution attribute to initial startup log.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: fleet-server
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/changelog/fragments/1744831791-Add-version-metadata-to-version-command-output.yaml
+++ b/changelog/fragments/1744831791-Add-version-metadata-to-version-command-output.yaml
@@ -27,7 +27,7 @@ component: fleet-server
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-#pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/fleet-server/pull/4820
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -49,6 +49,7 @@ func initLogger(cfg *config.Config, version, commit string) (*logger.Logger, err
 	log.Info().
 		Str("version", version).
 		Str("commit", commit).
+		Bool("fips-distribution", build.FIPSDistribution).
 		Int("pid", os.Getpid()).
 		Int("ppid", os.Getppid()).
 		Str("exe", os.Args[0]).
@@ -140,7 +141,7 @@ func NewCommand(bi build.Info) *cobra.Command {
 		Use:     build.ServiceName,
 		Short:   "Fleet Server controls a fleet of Elastic Agents",
 		RunE:    getRunCommand(bi),
-		Version: bi.Version,
+		Version: bi.FullVersion(),
 	}
 	cmd.Flags().StringP("config", "c", "fleet-server.yml", "Configuration for Fleet Server")
 	cmd.Flags().Bool(kAgentMode, false, "Running under execution of the Elastic Agent")

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -5,7 +5,10 @@
 // Package build contains build inforamtion that can be exposed during runtime.
 package build
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 const ServiceName = "fleet-server"
 
@@ -13,6 +16,10 @@ const ServiceName = "fleet-server"
 type Info struct {
 	Version, Commit string
 	BuildTime       time.Time
+}
+
+func (i Info) FullVersion() string {
+	return fmt.Sprintf("%s [%s built %s] (FIPS-distribution: %v)", i.Version, i.Commit, i.BuildTime, FIPSDistribution)
 }
 
 // Time parses the given string using RFC3339, or returns an empty time.Time.

--- a/internal/pkg/build/fips.go
+++ b/internal/pkg/build/fips.go
@@ -1,0 +1,9 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build requirefips
+
+package build
+
+const FIPSDistribution = true

--- a/internal/pkg/build/nofips.go
+++ b/internal/pkg/build/nofips.go
@@ -1,0 +1,9 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !requirefips
+
+package build
+
+const FIPSDistribution = false


### PR DESCRIPTION
## What is the problem this PR solves?

We are not able to determine if a fleet-server binary is a FIPS distribution or not.

## How does this PR solve the problem?

Add build commit, build time, and FIPS distribution indicator to the output of the version command. Add FIPS distribution indicator to initial log line.

## How to test this PR locally

Run: `./fleet-server -v`

Example output:

```
./bin/fleet-server -v
fleet-server version 9.1.0 [5500121e built 2025-04-16 19:28:02 +0000 UTC] (FIPS-distribution: false)
```

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)