### PR TITLE
Change FIPS build base images to golang-crossbuild

### DIFF
--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -1,5 +1,5 @@
 ARG GO_VERSION
-# Suffix should be main-debian11-fips or arm-fips
+# Suffix should be main-debian11-fips or base-arm-debian11-fips
 ARG SUFFIX
 FROM docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-${SUFFIX} AS base
 
@@ -23,7 +23,7 @@ CMD [ "build:release" ]
 # FIPS docker image defined below
 # Does not use base as the lowest layer so we don't have to deal with user/ownership issues when building the image.
 ARG GO_VERSION
-# Suffix should be main-debian11-fips or arm-fips
+# Suffix should be main-debian11-fips or base-arm-debian11-fips
 ARG SUFFIX
 FROM docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-${SUFFIX} AS builder
 

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -1,5 +1,7 @@
 ARG GO_VERSION
-FROM --platform=${BUILDPLATFORM:-linux} mcr.microsoft.com/oss/go/microsoft/golang:${GO_VERSION}-1-fips-bookworm AS base
+# Suffix should be main-debian11-fips or arm-fips
+ARG SUFFIX
+FROM docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-${SUFFIX} AS base
 
 RUN groupadd --gid 1000 fleet-server && \
     useradd -M -d /fleet-server/ --uid 1000 --gid 1000 fleet-server
@@ -21,7 +23,9 @@ CMD [ "build:release" ]
 # FIPS docker image defined below
 # Does not use base as the lowest layer so we don't have to deal with user/ownership issues when building the image.
 ARG GO_VERSION
-FROM --platform=${BUILDPLATFORM:-linux} mcr.microsoft.com/oss/go/microsoft/golang:${GO_VERSION}-1-fips-bookworm AS builder
+# Suffix should be main-debian11-fips or arm-fips
+ARG SUFFIX
+FROM docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-${SUFFIX} AS builder
 
 WORKDIR /fleet-server
 

--- a/magefile.go
+++ b/magefile.go
@@ -95,7 +95,7 @@ const (
 	binaryExe  = "fleet-server.exe"
 
 	dockerSuffix      = "main-debian11"
-	dockerArmSuffix   = "base-arm-debian9"
+	dockerArmSuffix   = "base-arm-debian11"
 	dockerBuilderFile = "Dockerfile.build"
 	dockerBuilderFIPS = "Dockerfile.fips"
 	dockerBuilderName = "fleet-server-builder"
@@ -899,7 +899,7 @@ func (Docker) Builder() error {
 
 	args := []string{"build", "-t", dockerBuilderName + ":" + getGoVersion(), "--build-arg", "GO_VERSION=" + getGoVersion()}
 	if isFIPS() {
-		args = append(args, "-f", dockerBuilderFIPS, "--target", "base", ".")
+		args = append(args, "-f", dockerBuilderFIPS, "--build-arg", "SUFFIX="+suffix+"-fips", "--target", "base", ".")
 	} else {
 		args = append(args, "-f", dockerBuilderFile, "--build-arg", "SUFFIX="+suffix, ".")
 	}


### PR DESCRIPTION
## What is the problem this PR solves?

Change FIPS build base images to golang-crossbuild.
Change arm base to debian11.

## How to test this PR locally

`FIPS=true mage docker:[image|binary]`