### PR TITLE
Remove required tags from openapi spec

### DIFF
--- a/changelog/fragments/1753460228-Correct-open-api-spec.yaml
+++ b/changelog/fragments/1753460228-Correct-open-api-spec.yaml
@@ -1,0 +1,33 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: other
+
+# Change summary; a 80ish characters long description of the change.
+summary: Correct open-api spec
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  Fixed required attributes in fleet-server's openapi.yml.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: fleet-server
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+issue: https://github.com/elastic/fleet-server/issues/3702

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -952,7 +952,7 @@ func TestParseComponents(t *testing.T) {
 				}},
 			},
 			req: &CheckinRequest{
-				Components: &degradedInputReqComponents,
+				Components: degradedInputReqComponents,
 			},
 			outComponents:   nil,
 			unhealthyReason: &[]string{"input"},
@@ -972,7 +972,7 @@ func TestParseComponents(t *testing.T) {
 			},
 			req: &CheckinRequest{
 				Status:     "DEGRADED",
-				Components: &degradedInputReqComponents,
+				Components: degradedInputReqComponents,
 			},
 			outComponents:   degradedInputReqComponents,
 			unhealthyReason: &[]string{"input"},

--- a/internal/pkg/api/openapi.gen.go
+++ b/internal/pkg/api/openapi.gen.go
@@ -228,7 +228,7 @@ type ActionMigrate struct {
 
 	// Settings An embedded JSON object that holds user-provided settings like TLS.
 	// Defined in fleet-server as a `json.RawMessage`.
-	Settings *json.RawMessage `json:"settings,omitempty"`
+	Settings json.RawMessage `json:"settings,omitempty"`
 
 	// TargetUri URI of Fleet Server in a target cluster.
 	TargetUri string `json:"target_uri"`
@@ -257,7 +257,7 @@ type ActionPrivilegeLevelChange struct {
 // ActionRequestDiagnostics The REQUEST_DIAGNOSTICS action data.
 type ActionRequestDiagnostics struct {
 	// AdditionalMetrics list optional additional metrics.
-	AdditionalMetrics *[]ActionRequestDiagnosticsAdditionalMetrics `json:"additional_metrics,omitempty"`
+	AdditionalMetrics []ActionRequestDiagnosticsAdditionalMetrics `json:"additional_metrics,omitempty"`
 }
 
 // ActionRequestDiagnosticsAdditionalMetrics defines model for ActionRequestDiagnostics.AdditionalMetrics.
@@ -316,13 +316,13 @@ type CheckinRequest struct {
 	// Components An embedded JSON object that holds component information that the agent is running.
 	// Defined in fleet-server as a `json.RawMessage`, defined as an object in the elastic-agent.
 	// fleet-server will update the components in an agent record if they differ from this object.
-	Components *json.RawMessage `json:"components,omitempty"`
+	Components json.RawMessage `json:"components,omitempty"`
 
 	// LocalMetadata An embedded JSON object that holds meta-data values.
 	// Defined in fleet-server as a `json.RawMessage`, defined as an object in the elastic-agent.
 	// elastic-agent will populate the object with information from the binary and host/system environment.
 	// fleet-server will update the agent record if a checkin response contains different data from the record.
-	LocalMetadata *json.RawMessage `json:"local_metadata,omitempty"`
+	LocalMetadata json.RawMessage `json:"local_metadata,omitempty"`
 
 	// Message State message, may be overridden or use the error message of a failing component.
 	Message string `json:"message"`
@@ -352,7 +352,7 @@ type CheckinResponse struct {
 	Action string `json:"action"`
 
 	// Actions A list of actions that the agent must execute.
-	Actions *[]Action `json:"actions,omitempty"`
+	Actions []Action `json:"actions,omitempty"`
 }
 
 // DiagnosticsEvent defines model for diagnosticsEvent.
@@ -408,7 +408,7 @@ type EnrollMetadata struct {
 
 	// Tags User provided tags for the agent.
 	// fleet-server will pass the tags to the agent record on enrollment.
-	Tags []string `json:"tags"`
+	Tags []string `json:"tags,omitempty"`
 
 	// UserProvided An embedded JSON object that holds user-provided meta-data values.
 	// Defined in fleet-server as a `json.RawMessage`.
@@ -480,7 +480,7 @@ type EnrollResponseItem struct {
 	//
 	// Never used by agent.
 	// Deprecated: Not used by elastic-agent.
-	Actions []map[string]interface{} `json:"actions"`
+	Actions []map[string]interface{} `json:"actions,omitempty"`
 
 	// Active If the agent is active in fleet.
 	// Set to true upon enrollment.
@@ -649,28 +649,28 @@ type InputEvent struct {
 // PolicyData The full policy that an agent should run after combining with local configuration/env vars.
 type PolicyData struct {
 	// Agent Agent configuration details associated with the policy. May include configuration toggling monitoring, uninstallation protection, etc.
-	Agent *map[string]interface{} `json:"agent,omitempty"`
+	Agent map[string]interface{} `json:"agent,omitempty"`
 
 	// Fleet Agent configuration to describe how to connect to fleet-server.
-	Fleet *map[string]interface{} `json:"fleet,omitempty"`
+	Fleet map[string]interface{} `json:"fleet,omitempty"`
 
 	// Id The policy's ID.
-	Id *string `json:"id,omitempty"`
+	Id string `json:"id,omitempty"`
 
 	// Inputs A list of all inputs that the agent should run.
-	Inputs *[]map[string]interface{} `json:"inputs,omitempty"`
+	Inputs []map[string]interface{} `json:"inputs,omitempty"`
 
 	// OutputPermissions Elasticsearch permissions that the agent requires in order to run the policy.
-	OutputPermissions *map[string]interface{} `json:"output_permissions,omitempty"`
+	OutputPermissions map[string]interface{} `json:"output_permissions,omitempty"`
 
 	// Outputs A map of all outputs that the agent running the policy can use to send data to.
-	Outputs *map[string]interface{} `json:"outputs,omitempty"`
+	Outputs map[string]interface{} `json:"outputs,omitempty"`
 
 	// Revision The revision number of the policy. Should match revision_idx.
-	Revision *int `json:"revision,omitempty"`
+	Revision int `json:"revision,omitempty"`
 
 	// SecretPaths A list of keys that reference secret values that have been injected into the policy.
-	SecretPaths *[]string `json:"secret_paths,omitempty"`
+	SecretPaths []string `json:"secret_paths,omitempty"`
 
 	// Signed Optional action signing data.
 	Signed *ActionSignature `json:"signed,omitempty" yaml:"signed"`

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -1226,8 +1226,8 @@ func Test_SmokeTest_CheckinPollTimeout(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("Ack actions for agent %s", agentID)
-	events := make([]api.AckRequest_Events_Item, 0, len(*checkinResponse.Actions))
-	for _, action := range *checkinResponse.Actions {
+	events := make([]api.AckRequest_Events_Item, 0, len(checkinResponse.Actions))
+	for _, action := range checkinResponse.Actions {
 		event := api.GenericEvent{
 			ActionId: action.Id,
 			AgentId:  agentID,
@@ -1358,8 +1358,8 @@ func Test_SmokeTest_CheckinPollShutdown(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("Ack actions for agent %s", agentID)
-	events := make([]api.AckRequest_Events_Item, 0, len(*checkinResponse.Actions))
-	for _, action := range *checkinResponse.Actions {
+	events := make([]api.AckRequest_Events_Item, 0, len(checkinResponse.Actions))
+	for _, action := range checkinResponse.Actions {
 		event := api.GenericEvent{
 			ActionId: action.Id,
 			AgentId:  agentID,

--- a/internal/pkg/server/fleet_secrets_integration_test.go
+++ b/internal/pkg/server/fleet_secrets_integration_test.go
@@ -223,14 +223,14 @@ func Test_Agent_Policy_Secrets(t *testing.T) {
 	require.NoError(t, err)
 
 	// expect 1 POLICY_CHANGE action
-	assert.Equal(t, 1, len(*checkinResponse.Actions))
-	assert.Equal(t, api.POLICYCHANGE, (*checkinResponse.Actions)[0].Type)
-	actionData, err := (*checkinResponse.Actions)[0].Data.AsActionPolicyChange()
+	assert.Equal(t, 1, len(checkinResponse.Actions))
+	assert.Equal(t, api.POLICYCHANGE, checkinResponse.Actions[0].Type)
+	actionData, err := checkinResponse.Actions[0].Data.AsActionPolicyChange()
 	require.NoError(t, err)
 	require.NotNil(t, actionData.Policy.Inputs)
-	require.NotNil(t, (*actionData.Policy.Inputs)[0])
+	require.NotNil(t, actionData.Policy.Inputs[0])
 
-	input := (*actionData.Policy.Inputs)[0]
+	input := actionData.Policy.Inputs[0]
 	// expect secret reference replaced with secret value
 	assert.Equal(t, map[string]interface{}{
 		"package_var_secret": "secret_value",
@@ -238,7 +238,7 @@ func Test_Agent_Policy_Secrets(t *testing.T) {
 	}, input)
 
 	// expect output secret to be replaced
-	output := (*actionData.Policy.Outputs)["default"]
+	output := actionData.Policy.Outputs["default"]
 	assert.Conditionf(t, func() bool {
 		mp, ok := output.(map[string]interface{})
 		if !ok {
@@ -256,5 +256,5 @@ func Test_Agent_Policy_Secrets(t *testing.T) {
 	}, "expected output to contain secret-key: output_secret_value, got %v", output)
 	assert.NotContains(t, output, "secrets")
 	// expect that secret_paths lists the key
-	assert.ElementsMatch(t, []string{"inputs.0.package_var_secret", "outputs.default.secret-key"}, *actionData.Policy.SecretPaths)
+	assert.ElementsMatch(t, []string{"inputs.0.package_var_secret", "outputs.default.secret-key"}, actionData.Policy.SecretPaths)
 }

--- a/model/openapi.yml
+++ b/model/openapi.yml
@@ -9,7 +9,6 @@ info:
     The fleet-server API that is used by agents when enrolled with fleet.
 
     Note that the current implementations in the fleet-server and elastic-agent may have some difference specifically when it comes to some objects.
-    This is most notable when comparing the `Action` implementations. Fleet-server uses a general template for all actions and the elastic-agent will have more specific representations.
 
     The implementation of fleet-server by default also includes a connection count limiter, as well as limiters for request body sizes.
     If an agent attempts to make request but there are no remaining connections, the attempt will be blocked and the agent will get an error.
@@ -102,7 +101,6 @@ components:
       required:
         - user_provided
         - local
-        - tags
       properties:
         user_provided:
           deprecated: true
@@ -130,6 +128,7 @@ components:
           description: |
             User provided tags for the agent.
             fleet-server will pass the tags to the agent record on enrollment.
+          x-go-type-skip-optional-pointer: true
           type: array
           items:
             type: string
@@ -190,7 +189,6 @@ components:
         - enrolled_at
         - user_provided_metadata
         - local_metadata
-        - actions
         - access_api_key_id
         - access_api_key
         - status
@@ -233,6 +231,7 @@ components:
           type: string
           format: application/json
           x-go-type: json.RawMessage
+          x-go-type-skip-optional-pointer: true
         local_metadata:
           deprecated: true
           x-deprecated-reason: Not used by elastic-agent.
@@ -243,8 +242,10 @@ components:
           type: string
           format: application/json
           x-go-type: json.RawMessage
+          x-go-type-skip-optional-pointer: true
         actions:
           deprecated: true
+          x-go-type-skip-optional-pointer: true
           x-deprecated-reason: Not used by elastic-agent.
           description: |
             Defined in fleet-server and elastic-agent as `[]interface{}`.
@@ -401,6 +402,7 @@ components:
           type: string
           format: application/json
           x-go-type: json.RawMessage
+          x-go-type-skip-optional-pointer: true
         components:
           description: |
             An embedded JSON object that holds component information that the agent is running.
@@ -409,6 +411,7 @@ components:
           type: string
           format: application/json
           x-go-type: json.RawMessage
+          x-go-type-skip-optional-pointer: true
         poll_timeout:
           description: |
             An optional timeout value that informs fleet-server of when a client will time out on it's checkin request.
@@ -497,6 +500,7 @@ components:
           # oapi-codegen type should be: interface{}
           description: An embedded action-specific object.
           x-go-custom-tag: yaml:"data"
+          x-go-type-skip-optional-pointer: true
           x-oapi-codegen-extra-tags:
             yaml: "data"
           oneOf:
@@ -561,33 +565,41 @@ components:
         id:
           description: The policy's ID.
           type: string
+          x-go-type-skip-optional-pointer: true
         secret_paths:
           description: A list of keys that reference secret values that have been injected into the policy.
           type: array
           items:
             type: string
+          x-go-type-skip-optional-pointer: true
         outputs:
           description: A map of all outputs that the agent running the policy can use to send data to.
           type: object
+          x-go-type-skip-optional-pointer: true
         inputs:
           description: A list of all inputs that the agent should run.
           type: array
           items:
             type: object
+          x-go-type-skip-optional-pointer: true
         revision:
           description: The revision number of the policy. Should match revision_idx.
           type: integer
+          x-go-type-skip-optional-pointer: true
         agent:
           description: Agent configuration details associated with the policy. May include configuration toggling monitoring, uninstallation protection, etc.
           type: object
+          x-go-type-skip-optional-pointer: true
         signed:
           $ref: "#/components/schemas/actionSignature"
         output_permissions:
           description: Elasticsearch permissions that the agent requires in order to run the policy.
           type: object
+          x-go-type-skip-optional-pointer: true
         fleet:
           description: Agent configuration to describe how to connect to fleet-server.
           type: object
+          x-go-type-skip-optional-pointer: true
     actionUnenroll:
       description: The UNENROLL action data.
       # unenroll actions have no `data` attribute
@@ -602,6 +614,7 @@ components:
             enum:
               - CPU
               - CONN
+          x-go-type-skip-optional-pointer: true
     actionPolicyReassign:
       description: The POLICY_REASSIGN action data.
       type: object
@@ -675,6 +688,7 @@ components:
             Defined in fleet-server as a `json.RawMessage`.
           format: application/json
           x-go-type: json.RawMessage
+          x-go-type-skip-optional-pointer: true
       required:
        - enrollment_token
        - target_uri
@@ -705,6 +719,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/action"
+          x-go-type-skip-optional-pointer: true
     eventType:
       deprecated: true
       x-deprecated-reason: Not used by fleet-server. # TODO check if this is used by security integrations and should be undeprecated.
@@ -880,8 +895,6 @@ components:
       type: object
       required:
         - action
-        - items # NOTE: work around as we don't want a pointer here
-        - errors # NOTE: work around as we don't want a pointer here
       properties:
         action:
           description: The action result. Will have the value "acks".
@@ -891,6 +904,7 @@ components:
           type: boolean
           x-oapi-codegen-extra-tags:
             json: "errors,omitempty"
+          x-go-type-skip-optional-pointer: true
         items:
           description: The in-order list of results from processing events.
           type: array
@@ -898,6 +912,7 @@ components:
             $ref: "#/components/schemas/ackResponseItem"
           x-oapi-codegen-extra-tags:
             json: "items,omitempty"
+          x-go-type-skip-optional-pointer: true
     uploadBeginRequest:
       title: "Upload Operation Start request body"
       type: object

--- a/pkg/api/types.gen.go
+++ b/pkg/api/types.gen.go
@@ -225,7 +225,7 @@ type ActionMigrate struct {
 
 	// Settings An embedded JSON object that holds user-provided settings like TLS.
 	// Defined in fleet-server as a `json.RawMessage`.
-	Settings *json.RawMessage `json:"settings,omitempty"`
+	Settings json.RawMessage `json:"settings,omitempty"`
 
 	// TargetUri URI of Fleet Server in a target cluster.
 	TargetUri string `json:"target_uri"`
@@ -254,7 +254,7 @@ type ActionPrivilegeLevelChange struct {
 // ActionRequestDiagnostics The REQUEST_DIAGNOSTICS action data.
 type ActionRequestDiagnostics struct {
 	// AdditionalMetrics list optional additional metrics.
-	AdditionalMetrics *[]ActionRequestDiagnosticsAdditionalMetrics `json:"additional_metrics,omitempty"`
+	AdditionalMetrics []ActionRequestDiagnosticsAdditionalMetrics `json:"additional_metrics,omitempty"`
 }
 
 // ActionRequestDiagnosticsAdditionalMetrics defines model for ActionRequestDiagnostics.AdditionalMetrics.
@@ -313,13 +313,13 @@ type CheckinRequest struct {
 	// Components An embedded JSON object that holds component information that the agent is running.
 	// Defined in fleet-server as a `json.RawMessage`, defined as an object in the elastic-agent.
 	// fleet-server will update the components in an agent record if they differ from this object.
-	Components *json.RawMessage `json:"components,omitempty"`
+	Components json.RawMessage `json:"components,omitempty"`
 
 	// LocalMetadata An embedded JSON object that holds meta-data values.
 	// Defined in fleet-server as a `json.RawMessage`, defined as an object in the elastic-agent.
 	// elastic-agent will populate the object with information from the binary and host/system environment.
 	// fleet-server will update the agent record if a checkin response contains different data from the record.
-	LocalMetadata *json.RawMessage `json:"local_metadata,omitempty"`
+	LocalMetadata json.RawMessage `json:"local_metadata,omitempty"`
 
 	// Message State message, may be overridden or use the error message of a failing component.
 	Message string `json:"message"`
@@ -349,7 +349,7 @@ type CheckinResponse struct {
 	Action string `json:"action"`
 
 	// Actions A list of actions that the agent must execute.
-	Actions *[]Action `json:"actions,omitempty"`
+	Actions []Action `json:"actions,omitempty"`
 }
 
 // DiagnosticsEvent defines model for diagnosticsEvent.
@@ -405,7 +405,7 @@ type EnrollMetadata struct {
 
 	// Tags User provided tags for the agent.
 	// fleet-server will pass the tags to the agent record on enrollment.
-	Tags []string `json:"tags"`
+	Tags []string `json:"tags,omitempty"`
 
 	// UserProvided An embedded JSON object that holds user-provided meta-data values.
 	// Defined in fleet-server as a `json.RawMessage`.
@@ -477,7 +477,7 @@ type EnrollResponseItem struct {
 	//
 	// Never used by agent.
 	// Deprecated: Not used by elastic-agent.
-	Actions []map[string]interface{} `json:"actions"`
+	Actions []map[string]interface{} `json:"actions,omitempty"`
 
 	// Active If the agent is active in fleet.
 	// Set to true upon enrollment.
@@ -646,28 +646,28 @@ type InputEvent struct {
 // PolicyData The full policy that an agent should run after combining with local configuration/env vars.
 type PolicyData struct {
 	// Agent Agent configuration details associated with the policy. May include configuration toggling monitoring, uninstallation protection, etc.
-	Agent *map[string]interface{} `json:"agent,omitempty"`
+	Agent map[string]interface{} `json:"agent,omitempty"`
 
 	// Fleet Agent configuration to describe how to connect to fleet-server.
-	Fleet *map[string]interface{} `json:"fleet,omitempty"`
+	Fleet map[string]interface{} `json:"fleet,omitempty"`
 
 	// Id The policy's ID.
-	Id *string `json:"id,omitempty"`
+	Id string `json:"id,omitempty"`
 
 	// Inputs A list of all inputs that the agent should run.
-	Inputs *[]map[string]interface{} `json:"inputs,omitempty"`
+	Inputs []map[string]interface{} `json:"inputs,omitempty"`
 
 	// OutputPermissions Elasticsearch permissions that the agent requires in order to run the policy.
-	OutputPermissions *map[string]interface{} `json:"output_permissions,omitempty"`
+	OutputPermissions map[string]interface{} `json:"output_permissions,omitempty"`
 
 	// Outputs A map of all outputs that the agent running the policy can use to send data to.
-	Outputs *map[string]interface{} `json:"outputs,omitempty"`
+	Outputs map[string]interface{} `json:"outputs,omitempty"`
 
 	// Revision The revision number of the policy. Should match revision_idx.
-	Revision *int `json:"revision,omitempty"`
+	Revision int `json:"revision,omitempty"`
 
 	// SecretPaths A list of keys that reference secret values that have been injected into the policy.
-	SecretPaths *[]string `json:"secret_paths,omitempty"`
+	SecretPaths []string `json:"secret_paths,omitempty"`
 
 	// Signed Optional action signing data.
 	Signed *ActionSignature `json:"signed,omitempty" yaml:"signed"`

--- a/testing/e2e/api_version/client_api_2023_06_01.go
+++ b/testing/e2e/api_version/client_api_2023_06_01.go
@@ -132,11 +132,13 @@ func (tester *ClientAPITester20230601) Checkin(ctx context.Context, apiKey, agen
 	tester.Assert().Equal(http.StatusOK, resp.StatusCode())
 	checkin := resp.JSON200
 	tester.Assert().NotNil(checkin.AckToken, "expected to recieve ack token from checkin")
-	tester.Assert().NotNil(checkin.Actions, "expected to actions from checkin")
 
-	actionIds := make([]string, len(*checkin.Actions))
-	for i, action := range *checkin.Actions {
-		actionIds[i] = action.Id
+	var actionIds []string
+	if checkin.Actions != nil {
+		actionIds = make([]string, len(*checkin.Actions))
+		for i, action := range *checkin.Actions {
+			actionIds[i] = action.Id
+		}
 	}
 
 	return checkin.AckToken, actionIds

--- a/testing/e2e/api_version/client_api_current.go
+++ b/testing/e2e/api_version/client_api_current.go
@@ -142,10 +142,9 @@ func (tester *ClientAPITester) Checkin(ctx context.Context, apiKey, agentID stri
 	// Process a successful check-in response.
 	checkin := resp.JSON200
 	tester.Require().NotNil(checkin.AckToken, "expected to recieve ack token from checkin")
-	tester.Require().NotNil(checkin.Actions, "expected to actions from checkin")
 
-	actionIds := make([]string, len(*checkin.Actions))
-	for i, action := range *checkin.Actions {
+	actionIds := make([]string, len(checkin.Actions))
+	for i, action := range checkin.Actions {
 		actionIds[i] = action.Id
 	}
 


### PR DESCRIPTION
## What is the problem this PR solves?

Fixed required attributes in fleet-server's openapi.yml.

## How does this PR solve the problem?

Remove some attributes from the required lists in the openapi spec so that the spec actually reflects what the fleet-server does. Instruct openapi to avoid pointers when using lists, maps, or `json.RawMessage` as these are already pointers in go, and the extra indirection is not needed.

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Closes #3702 