### PR TITLE
Reenable benchmark steps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -58,7 +58,6 @@ steps:
           machineType: "c2-standard-8"
 
       - label: "Run go benchmark for ${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
-        skip: true # FIXME: Temporarily disabled until mage is on main
         key: "go-benchmark-base"
         command: ".buildkite/scripts/run_benchmark.sh base"
         env:
@@ -71,7 +70,6 @@ steps:
           machineType: "c2-standard-8"
 
       - label: "Compare results"
-        skip: true # FIXME: Temporarily disabled until mage is on main
         key: "go-benchmark-compare"
         command: ".buildkite/scripts/run_benchmark.sh compare"
         artifact_paths:


### PR DESCRIPTION
## What is the problem this PR solves?

Reenable benchmarks steps that had to be disabled for the mage migration