### PR TITLE
Remove async in buildkite pipelines

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -259,7 +259,6 @@ steps:
         allow_failure: false
 
   - label: ":serverless::argo: Run synthetics tests and update fleet to ${BUILDKITE_COMMIT:0:12} in serverless-gitops"
-    async: true
     branches: main
     trigger: gpctl-promote-after-serverless-devenv-synthetics
     build:
@@ -288,7 +287,6 @@ steps:
   - label: ":jenkins: Release - Package Registry Distribution"
     key: "release-package-registry"
     trigger: "package-registry-release-package-registry-distribution"
-    async: true
     build:
       branch: "main"
       meta_data:
@@ -298,7 +296,6 @@ steps:
   - trigger: "fleet-server-package-mbp"
     label: ":esbuild: Downstream - Package"
     key: "downstream-package"
-    async: true
     if: "build.env('BUILDKITE_PULL_REQUEST') == 'false' && build.env('BUILDKITE_TAG') == '' && build.env('BUILDKITE_BRANCH') != ''"
     build:
       branch: "${BUILDKITE_BRANCH}"


### PR DESCRIPTION
## What is the problem this PR solves?

This ensures that `main` is not marked green unless the spawned jobs are successful. This gives better visibility to ensure that what is in `main` ends up in production.

## How does this PR solve the problem?

Removes `async` from the `.buildkite/pipeline.yml`.
