### PR TITLE
Add ms_tls13kdf tag when requirefips is passed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ ifeq "${FIPS}" "true"
 BUILDER_IMAGE=fleet-server-fips-builder:${GO_VERSION}
 DOCKER_IMAGE:=docker.elastic.co/fleet-server/fleet-server-fips
 STANDALONE_DOCKERFILE=Dockerfile.fips
-gobuildtags += requirefips
+gobuildtags += requirefips ms_tls13kdf
 GOFIPSEXPERIMENT=GOEXPERIMENT=systemcrypto CGO_ENABLED=1
 FIPSSUFFIX=-fips
 endif

--- a/docs/fips.md
+++ b/docs/fips.md
@@ -13,7 +13,7 @@ This toolchain must be present for local compilation.
 
 As we are using Microsfot/go as a base we follow their conventions.
 
-The buildtag `requirefips` is passed when FIPS is enabled/required.
+The buildtags `requirefips`, and `ms_tls13kdf` are passed when FIPS is enabled/required.
 Additionally when compiling `GOEXPERIMENT=systemcrypto` is specified.
 
 The `FIPS=true` env var is used by our Makefile as the indicator that controls FIPS.
@@ -23,8 +23,8 @@ The following make commands have different behaviour when FIPS is enabled:
 - `make multipass` - Provision a multipass VM with the Microsoft/go toolchain. See [Multipass VM Usage](#multipass-vm-usage) for additional details.
 - `make local` - Compile a fleet-server targetting the machine's GOOS/GOARCH with FIPS enabled
 - `make cover-*` - Compile a coverage and fips enabled fleet-server for e2e tests
-- `make test-unit` - Run unit tests passing the `requirefips` build tag.
-- `make benchmark` - Run benchmarks passing the `requirefips` build tag.
+- `make test-unit` - Run unit tests passing the `requirefips`, and `ms_tls13kdf` build tags.
+- `make benchmark` - Run benchmarks passing the `requirefips`, and  `ms_tls13kdf` build tags.
 - `make release-*` - Compile a release binary with FIPS enabled. Will have the name fleet-server-$VERSION-$OS-$ARCH-fips
 - `make package-target` - Will package a FIPS enabled release and produce the sha512 checksum for it.
 - `make build-releaser` - Will create the fleet-server builder image based on Microsoft's FIPS enabled golang image.

--- a/testing/e2e/fips_test.go
+++ b/testing/e2e/fips_test.go
@@ -61,6 +61,7 @@ func (suite *FIPSStandAlone) TestVerifyArtifact() {
 		case "-tags":
 			foundTags = true
 			suite.Require().Contains(setting.Value, "requirefips")
+			suite.Require().Contains(setting.Value, "ms_tls13kdf")
 			continue
 		case "GOEXPERIMENT":
 			foundExperiment = true


### PR DESCRIPTION
## What is the problem this PR solves?

Add the `ms_tls13kdf` build tag to FIPS builds.

## How does this PR solve the problem?

microsoft/go TLSv1.3 kdf support (https://github.com/microsoft/go/pull/1662) requires the `ms_tls13kdf` build tag.