### PR TITLE
Include base error for json decode error responses

### DIFF
--- a/changelog/fragments/1750971846-Include-error-on-json-decode-error-responses.yaml
+++ b/changelog/fragments/1750971846-Include-error-on-json-decode-error-responses.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Include the base error for json decode error responses
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: fleet-server
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/changelog/fragments/1750971846-Include-error-on-json-decode-error-responses.yaml
+++ b/changelog/fragments/1750971846-Include-error-on-json-decode-error-responses.yaml
@@ -25,7 +25,7 @@ component: fleet-server
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-#pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/fleet-server/pull/5069
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.

--- a/internal/pkg/api/error.go
+++ b/internal/pkg/api/error.go
@@ -52,7 +52,11 @@ type BadRequestErr struct {
 }
 
 func (e *BadRequestErr) Error() string {
-	return fmt.Sprintf("Bad request: %s", e.msg)
+	s := fmt.Sprintf("Bad request: %s", e.msg)
+	if e.nextErr != nil {
+		s += ": " + e.nextErr.Error()
+	}
+	return s
 }
 
 func (e *BadRequestErr) Unwrap() error {

--- a/internal/pkg/api/handleAck_test.go
+++ b/internal/pkg/api/handleAck_test.go
@@ -825,7 +825,7 @@ func TestValidateAckRequest(t *testing.T) {
 			cfg: &config.Server{
 				Limits: config.ServerLimits{},
 			},
-			expErr: &BadRequestErr{msg: "unable to decode ack request"},
+			expErr: &BadRequestErr{msg: "unable to decode ack request", nextErr: errors.New("invalid character 'o' in literal null (expecting 'u')")},
 			expAck: nil,
 		},
 	}

--- a/internal/pkg/api/handleAudit_test.go
+++ b/internal/pkg/api/handleAudit_test.go
@@ -6,6 +6,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,13 +14,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
 	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
 	"github.com/elastic/fleet-server/v7/internal/pkg/model"
 	ftesting "github.com/elastic/fleet-server/v7/internal/pkg/testing"
 	testlog "github.com/elastic/fleet-server/v7/internal/pkg/testing/log"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_Audit_validateUnenrollRequst(t *testing.T) {
@@ -47,7 +49,7 @@ func Test_Audit_validateUnenrollRequst(t *testing.T) {
 		},
 		cfg:   &config.Server{},
 		valid: nil,
-		err:   &BadRequestErr{msg: "unable to decode audit/unenroll request"},
+		err:   &BadRequestErr{msg: "unable to decode audit/unenroll request", nextErr: errors.New("invalid character '}' looking for beginning of value")},
 	}, {
 		name: "bad reason",
 		req: &http.Request{
@@ -69,7 +71,7 @@ func Test_Audit_validateUnenrollRequst(t *testing.T) {
 			},
 		},
 		valid: nil,
-		err:   &BadRequestErr{msg: "unable to decode audit/unenroll request"},
+		err:   &BadRequestErr{msg: "unable to decode audit/unenroll request", nextErr: errors.New("http: request body too large")},
 	}}
 
 	for _, tc := range tests {

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -10,6 +10,7 @@ import (
 	"compress/flate"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -991,7 +992,7 @@ func TestValidateCheckinRequest(t *testing.T) {
 			req: &http.Request{
 				Body: io.NopCloser(strings.NewReader(`{"invalidJson":}`)),
 			},
-			expErr: &BadRequestErr{msg: "unable to decode checkin request"},
+			expErr: &BadRequestErr{msg: "unable to decode checkin request", nextErr: errors.New("invalid character '}' looking for beginning of value")},
 			cfg: &config.Server{
 				Limits: config.ServerLimits{
 					CheckinLimit: config.Limit{
@@ -1021,7 +1022,7 @@ func TestValidateCheckinRequest(t *testing.T) {
 			req: &http.Request{
 				Body: io.NopCloser(strings.NewReader(`{"validJson": "test", "status": "test", "poll_timeout": "not a timeout", "message": "test message"}`)),
 			},
-			expErr: &BadRequestErr{msg: "poll_timeout cannot be parsed as duration"},
+			expErr: &BadRequestErr{msg: "poll_timeout cannot be parsed as duration", nextErr: errors.New("time: invalid duration \"not a timeout\"")},
 			cfg: &config.Server{
 				Limits: config.ServerLimits{
 					CheckinLimit: config.Limit{

--- a/internal/pkg/api/handleEnroll_test.go
+++ b/internal/pkg/api/handleEnroll_test.go
@@ -572,7 +572,7 @@ func TestEnrollerT_retrieveStaticTokenEnrollmentToken(t *testing.T) {
 func TestValidateEnrollRequest(t *testing.T) {
 	t.Run("invalid json", func(t *testing.T) {
 		req, err := validateRequest(context.Background(), strings.NewReader("not a json"))
-		assert.Equal(t, "Bad request: unable to decode enroll request", err.Error())
+		assert.Equal(t, "Bad request: unable to decode enroll request: invalid character 'o' in literal null (expecting 'u')", err.Error())
 		assert.Nil(t, req)
 	})
 	t.Run("fips attribute in local metadata", func(t *testing.T) {


### PR DESCRIPTION
## What is the problem this PR solves?

There is no information on why request bodies fail to decode as JSON

## How does this PR solve the problem?

Include the base json decode error as part of the response.

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)
