### PR TITLE
Add rollback attribute to upgrade actions

### DIFF
--- a/changelog/fragments/1745450998-Add-rollback-attribute-to-Upgrade-actions.yaml
+++ b/changelog/fragments/1745450998-Add-rollback-attribute-to-Upgrade-actions.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Add rollback attribute to Upgrade actions
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: fleet-server
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/fleet-server/issues/4838

--- a/internal/pkg/api/openapi.gen.go
+++ b/internal/pkg/api/openapi.gen.go
@@ -261,6 +261,9 @@ type ActionUnenroll = interface{}
 
 // ActionUpgrade the UPGRADE action data.
 type ActionUpgrade struct {
+	// Rollback Indicates if this version change should be performed as a rollback to a previous version.
+	Rollback *bool `json:"rollback,omitempty"`
+
 	// SourceUri The source of the upgrade artifact.
 	SourceUri *string `json:"source_uri,omitempty"`
 

--- a/model/openapi.yml
+++ b/model/openapi.yml
@@ -606,6 +606,9 @@ components:
         source_uri:
           description: The source of the upgrade artifact.
           type: string
+        rollback:
+          description: Indicates if this version change should be performed as a rollback to a previous version.
+          type: boolean
     actionSettings:
       description: The SETTINGS action data.
       type: object

--- a/pkg/api/types.gen.go
+++ b/pkg/api/types.gen.go
@@ -258,6 +258,9 @@ type ActionUnenroll = interface{}
 
 // ActionUpgrade the UPGRADE action data.
 type ActionUpgrade struct {
+	// Rollback Indicates if this version change should be performed as a rollback to a previous version.
+	Rollback *bool `json:"rollback,omitempty"`
+
 	// SourceUri The source of the upgrade artifact.
 	SourceUri *string `json:"source_uri,omitempty"`
 


### PR DESCRIPTION
## What is the problem this PR solves?

Fleet does not support explicit rollbacks to earlier versions.

## How does this PR solve the problem?

Add an attribute to upgrade actions that indicate that the agent will rollback.

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Closes #4838 