### PR TITLE
Fix changed files check in the post-dependabot GHA job

### DIFF
--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: check for modified files
         id: check-files
-        run: echo "modified=$(if git diff-index --quiet HEAD -- NOTICE.txt NOTICE-fips.txt testing/go.mod testing/go.sum; then echo "false"; else echo "true"; fi)" >> $GITHUB_OUTPUT
+        run: echo "modified=$(if git diff --quiet HEAD -- NOTICE.txt NOTICE-fips.txt testing/go.mod testing/go.sum; then echo "false"; else echo "true"; fi)" >> $GITHUB_OUTPUT
 
       - name: commit modified files
         if: steps.check-files.outputs.modified == 'true'


### PR DESCRIPTION
## What is the problem this PR solves?

We run a Github Actions job for dependabot PRs where we update the notice files. However, this job fails for PRs which only touch the `testing` directory. See https://github.com/elastic/fleet-server/pull/5161 for example.

## How does this PR solve the problem?

The check currently uses git diff-index, which can give false positives if the file's modification time has changed, but the content hasn't. Our job regenerates both go.sum and the notice files, so their modification times change even if the content doesn't. Use git diff instead, which will silently run git update-index --refresh in this case.

See https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-diffautoRefreshIndex and https://git-scm.com/docs/git-diff-index#_non_cached_mode for more details. Also see https://git-scm.com/docs/racy-git if you're interested in a more holistic explanation of this behavior of git.

## How to test this PR locally

Run the following commands and compare the output:

```bash
touch NOTICE.txt
git diff -- NOTICE.txt
git diff-index -- NOTICE.TXT
```