### PR TITLE
ci: move from dependabot reviewers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,5 @@
 
 # Allow to auto-merge PRs with Mergify
 dev-tools/integration/.env
+
+/.github @elastic/observablt-ci @elastic/observablt-ci-contractors

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,9 +22,6 @@ updates:
     directories:
       - '/'
       - '/.github/actions/*'
-    reviewers:
-      - "elastic/observablt-ci"
-      - "elastic/observablt-ci-contractors"
     schedule:
       interval: "weekly"
       day: "sunday"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?
Reviewers dependabot.yml configuration is being retired option because the functionality overlaps with [GitHub code owners](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
See: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/


## How does this PR solve the problem?
Removed reviewers section in dependabot.yml and moved it's definition to CODEOWNERS.


## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- ~[ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~
- ~[ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~
- ~[ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- ~[ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)~


