### PR TITLE
github-actions: support label after being merged

### DIFF
--- a/.github/workflows/backport-active.yml
+++ b/.github/workflows/backport-active.yml
@@ -2,7 +2,7 @@ name: Backport to active branches
 
 on:
   pull_request_target:
-    types: [closed]
+    types: [closed, labeled]
     branches:
       - main
 
@@ -15,7 +15,7 @@ jobs:
     # Only run if the PR was merged (not just closed) and has one of the backport labels
     if: |
       github.event.pull_request.merged == true && 
-      contains(toJSON(github.event.pull_request.labels.*.name), 'backport-active-')
+      ( contains(toJSON(github.event.pull_request.labels.*.name), 'backport-active-') || startsWith(github.event.label.name, 'backport-active-') )
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## What is the problem this PR solves?

Fixes a corner case when the PRs have been labeled after being merged with the supported list of active branches.

## How does this PR solve the problem?


## How to test this PR locally

In the CI

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
