### PR TITLE
Ensure directory is made within zip artifacts

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -791,6 +791,9 @@ func packageWindows(arch string) error {
 	if err != nil {
 		return fmt.Errorf("unable to turn dir stat into header: %w", err)
 	}
+	if !strings.HasSuffix(dirHeader.Name, "/") {
+		dirHeader.Name += "/"
+	}
 	_, err = zw.CreateHeader(dirHeader)
 	if err != nil {
 		return fmt.Errorf("unable to create zip dir: %w", err)

--- a/magefile.go
+++ b/magefile.go
@@ -1424,10 +1424,6 @@ func unzip(sourceFile, destinationDir string) error {
 			return os.MkdirAll(path, f.Mode())
 		}
 
-		if err = os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			return err
-		}
-
 		out, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
 		if err != nil {
 			return err


### PR DESCRIPTION
## What is the problem this PR solves?

.zip artifacts are incorrectly created so not all tools are able to extract them.

## How does this PR solve the problem?

Ensure that the distribution folder is created within the artifact

## How to test this PR locally

```bash
SNAPSHOT=true PLATFORMS=windows/amd64 mage build:release

unzip build/distributions/fleet-server-9.1.0-SNAPSHOT-windows-x86_64.zip
```