### PR TITLE
Update command used by Dependabot to update NOTICE files

### DIFF
--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           go-version-file: .go-version
 
+      - uses: magefile/mage-action@v3
+        with:
+          install-only: true
+
       - name: update NOTICE.txt and NOTICE-FIPS.txt
         run: mage check:notice
 


### PR DESCRIPTION
Otherwise the Post-dependabot check on PRs fails like so:

```
Run make notice
make: *** No rule to make target 'notice'.  Stop.
Error: Process completed with exit code 2.
```