### PR TITLE
Revert "Remove context.background and variable copy from test case"

### DIFF
--- a/internal/pkg/action/dispatcher_test.go
+++ b/internal/pkg/action/dispatcher_test.go
@@ -259,7 +259,7 @@ func Test_Dispatcher_Run(t *testing.T) {
 			}
 
 			now := time.Now()
-			ctx, cancel := context.WithCancel(t.Context())
+			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			go func() {
 				err := d.Run(ctx)
@@ -366,7 +366,7 @@ func Test_offsetStartTime(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := offsetStartTime(t.Context(), tt.start, tt.dur, tt.i, tt.total)
+			r := offsetStartTime(context.Background(), tt.start, tt.dur, tt.i, tt.total)
 			assert.Equal(t, tt.result, r)
 		})
 	}

--- a/internal/pkg/api/error_test.go
+++ b/internal/pkg/api/error_test.go
@@ -48,7 +48,7 @@ func Test_ErrorResp(t *testing.T) {
 			tracer.ResetPayloads()
 
 			tx := tracer.StartTransaction("test", "test")
-			ctx := apm.ContextWithTransaction(t.Context(), tx)
+			ctx := apm.ContextWithTransaction(context.Background(), tx)
 			ctx = logger.WithContext(ctx)
 
 			wr := httptest.NewRecorder()
@@ -78,7 +78,7 @@ func Test_ErrorResp(t *testing.T) {
 
 func Test_ErrorResp_NoTransaction(t *testing.T) {
 	tracer := apmtest.NewRecordingTracer()
-	ctx := testlog.SetLogger(t).WithContext(t.Context())
+	ctx := testlog.SetLogger(t).WithContext(context.Background())
 
 	wr := httptest.NewRecorder()
 	req, err := http.NewRequestWithContext(ctx, "GET", "http://localhost", nil)

--- a/internal/pkg/api/handleAudit_test.go
+++ b/internal/pkg/api/handleAudit_test.go
@@ -5,6 +5,7 @@
 package api
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -97,7 +98,7 @@ func Test_Audit_markUnenroll(t *testing.T) {
 	bulker.On("Update", mock.Anything, dl.FleetAgents, agent.Id, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	audit := AuditT{bulk: bulker}
 	logger := testlog.SetLogger(t)
-	err := audit.markUnenroll(t.Context(), logger, &AuditUnenrollRequest{Reason: Uninstall, Timestamp: time.Now().UTC()}, agent)
+	err := audit.markUnenroll(context.Background(), logger, &AuditUnenrollRequest{Reason: Uninstall, Timestamp: time.Now().UTC()}, agent)
 	require.NoError(t, err)
 	bulker.AssertExpectations(t)
 }

--- a/internal/pkg/api/handlePGPRequest_test.go
+++ b/internal/pkg/api/handlePGPRequest_test.go
@@ -5,6 +5,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -118,7 +119,7 @@ func Test_PGPRetrieverT_getPGPKey(t *testing.T) {
 				},
 			}
 
-			content, err := pt.getPGPKey(t.Context(), testlog.SetLogger(t))
+			content, err := pt.getPGPKey(context.Background(), testlog.SetLogger(t))
 			require.ErrorIs(t, err, tc.err)
 			require.Equal(t, tc.content, content)
 			mockCache.AssertExpectations(t)

--- a/internal/pkg/api/metrics_integration_test.go
+++ b/internal/pkg/api/metrics_integration_test.go
@@ -29,7 +29,7 @@ func TestMetricsEndpoints(t *testing.T) {
 			Port:    8080,
 		},
 	}
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 

--- a/internal/pkg/api/openapi_spec_test.go
+++ b/internal/pkg/api/openapi_spec_test.go
@@ -228,6 +228,7 @@ func Test_UpgradeDetailsMetadata_Downloading(t *testing.T) {
 	}}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			meta, err := tc.md.AsUpgradeMetadataDownloading()
 			if tc.err == nil {
@@ -285,6 +286,7 @@ func Test_UpgradeDetailsMetadata_Failed(t *testing.T) {
 	}}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			meta, err := tc.md.AsUpgradeMetadataFailed()
 			if tc.err == nil {
@@ -340,6 +342,7 @@ func Test_UpgradeDetailsMetadata_Scheduled(t *testing.T) {
 	}}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			meta, err := tc.md.AsUpgradeMetadataScheduled()
 			if tc.err == nil {
@@ -382,6 +385,7 @@ func TestUpgradeDetailsSerialization(t *testing.T) {
 		TargetVersion: "1.2.3",
 	}}
 	for _, d := range details {
+		d := d
 		t.Run(string(d.State), func(t *testing.T) {
 			p, err := json.Marshal(d)
 			require.NoError(t, err)

--- a/internal/pkg/apikey/apikey_integration_test.go
+++ b/internal/pkg/apikey/apikey_integration_test.go
@@ -32,7 +32,7 @@ const testFleetRoles = `
 `
 
 func TestRead_existingKey(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -84,7 +84,7 @@ func TestRead_existingKey(t *testing.T) {
 }
 
 func TestRead_noKey(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -116,7 +116,7 @@ func TestCreateAPIKeyWithMetadata(t *testing.T) {
 
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cn := context.WithCancel(t.Context())
+			ctx, cn := context.WithCancel(context.Background())
 			defer cn()
 			ctx = testlog.SetLogger(t).WithContext(ctx)
 

--- a/internal/pkg/apikey/auth_test.go
+++ b/internal/pkg/apikey/auth_test.go
@@ -24,7 +24,7 @@ func setup(t *testing.T, statusCode int) (context.Context, *APIKey, *elasticsear
 	token := base64.StdEncoding.EncodeToString([]byte(rawToken))
 	apiKey, err := NewAPIKeyFromToken(token)
 	assert.NoError(t, err)
-	ctx := t.Context()
+	ctx := context.Background()
 
 	mockES, mockTransport := esutil.MockESClient(t)
 	mockTransport.RoundTripFn = func(req *http.Request) (*http.Response, error) { return &http.Response{StatusCode: statusCode}, nil }

--- a/internal/pkg/bulk/bulk_integration_test.go
+++ b/internal/pkg/bulk/bulk_integration_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestBulkCreate(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 
 	index, bulker := SetupIndexWithBulk(ctx, t, testPolicy, WithFlushThresholdCount(1))
@@ -124,7 +124,7 @@ func TestBulkCreate(t *testing.T) {
 }
 
 func TestBulkCreateBody(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 
 	index, bulker := SetupIndexWithBulk(ctx, t, testPolicy, WithFlushThresholdCount(1))
@@ -177,7 +177,7 @@ func TestBulkCreateBody(t *testing.T) {
 }
 
 func TestBulkIndex(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -201,7 +201,7 @@ func TestBulkIndex(t *testing.T) {
 }
 
 func TestBulkUpdate(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -240,7 +240,7 @@ func TestBulkUpdate(t *testing.T) {
 }
 
 func TestBulkSearch(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -283,7 +283,7 @@ func TestBulkSearch(t *testing.T) {
 }
 
 func TestBulkSearchWithIgnoreUnavailable(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -306,7 +306,7 @@ func TestBulkSearchWithIgnoreUnavailable(t *testing.T) {
 }
 
 func TestBulkDelete(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -344,7 +344,7 @@ func TestBulkDelete(t *testing.T) {
 func benchmarkCreate(n int, b *testing.B) {
 	b.ReportAllocs()
 
-	ctx, cn := context.WithCancel(b.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(b).WithContext(ctx)
 
@@ -396,7 +396,7 @@ func BenchmarkCreate(b *testing.B) {
 // Not a particularly useful benchmark, but gives some idea of memory overhead.
 
 func benchmarkCRUD(n int, b *testing.B) {
-	ctx, cn := context.WithCancel(b.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(b).WithContext(ctx)
 

--- a/internal/pkg/bulk/bulk_remote_output_test.go
+++ b/internal/pkg/bulk/bulk_remote_output_test.go
@@ -91,7 +91,7 @@ func Test_hasChangedAndUpdateRemoteOutputConfig(t *testing.T) {
 }
 
 func Test_CreateAndGetBulkerNew(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	bulker := NewBulker(nil, nil)
 	outputMap := make(map[string]map[string]interface{})
@@ -107,7 +107,7 @@ func Test_CreateAndGetBulkerNew(t *testing.T) {
 }
 
 func Test_CreateAndGetBulkerExisting(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	bulker := NewBulker(nil, nil)
 	outputBulker := NewBulker(nil, nil)
@@ -127,7 +127,7 @@ func Test_CreateAndGetBulkerExisting(t *testing.T) {
 }
 
 func Test_CreateAndGetBulkerChanged(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	bulker := NewBulker(nil, nil)
 	outputBulker := NewBulker(nil, nil)
@@ -154,7 +154,7 @@ func Test_CreateAndGetBulkerChanged(t *testing.T) {
 
 func Benchmark_CreateAndGetBulker(b *testing.B) {
 	b.Skip("Crashes on remote runner")
-	ctx, cancel := context.WithCancel(b.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	log := zerolog.Nop()
 	outputMap := map[string]map[string]any{

--- a/internal/pkg/bulk/bulk_test.go
+++ b/internal/pkg/bulk/bulk_test.go
@@ -253,7 +253,7 @@ func TestCancelCtx(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx, cancelF := context.WithCancel(t.Context())
+			ctx, cancelF := context.WithCancel(context.Background())
 
 			cancelF()
 			var wg sync.WaitGroup
@@ -273,7 +273,7 @@ func TestCancelCtx(t *testing.T) {
 func TestCancelCtxChildBulker(t *testing.T) {
 	bulker := NewBulker(nil, nil)
 
-	ctx, cancelF := context.WithCancel(t.Context())
+	ctx, cancelF := context.WithCancel(context.Background())
 
 	outputMap := make(map[string]map[string]interface{})
 	outputMap["remote"] = map[string]interface{}{
@@ -306,7 +306,7 @@ func TestCancelCtxChildBulker(t *testing.T) {
 func benchmarkMockBulk(b *testing.B, samples [][]byte) {
 	mock := &mockBulkTransport{}
 
-	ctx, cancelF := context.WithCancel(b.Context())
+	ctx, cancelF := context.WithCancel(context.Background())
 	defer cancelF()
 
 	n := len(samples)

--- a/internal/pkg/bulk/opMulti_integration_test.go
+++ b/internal/pkg/bulk/opMulti_integration_test.go
@@ -18,7 +18,7 @@ import (
 // benchmarkMultiUpdate runs a series of CRUD operations through elastic.
 // Not a particularly useful benchmark, but gives some idea of memory overhead.
 func benchmarkMultiUpdate(n int, b *testing.B) {
-	ctx, cn := context.WithCancel(b.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(b).WithContext(ctx)
 

--- a/internal/pkg/bulk/opMulti_test.go
+++ b/internal/pkg/bulk/opMulti_test.go
@@ -5,6 +5,7 @@
 package bulk
 
 import (
+	"context"
 	"strconv"
 	"testing"
 
@@ -49,7 +50,7 @@ func BenchmarkMultiUpdateMock(b *testing.B) {
 
 	for _, n := range benchmarks {
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
-			ctx := testlog.SetLogger(b).WithContext(b.Context())
+			ctx := testlog.SetLogger(b).WithContext(context.Background())
 			b.ResetTimer()
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {

--- a/internal/pkg/checkin/bulk_test.go
+++ b/internal/pkg/checkin/bulk_test.go
@@ -199,7 +199,7 @@ func TestBulkSimple(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			ctx := testlog.SetLogger(t).WithContext(t.Context())
+			ctx := testlog.SetLogger(t).WithContext(context.Background())
 			mockBulk := ftesting.NewMockBulk()
 			mockBulk.On("MUpdate", mock.Anything, mock.MatchedBy(matchOp(t, c, start)), mock.Anything).Return([]bulk.BulkIndexerResponseItem{}, nil).Once()
 			bc := NewBulk(mockBulk)

--- a/internal/pkg/dl/action_results_integration_test.go
+++ b/internal/pkg/dl/action_results_integration_test.go
@@ -101,7 +101,7 @@ func (acrs ActionsResults) find(ar model.ActionResult) *model.ActionResult {
 }
 
 func TestActionsResultsStored(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 

--- a/internal/pkg/dl/actions_integration_test.go
+++ b/internal/pkg/dl/actions_integration_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestSearchActionsQuery(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 

--- a/internal/pkg/dl/agent_integration_test.go
+++ b/internal/pkg/dl/agent_integration_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestFindAgent_NewModel(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 

--- a/internal/pkg/dl/enrollment_api_key_integration_test.go
+++ b/internal/pkg/dl/enrollment_api_key_integration_test.go
@@ -53,7 +53,7 @@ func storeRandomEnrollmentAPIKey(ctx context.Context, bulker bulk.Bulk, index st
 }
 
 func TestSearchEnrollmentAPIKeyByID(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -86,7 +86,7 @@ func TestSearchEnrollmentAPIKeyByID(t *testing.T) {
 
 func TestSearchEnrollmentAPIKeyByPolicyID(t *testing.T) {
 	t.Skip("Flaky test see https://github.com/elastic/fleet-server/issues/1289")
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -118,7 +118,7 @@ func TestSearchEnrollmentAPIKeyByPolicyID(t *testing.T) {
 }
 
 func TestSearchEnrollmentAPIKeyByPolicyIDWithInactiveIDs(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 

--- a/internal/pkg/dl/migration_integration_test.go
+++ b/internal/pkg/dl/migration_integration_test.go
@@ -72,7 +72,7 @@ func createSomeAgents(ctx context.Context, t *testing.T, n int, apiKey bulk.APIK
 }
 
 func TestMigrateOutputs_withDefaultAPIKeyHistory(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -164,7 +164,7 @@ func TestMigrateOutputs_withDefaultAPIKeyHistory(t *testing.T) {
 }
 
 func TestMigrateOutputs_dontMigrateTwice(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -193,7 +193,7 @@ func TestMigrateOutputs_dontMigrateTwice(t *testing.T) {
 }
 
 func TestMigrateOutputs_nil_DefaultAPIKeyHistory(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -294,7 +294,7 @@ func TestMigrateOutputs_nil_DefaultAPIKeyHistory(t *testing.T) {
 }
 
 func TestMigrateOutputs_no_agent_document(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 

--- a/internal/pkg/dl/policies_integration_test.go
+++ b/internal/pkg/dl/policies_integration_test.go
@@ -56,7 +56,7 @@ func storeRandomPolicy(ctx context.Context, bulker bulk.Bulk, index string) (mod
 }
 
 func TestQueryLatestPolicies(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -87,7 +87,7 @@ func TestQueryLatestPolicies(t *testing.T) {
 }
 
 func TestCreatePolicy(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -107,7 +107,7 @@ func TestCreatePolicy(t *testing.T) {
 }
 
 func TestQueryOutputFromPolicy(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 

--- a/internal/pkg/es/client_test.go
+++ b/internal/pkg/es/client_test.go
@@ -5,6 +5,7 @@
 package es
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -41,7 +42,7 @@ func TestClientCerts(t *testing.T) {
 		defer server.Close()
 
 		// client does not use client certs
-		client, err := NewClient(t.Context(), &config.Config{
+		client, err := NewClient(context.Background(), &config.Config{
 			Output: config.Output{
 				Elasticsearch: config.Elasticsearch{
 					Protocol: "https",
@@ -55,7 +56,7 @@ func TestClientCerts(t *testing.T) {
 		}, false)
 		require.NoError(t, err)
 
-		req, err := http.NewRequestWithContext(t.Context(), "GET", server.URL, nil)
+		req, err := http.NewRequestWithContext(context.Background(), "GET", server.URL, nil)
 		require.NoError(t, err)
 
 		resp, err := client.Perform(req)
@@ -86,7 +87,7 @@ func TestClientCerts(t *testing.T) {
 		cert := certs.GenCert(t, ca)
 
 		// client uses valid, matching certs
-		client, err := NewClient(t.Context(), &config.Config{
+		client, err := NewClient(context.Background(), &config.Config{
 			Output: config.Output{
 				Elasticsearch: config.Elasticsearch{
 					Protocol: "https",
@@ -104,7 +105,7 @@ func TestClientCerts(t *testing.T) {
 		}, false)
 		require.NoError(t, err)
 
-		req, err := http.NewRequestWithContext(t.Context(), "GET", server.URL, nil)
+		req, err := http.NewRequestWithContext(context.Background(), "GET", server.URL, nil)
 		require.NoError(t, err)
 
 		resp, err := client.Perform(req)
@@ -136,7 +137,7 @@ func TestClientCerts(t *testing.T) {
 		cert := certs.GenCert(t, certCA)
 
 		// client uses certs that are signed by a different CA
-		client, err := NewClient(t.Context(), &config.Config{
+		client, err := NewClient(context.Background(), &config.Config{
 			Output: config.Output{
 				Elasticsearch: config.Elasticsearch{
 					Protocol: "https",
@@ -154,7 +155,7 @@ func TestClientCerts(t *testing.T) {
 		}, false)
 		require.NoError(t, err)
 
-		req, err := http.NewRequestWithContext(t.Context(), "GET", server.URL, nil)
+		req, err := http.NewRequestWithContext(context.Background(), "GET", server.URL, nil)
 		require.NoError(t, err)
 
 		_, err = client.Perform(req) //nolint:bodyclose // no response is expected

--- a/internal/pkg/file/delivery/delivery_test.go
+++ b/internal/pkg/file/delivery/delivery_test.go
@@ -6,6 +6,7 @@ package delivery
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -69,7 +70,7 @@ func TestFindFile(t *testing.T) {
 
 	d := New(nil, fakeBulk, -1)
 
-	info, err := d.FindFileForAgent(t.Context(), fileID, agentID)
+	info, err := d.FindFileForAgent(context.Background(), fileID, agentID)
 	require.NoError(t, err)
 
 	assert.NotNil(t, info.File.Hash)
@@ -93,7 +94,7 @@ func TestFindFileHandlesNoResults(t *testing.T) {
 
 	d := New(nil, fakeBulk, -1)
 
-	_, err := d.FindFileForAgent(t.Context(), "somefile", "anyagent")
+	_, err := d.FindFileForAgent(context.Background(), "somefile", "anyagent")
 	assert.ErrorIs(t, ErrNoFile, err)
 }
 
@@ -133,7 +134,7 @@ func TestLocateChunks(t *testing.T) {
 
 	d := New(nil, fakeBulk, -1)
 
-	chunks, err := d.LocateChunks(t.Context(), zerolog.Logger{}, baseID)
+	chunks, err := d.LocateChunks(context.Background(), zerolog.Logger{}, baseID)
 	require.NoError(t, err)
 
 	assert.Len(t, chunks, 2)
@@ -155,7 +156,7 @@ func TestLocateChunksEmpty(t *testing.T) {
 
 	d := New(nil, fakeBulk, -1)
 
-	_, err := d.LocateChunks(t.Context(), zerolog.Logger{}, "afile")
+	_, err := d.LocateChunks(context.Background(), zerolog.Logger{}, "afile")
 	assert.Error(t, err)
 }
 
@@ -172,7 +173,7 @@ func TestSendFile(t *testing.T) {
 	// Chunk data from a tiny PNG, as a full CBOR document
 	esMock.Response = sendBodyBytes(hexDecode("bf665f696e64657878212e666c6565742d66696c6564656c69766572792d646174612d656e64706f696e74635f6964654142432e30685f76657273696f6e02675f7365715f6e6f016d5f7072696d6172795f7465726d0165666f756e64f5666669656c6473bf64646174619f586789504e470d0a1a0a0000000d494844520000010000000100010300000066bc3a2500000003504c5445b5d0d0630416ea0000001f494441546881edc1010d000000c2a0f74f6d0e37a00000000000000000be0d210000019a60e1d50000000049454e44ae426082ffffff")) //nolint:bodyclose // nopcloser is used, linter does not see it
 	d := New(esClient, fakeBulk, -1)
-	err := d.SendFile(t.Context(), zerolog.Logger{}, buf, chunks, fileID)
+	err := d.SendFile(context.Background(), zerolog.Logger{}, buf, chunks, fileID)
 	require.NoError(t, err)
 
 	// the byte string is the bare PNG file data
@@ -208,7 +209,7 @@ func TestSendFileMultipleChunks(t *testing.T) {
 	}
 
 	d := New(esClient, fakeBulk, -1)
-	err := d.SendFile(t.Context(), zerolog.Logger{}, buf, chunks, fileID)
+	err := d.SendFile(context.Background(), zerolog.Logger{}, buf, chunks, fileID)
 	require.NoError(t, err)
 
 	// the collective bytes sent (0xabcd in first chunk, 0xef01 in second)
@@ -248,7 +249,7 @@ func TestSendFileMultipleChunksUsesBackingIndex(t *testing.T) {
 	}
 
 	d := New(esClient, fakeBulk, -1)
-	err := d.SendFile(t.Context(), zerolog.Logger{}, buf, chunks, fileID)
+	err := d.SendFile(context.Background(), zerolog.Logger{}, buf, chunks, fileID)
 	require.NoError(t, err)
 }
 
@@ -306,7 +307,7 @@ func TestSendFileHandlesDisorderedChunks(t *testing.T) {
 	}
 
 	d := New(esClient, fakeBulk, -1)
-	err := d.SendFile(t.Context(), zerolog.Logger{}, buf, chunks, fileID)
+	err := d.SendFile(context.Background(), zerolog.Logger{}, buf, chunks, fileID)
 	require.NoError(t, err)
 }
 

--- a/internal/pkg/file/es_test.go
+++ b/internal/pkg/file/es_test.go
@@ -5,6 +5,7 @@
 package file
 
 import (
+	"context"
 	"testing"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/es"
@@ -49,7 +50,7 @@ func TestChunkInfoResultsParseCorrectly(t *testing.T) {
 		},
 	}, nil)
 
-	chunks, err := GetChunkInfos(t.Context(), fakeBulk, "", baseID, GetChunkInfoOpt{IncludeSize: true})
+	chunks, err := GetChunkInfos(context.Background(), fakeBulk, "", baseID, GetChunkInfoOpt{IncludeSize: true})
 	assert.NoError(t, err)
 	assert.Len(t, chunks, 2)
 

--- a/internal/pkg/file/uploader/upload_test.go
+++ b/internal/pkg/file/uploader/upload_test.go
@@ -83,7 +83,7 @@ func TestUploadBeginReturnsCorrectInfo(t *testing.T) {
 	c, err := cache.New(config.Cache{NumCounters: 100, MaxCost: 100000})
 	require.NoError(t, err)
 	u := New(nil, fakeBulk, c, int64(size), time.Hour)
-	info, err := u.Begin(t.Context(), []string{}, data)
+	info, err := u.Begin(context.Background(), []string{}, data)
 	assert.NoError(t, err)
 
 	assert.Equal(t, int64(size), info.Total)
@@ -127,7 +127,7 @@ func TestUploadBeginWritesDocumentFromInputs(t *testing.T) {
 	c, err := cache.New(config.Cache{NumCounters: 100, MaxCost: 100000})
 	require.NoError(t, err)
 	u := New(nil, fakeBulk, c, int64(size), time.Hour)
-	_, err = u.Begin(t.Context(), []string{}, data)
+	_, err = u.Begin(context.Background(), []string{}, data)
 	assert.NoError(t, err)
 
 	payload, ok := fakeBulk.Calls[0].Arguments[3].([]byte)
@@ -171,7 +171,7 @@ func TestUploadBeginCalculatesCorrectChunkCount(t *testing.T) {
 			data := makeUploadRequestDict(map[string]interface{}{
 				"file.size": tc.FileSize,
 			})
-			info, err := u.Begin(t.Context(), []string{}, data)
+			info, err := u.Begin(context.Background(), []string{}, data)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.ExpectedCount, info.Count)
 		})
@@ -210,7 +210,7 @@ func TestUploadBeginMaxFileSize(t *testing.T) {
 			data := makeUploadRequestDict(map[string]interface{}{
 				"file.size": tc.FileSize,
 			})
-			_, err := u.Begin(t.Context(), []string{}, data)
+			_, err := u.Begin(context.Background(), []string{}, data)
 			if tc.ShouldError {
 				assert.ErrorIs(t, err, ErrFileSizeTooLarge)
 			} else {
@@ -264,7 +264,7 @@ func TestUploadRejectsMissingRequiredFields(t *testing.T) {
 				}
 			}
 
-			_, err = u.Begin(t.Context(), []string{}, data)
+			_, err = u.Begin(context.Background(), []string{}, data)
 			assert.Errorf(t, err, "%s is a required field and should error if not provided", field)
 		})
 
@@ -342,13 +342,13 @@ func TestChunkMarksFinal(t *testing.T) {
 				"file.size": tc.FileSize,
 			})
 
-			info, err := u.Begin(t.Context(), []string{}, data)
+			info, err := u.Begin(context.Background(), []string{}, data)
 			assert.NoError(t, err)
 
 			// for anything larger than 1-chunk, check for off-by-ones
 			if tc.FinalChunk > 0 {
 				mockUploadInfoResult(fakeBulk, info)
-				_, prev, err := u.Chunk(t.Context(), info.ID, tc.FinalChunk-1, "")
+				_, prev, err := u.Chunk(context.Background(), info.ID, tc.FinalChunk-1, "")
 				assert.NoError(t, err)
 				assert.Falsef(t, prev.Last, "penultimate chunk number (%d) should not be marked final", tc.FinalChunk-1)
 			}
@@ -356,7 +356,7 @@ func TestChunkMarksFinal(t *testing.T) {
 			mockUploadInfoResult(fakeBulk, info)
 
 			// make sure the final chunk is marked as such
-			_, chunk, err := u.Chunk(t.Context(), info.ID, tc.FinalChunk, "")
+			_, chunk, err := u.Chunk(context.Background(), info.ID, tc.FinalChunk, "")
 			assert.NoError(t, err)
 			assert.Truef(t, chunk.Last, "chunk number %d should be marked as Last", tc.FinalChunk)
 		})

--- a/internal/pkg/gc/actions_integration_test.go
+++ b/internal/pkg/gc/actions_integration_test.go
@@ -7,6 +7,7 @@
 package gc
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -51,7 +52,7 @@ func testCleanupActionsWithSelectSize(t *testing.T, _ int) {
 		err                               error
 	)
 
-	ctx := t.Context()
+	ctx := context.Background()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
 	index, bulker := ftesting.SetupCleanIndex(ctx, t, dl.FleetActions)

--- a/internal/pkg/logger/http_test.go
+++ b/internal/pkg/logger/http_test.go
@@ -30,7 +30,7 @@ func TestMiddleware(t *testing.T) {
 
 	var b bytes.Buffer
 	logger := zerolog.New(&b).Level(zerolog.InfoLevel)
-	ctx := logger.WithContext(t.Context())
+	ctx := logger.WithContext(context.Background())
 
 	srv := httptest.NewUnstartedServer(Middleware(h))
 	srv.Config.BaseContext = func(_ net.Listener) context.Context {
@@ -38,7 +38,7 @@ func TestMiddleware(t *testing.T) {
 	}
 	srv.Start()
 	defer srv.Close()
-	reqCtx, cancel := context.WithCancel(t.Context())
+	reqCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	req, err := http.NewRequestWithContext(reqCtx, "GET", srv.URL, nil)
 	require.NoError(t, err)

--- a/internal/pkg/logger/logger_test.go
+++ b/internal/pkg/logger/logger_test.go
@@ -7,6 +7,7 @@ package logger
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
@@ -42,7 +43,7 @@ func Test_Logger_Reload(t *testing.T) {
 		logger.cfg = stderrcfg()
 		logger.sync = &nopSync{}
 
-		err := logger.Reload(t.Context(), stderrcfg())
+		err := logger.Reload(context.Background(), stderrcfg())
 		require.NoError(t, err)
 		log.Info().Msg("Hello, World!")
 
@@ -58,7 +59,7 @@ func Test_Logger_Reload(t *testing.T) {
 
 		cfg := stderrcfg()
 		cfg.Logging.Level = "debug"
-		err := logger.Reload(t.Context(), cfg)
+		err := logger.Reload(context.Background(), cfg)
 		require.NoError(t, err)
 		log.Info().Msg("Hello, World!")
 
@@ -74,7 +75,7 @@ func Test_Logger_Reload(t *testing.T) {
 
 		cfg := stderrcfg()
 		cfg.Logging.ToStderr = false
-		err := logger.Reload(t.Context(), cfg)
+		err := logger.Reload(context.Background(), cfg)
 		require.NoError(t, err)
 		log.Info().Msg("Hello, World!")
 
@@ -91,7 +92,7 @@ func Test_Logger_Reload(t *testing.T) {
 		cfg := stderrcfg()
 		cfg.Logging.ToStderr = false
 		cfg.Logging.Level = "warn"
-		err := logger.Reload(t.Context(), cfg)
+		err := logger.Reload(context.Background(), cfg)
 		require.NoError(t, err)
 		log.Info().Msg("Hello, World!")
 
@@ -105,15 +106,15 @@ func Test_Logger_Reload(t *testing.T) {
 		logger.cfg = stderrcfg()
 		logger.sync = &nopSync{}
 
-		zerolog.Ctx(t.Context()).Error().Msg("Hello, World!")
+		zerolog.Ctx(context.Background()).Error().Msg("Hello, World!")
 		assert.NotEmpty(t, b, "expected something to be written")
 		b.Reset()
 
 		cfg := stderrcfg()
 		cfg.Logging.Level = "debug"
-		err := logger.Reload(t.Context(), cfg)
+		err := logger.Reload(context.Background(), cfg)
 		require.NoError(t, err)
-		zerolog.Ctx(t.Context()).Error().Msg("Hello, World!")
+		zerolog.Ctx(context.Background()).Error().Msg("Hello, World!")
 
 		assert.Equal(t, zerolog.DebugLevel, zerolog.GlobalLevel())
 		assert.NotEmpty(t, b, "expected something to be written")

--- a/internal/pkg/monitor/monitor_integration_test.go
+++ b/internal/pkg/monitor/monitor_integration_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestSimpleMonitorEmptyIndex(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -39,7 +39,7 @@ func TestSimpleMonitorEmptyIndex(t *testing.T) {
 }
 
 func TestSimpleMonitorNonEmptyIndex(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -49,7 +49,7 @@ func TestSimpleMonitorNonEmptyIndex(t *testing.T) {
 }
 
 func TestSimpleMonitorWithDebounce(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -109,7 +109,7 @@ func TestSimpleMonitorWithDebounce(t *testing.T) {
 }
 
 func TestSimpleMonitorCheckpointOutOfSync(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 

--- a/internal/pkg/monitor/subscription_monitor_integration_test.go
+++ b/internal/pkg/monitor/subscription_monitor_integration_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestMonitorEmptyIndex(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -32,7 +32,7 @@ func TestMonitorEmptyIndex(t *testing.T) {
 }
 
 func TestMonitorNonEmptyIndex(t *testing.T) {
-	ctx, cn := context.WithCancel(t.Context())
+	ctx, cn := context.WithCancel(context.Background())
 	defer cn()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 

--- a/internal/pkg/policy/monitor_integration_test.go
+++ b/internal/pkg/policy/monitor_integration_test.go
@@ -34,7 +34,7 @@ var intPolData = model.PolicyData{
 }
 
 func TestMonitor_Integration(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -130,7 +130,7 @@ func TestMonitor_Integration(t *testing.T) {
 }
 
 func TestMonitor_Debounce_Integration(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -321,7 +321,7 @@ func TestMonitor_Debounce_Integration(t *testing.T) {
 }
 
 func TestMonitor_Revisions(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 
@@ -443,7 +443,7 @@ func TestMonitor_Revisions(t *testing.T) {
 }
 
 func TestMonitor_KickDeploy(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ctx = testlog.SetLogger(t).WithContext(ctx)
 

--- a/internal/pkg/policy/policy_output_integration_test.go
+++ b/internal/pkg/policy/policy_output_integration_test.go
@@ -48,7 +48,7 @@ func TestRenderUpdatePainlessScript(t *testing.T) {
 			outputName := "output_" + tt.name
 			outputAPIKey := bulk.APIKey{ID: "new_ID", Key: "new-key"}
 
-			ctx := testlog.SetLogger(t).WithContext(t.Context())
+			ctx := testlog.SetLogger(t).WithContext(context.Background())
 			index, bulker := ftesting.SetupCleanIndex(ctx, t, dl.FleetAgents)
 
 			now := time.Now().UTC()
@@ -132,7 +132,7 @@ func TestRenderUpdatePainlessScript(t *testing.T) {
 }
 
 func TestPolicyOutputESPrepareRealES(t *testing.T) {
-	ctx := testlog.SetLogger(t).WithContext(t.Context())
+	ctx := testlog.SetLogger(t).WithContext(context.Background())
 	index, bulker := ftesting.SetupCleanIndex(ctx, t, dl.FleetAgents)
 
 	agentID := createAgent(ctx, t, index, bulker, map[string]*model.PolicyOutput{})
@@ -205,7 +205,7 @@ func createAgent(ctx context.Context, t *testing.T, index string, bulker bulk.Bu
 }
 
 func TestPolicyOutputESPrepareRemoteES(t *testing.T) {
-	ctx := testlog.SetLogger(t).WithContext(t.Context())
+	ctx := testlog.SetLogger(t).WithContext(context.Background())
 	index, bulker := ftesting.SetupCleanIndex(ctx, t, dl.FleetAgents)
 
 	agentID := createAgent(ctx, t, index, bulker, map[string]*model.PolicyOutput{})
@@ -254,7 +254,7 @@ func TestPolicyOutputESPrepareRemoteES(t *testing.T) {
 }
 
 func TestPolicyOutputESPrepareESRetireRemoteAPIKeys(t *testing.T) {
-	ctx := testlog.SetLogger(t).WithContext(t.Context())
+	ctx := testlog.SetLogger(t).WithContext(context.Background())
 	index, bulker := ftesting.SetupCleanIndex(ctx, t, dl.FleetAgents)
 
 	// simulate a previous remote output, that is removed from outputMap

--- a/internal/pkg/profile/profile_test.go
+++ b/internal/pkg/profile/profile_test.go
@@ -21,7 +21,7 @@ func TestRunProfiler(t *testing.T) {
 	}
 	ln.Close()
 
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	errCh := make(chan error)

--- a/internal/pkg/server/agent_test.go
+++ b/internal/pkg/server/agent_test.go
@@ -88,7 +88,7 @@ func TestCLIOverrides(t *testing.T) {
 		agent:      clientMock,
 	}
 
-	generatedCfg, err := agent.configFromUnits(t.Context())
+	generatedCfg, err := agent.configFromUnits(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, httpEnabledExpected, generatedCfg.HTTP.Enabled)
 	require.Equal(t, httpHostExpected, generatedCfg.HTTP.Host)
@@ -194,7 +194,7 @@ func Test_Agent_configFromUnits(t *testing.T) {
 			outputUnit: mockOutClient,
 		}
 
-		cfg, err := a.configFromUnits(t.Context())
+		cfg, err := a.configFromUnits(context.Background())
 		require.NoError(t, err)
 		require.Len(t, cfg.Inputs, 1)
 		assert.Equal(t, "fleet-server", cfg.Inputs[0].Type)
@@ -234,7 +234,7 @@ func Test_Agent_configFromUnits(t *testing.T) {
 			outputUnit: mockOutClient,
 		}
 
-		cfg, err := a.configFromUnits(t.Context())
+		cfg, err := a.configFromUnits(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, "fleet-server", cfg.Inputs[0].Type)
 		require.Len(t, cfg.Output.Elasticsearch.Hosts, 2)
@@ -295,7 +295,7 @@ func Test_Agent_configFromUnits(t *testing.T) {
 			outputUnit: mockOutClient,
 		}
 
-		cfg, err := a.configFromUnits(t.Context())
+		cfg, err := a.configFromUnits(context.Background())
 		require.NoError(t, err)
 		require.Len(t, cfg.Inputs, 1)
 		assert.Equal(t, "fleet-server", cfg.Inputs[0].Type)
@@ -375,7 +375,7 @@ func Test_Agent_configFromUnits(t *testing.T) {
 			outputUnit: mockOutClient,
 		}
 
-		cfg, err := a.configFromUnits(t.Context())
+		cfg, err := a.configFromUnits(context.Background())
 		require.NoError(t, err)
 		require.Len(t, cfg.Inputs, 1)
 		assert.Equal(t, "fleet-server", cfg.Inputs[0].Type)
@@ -439,7 +439,7 @@ func Test_Agent_configFromUnits(t *testing.T) {
 			outputUnit: mockOutClient,
 		}
 
-		cfg, err := a.configFromUnits(t.Context())
+		cfg, err := a.configFromUnits(context.Background())
 		require.NoError(t, err)
 		require.Len(t, cfg.Inputs, 1)
 		assert.Equal(t, "fleet-server", cfg.Inputs[0].Type)
@@ -518,7 +518,7 @@ func Test_Agent_configFromUnits(t *testing.T) {
 			outputUnit: mockOutClient,
 		}
 
-		cfg, err := a.configFromUnits(t.Context())
+		cfg, err := a.configFromUnits(context.Background())
 		require.NoError(t, err)
 		require.Len(t, cfg.Inputs, 1)
 		assert.Equal(t, "fleet-server", cfg.Inputs[0].Type)
@@ -571,7 +571,7 @@ func Test_Agent_configFromUnits(t *testing.T) {
 			outputUnit: mockOutClient,
 		}
 
-		cfg, err := a.configFromUnits(t.Context())
+		cfg, err := a.configFromUnits(context.Background())
 		require.NoError(t, err)
 		require.Len(t, cfg.Inputs, 1)
 		assert.Equal(t, "fleet-server", cfg.Inputs[0].Type)
@@ -625,7 +625,7 @@ func Test_Agent_configFromUnits(t *testing.T) {
 			outputUnit: mockOutClient,
 		}
 
-		cfg, err := a.configFromUnits(t.Context())
+		cfg, err := a.configFromUnits(context.Background())
 		require.NoError(t, err)
 		require.Len(t, cfg.Inputs, 1)
 		assert.Equal(t, "fleet-server", cfg.Inputs[0].Type)
@@ -684,7 +684,7 @@ func Test_Agent_configFromUnits(t *testing.T) {
 			},
 		}
 
-		ctx := testlog.SetLogger(t).WithContext(t.Context())
+		ctx := testlog.SetLogger(t).WithContext(context.Background())
 		cfg, err := a.configFromUnits(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "test-token", cfg.Output.Elasticsearch.ServiceToken)
@@ -734,7 +734,7 @@ func Test_Agent_configFromUnits(t *testing.T) {
 			},
 		}
 
-		ctx := testlog.SetLogger(t).WithContext(t.Context())
+		ctx := testlog.SetLogger(t).WithContext(context.Background())
 		cfg, err := a.configFromUnits(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, "test-token", cfg.Output.Elasticsearch.ServiceToken)
@@ -839,7 +839,7 @@ func TestInjectMissingOutputAttributes(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			injectMissingOutputAttributes(t.Context(), tc.input, bootstrap)
+			injectMissingOutputAttributes(context.Background(), tc.input, bootstrap)
 			assert.Equal(t, len(tc.expect), len(tc.input), "expected map sizes don't match")
 			assert.Equal(t, tc.expect, tc.input)
 		})
@@ -914,7 +914,7 @@ func TestInjectMissingOutputAttributes(t *testing.T) {
 
 	for _, tc := range sslTests {
 		t.Run(tc.name, func(t *testing.T) {
-			injectMissingOutputAttributes(t.Context(), tc.input, bootstrapVerifyNone)
+			injectMissingOutputAttributes(context.Background(), tc.input, bootstrapVerifyNone)
 			assert.Equal(t, len(tc.expect), len(tc.input), "expected map sizes don't match")
 			assert.Equal(t, tc.expect, tc.input)
 		})
@@ -928,7 +928,7 @@ func Test_Agent_esOutputCheckLoop(t *testing.T) {
 			chReconfigure: make(chan struct{}, 1),
 		}
 
-		ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		a.esOutputCheckLoop(ctx, time.Millisecond*10, map[string]interface{}{})
 		assert.Empty(t, a.chReconfigure)
@@ -948,7 +948,7 @@ func Test_Agent_esOutputCheckLoop(t *testing.T) {
 			},
 			chReconfigure: make(chan struct{}, 1),
 		}
-		ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		a.esOutputCheckLoop(ctx, time.Millisecond*10, map[string]interface{}{
 			"service_token": "test-token",
@@ -977,7 +977,7 @@ func Test_Agent_esOutputCheckLoop(t *testing.T) {
 			},
 			chReconfigure: make(chan struct{}, 1),
 		}
-		ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		a.esOutputCheckLoop(ctx, time.Millisecond*10, map[string]interface{}{
 			"service_token": "test-token",

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -296,7 +296,7 @@ func (m *MockReporter) UpdateState(state client.UnitState, message string, paylo
 }
 
 func TestServerConfigErrorReload(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// don't use startTestServer as we need failing initial config.
@@ -402,7 +402,7 @@ func TestServerConfigErrorReload(t *testing.T) {
 }
 
 func TestServerUnauthorized(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start test server
@@ -503,7 +503,7 @@ func stubAPMServer(t *testing.T, ch chan<- struct{}) http.Handler {
 }
 
 func TestServerInstrumentation(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	tracerConnected := make(chan struct{}, 1)
@@ -592,7 +592,7 @@ func TestServerInstrumentation(t *testing.T) {
 // make a followup checkin request to get the policy action
 // make another followup ack request for the action
 func Test_SmokeTest_Agent_Calls(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start test server
@@ -741,7 +741,7 @@ func Test_Agent_Enrollment_Id(t *testing.T) {
 		"tags": []
 	    }
 	}`
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start test server
@@ -788,7 +788,7 @@ func Test_Agent_Enrollment_Id_Invalidated_API_key(t *testing.T) {
 		"tags": []
 	    }
 	}`
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start test server
@@ -846,7 +846,7 @@ func Test_Agent_Id_No_ReplaceToken(t *testing.T) {
 		"tags": []
 	    }
 	}`
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start test server
@@ -890,7 +890,7 @@ func Test_Agent_Id_ReplaceToken_Mismatch(t *testing.T) {
 		"tags": []
 	    }
 	}`
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start test server
@@ -945,7 +945,7 @@ func Test_Agent_Id(t *testing.T) {
 		"tags": []
 	    }
 	}`
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start test server
@@ -992,7 +992,7 @@ func Test_Agent_Id(t *testing.T) {
 }
 
 func Test_Agent_Auth_errors(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start test server
@@ -1117,7 +1117,7 @@ func Test_Agent_Auth_errors(t *testing.T) {
 }
 
 func Test_Agent_request_errors(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start test server
@@ -1199,7 +1199,7 @@ func Test_Agent_request_errors(t *testing.T) {
 }
 
 func Test_SmokeTest_CheckinPollTimeout(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start test server
@@ -1331,7 +1331,7 @@ func Test_SmokeTest_CheckinPollTimeout(t *testing.T) {
 }
 
 func Test_SmokeTest_CheckinPollShutdown(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start test server
@@ -1445,7 +1445,7 @@ func Test_SmokeTest_CheckinPollShutdown(t *testing.T) {
 
 // Test_SmokeTest_Verify_v85Migrate will ensure that the policy regenerates output keys when the agent doc contains an empty key
 func Test_SmokeTest_Verify_v85Migrate(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start test server
@@ -1589,7 +1589,7 @@ func Test_SmokeTest_Verify_v85Migrate(t *testing.T) {
 }
 
 func Test_SmokeTest_AuditUnenroll(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start test server

--- a/internal/pkg/server/fleet_secrets_integration_test.go
+++ b/internal/pkg/server/fleet_secrets_integration_test.go
@@ -157,7 +157,7 @@ func createAgentPolicyWithSecrets(t *testing.T, ctx context.Context, bulker bulk
 }
 
 func Test_Agent_Policy_Secrets(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start test server

--- a/internal/pkg/server/fleet_test.go
+++ b/internal/pkg/server/fleet_test.go
@@ -5,6 +5,7 @@
 package server
 
 import (
+	"context"
 	"testing"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
@@ -143,7 +144,7 @@ func Test_initTracer(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := testlog.SetLogger(t).WithContext(t.Context())
+			ctx := testlog.SetLogger(t).WithContext(context.Background())
 			f := Fleet{}
 			t.Setenv("ELASTIC_APM_ACTIVE", tc.apmActiveEnvVariable)
 			tarcer, err := f.initTracer(ctx, tc.cfg)

--- a/internal/pkg/server/namespaces_integration_test.go
+++ b/internal/pkg/server/namespaces_integration_test.go
@@ -154,7 +154,7 @@ func CheckActionResultsNamespace(t *testing.T, ctx context.Context, srv *tserver
 
 func Test_Agent_Namespace_test1(t *testing.T) {
 	testNamespace := "test1"
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start test server

--- a/internal/pkg/server/remote_es_output_integration_test.go
+++ b/internal/pkg/server/remote_es_output_integration_test.go
@@ -140,7 +140,7 @@ func Ack(t *testing.T, ctx context.Context, srv *tserver, actionID, agentID, key
 }
 
 func Test_Agent_Remote_ES_Output(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start test server
@@ -294,7 +294,7 @@ func verifyRemoteAPIKey(t *testing.T, ctx context.Context, apiKeyID string, inva
 }
 
 func Test_Agent_Remote_ES_Output_ForceUnenroll(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start test server
@@ -415,7 +415,7 @@ func Test_Agent_Remote_ES_Output_ForceUnenroll(t *testing.T) {
 }
 
 func Test_Agent_Remote_ES_Output_Unenroll(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start test server

--- a/internal/pkg/ver/check_test.go
+++ b/internal/pkg/ver/check_test.go
@@ -5,6 +5,7 @@
 package ver
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -87,7 +88,7 @@ func TestCheckCompatibilityInternal(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := testlog.SetLogger(t).WithContext(t.Context())
+			ctx := testlog.SetLogger(t).WithContext(context.Background())
 			err := checkCompatibility(ctx, tc.fleetVersion, tc.esVersion)
 			if tc.err != nil {
 				if err == nil {


### PR DESCRIPTION
Reverts elastic/fleet-server#4875 as most likely this PR introduced some data races; CI runs [here](https://buildkite.com/elastic/fleet-server/builds/8219#0196a863-9084-4480-8a42-a5c4f1e00ac3/1799-1812), [here](https://buildkite.com/elastic/fleet-server/builds/8219#0196a863-9085-48b4-9e2f-9e123ed4fe0e/1778-1799) and [here](https://buildkite.com/elastic/fleet-server/builds/8220#0196a948-d0a2-4bdf-8bfe-30813c3e3a7a/1690-1703)