### PR TITLE
Log agent download url in e2e tests

### DIFF
--- a/testing/e2e/agent_install_test.go
+++ b/testing/e2e/agent_install_test.go
@@ -149,6 +149,7 @@ func (suite *AgentInstallSuite) downloadAgent(ctx context.Context) io.ReadCloser
 	suite.Require().NoError(err)
 	resp, err = suite.Client.Do(req)
 	suite.Require().NoError(err)
+	suite.T().Logf("Downloading elastic-agent from %s", pkg.URL)
 	return resp.Body
 }
 


### PR DESCRIPTION
## What is the problem this PR solves?

agent install e2e tests can fail due to bad downloads, for example https://github.com/elastic/fleet-server/pull/5190 shows an error: `gzip: invalid header` when trying to extract a downloaded file. but we don't see what the URL is.

## How does this PR solve the problem?

Log the URL that the agent file is downloaded from.