### PR TITLE
Add a retry to cloudE2E testing

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -209,6 +209,11 @@ steps:
             allow_failure: false
           - step: "e2e-test"
             allow_failure: false
+        retry:
+          automatic:
+            limit: 1
+          manual:
+            allowed: true
 
       - label: ":gcloud: Cloud e2e FIPS Test"
         key: "cloud-e2e-fips-test"
@@ -231,6 +236,11 @@ steps:
             allow_failure: false
           - step: "e2e-test"
             allow_failure: false
+        retry:
+          automatic:
+            limit: 1
+          manual:
+            allowed: true
 
   - label: ":docker: Publish docker image"
     key: "publish"


### PR DESCRIPTION
## What is the problem this PR solves?

The terrafrom deployment for cloudE2E tests are not completely reliable. See https://buildkite.com/elastic/fleet-server/builds/8783

## How does this PR solve the problem?

Add an automatic retry if one of the cloudE2E test steps fail.