### PR TITLE
Redirect FIPS cloud e2e tests to FRH-Staging

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -45,15 +45,6 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server-package-mbp" ]]; then
 fi
 
 # TODO: use a builkite plugin to handle this
-if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server" ]]; then
-  if [[ "$BUILDKITE_STEP_KEY" == "cloud-e2e-test" || "$BUILDKITE_STEP_KEY" == "cloud-e2e-fips-test"  ]]; then
-    export EC_API_KEY_SECRET=$(retry 5 vault kv get -field apiKey "${EC_KEY_SECRET_PATH}")
-    # Environment variables required by the Elastic Cloud service deployer
-    export EC_API_KEY=${EC_API_KEY_SECRET}
-  fi
-fi
-
-# TODO: use a builkite plugin to handle this
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "fleet-server-package-mbp" ]]; then
   if [[ "$BUILDKITE_STEP_KEY" == "dra-snapshot" || "$BUILDKITE_STEP_KEY" == "dra-staging" ]]; then
     DRA_CREDS_SECRET=$(retry 5 vault kv get -field=data -format=json ${CI_DRA_ROLE_PATH})

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -4,7 +4,6 @@ set -euo pipefail
 
 source .buildkite/scripts/common.sh
 
-EC_KEY_SECRET_PATH="kv/ci-shared/platform-ingest/platform-ingest-ec-prod"
 CI_DRA_ROLE_PATH="kv/ci-shared/release/dra-role"
 JOB_GCS_BUCKET="fleet-server-ci-internal"
 GITHUB_REPO_TOKEN=$VAULT_GITHUB_TOKEN

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -208,6 +208,10 @@ steps:
           provider: "gcp"
         plugins:
           - *docker_elastic_login_plugin
+          - elastic/vault-secrets#v0.1.0:
+              path: "kv/ci-shared/platform-ingest/platform-ingest-ec-prod"
+              field: "apiKey"
+              env_var: "EC_API_KEY"
         depends_on:
           - step: "unit-test"
             allow_failure: false
@@ -231,11 +235,18 @@ steps:
           PLATFORMS: "linux/amd64"
           TF_VAR_pull_request: "${BUILDKITE_PULL_REQUEST}"
           FIPS: "true"
+          EC_ENDPOINT: "https://api.staging.elastic-gov.com"
+          TF_VAR_ess_region: "us-gov-east-1"
+          TF_VAR_deployment_template_id: "aws-general-purpose"
         command: ".buildkite/scripts/cloud_e2e_test.sh"
         agents:
           provider: "gcp"
         plugins:
           - *docker_elastic_login_plugin
+          - elastic/vault-secrets#v0.1.0:
+              path: "kv/ci-shared/platform-ingest/platform-ingest-ec-staging-gov"
+              field: "apiKey"
+              env_var: "EC_API_KEY"
         depends_on:
           - step: "unit-test"
             allow_failure: false

--- a/dev-tools/cloud/terraform/main.tf
+++ b/dev-tools/cloud/terraform/main.tf
@@ -28,6 +28,18 @@ variable "pull_request" {
   description = "The github pull request number."
 }
 
+variable "ess_region" {
+  type        = string
+  default     = "gcp-us-west2"
+  description = "The ESS region to use"
+}
+
+variable "deployment_template_id" {
+  type        = string
+  default     = "gcp-general-purpose"
+  description = "The ess deployment template to use"
+}
+
 locals {
   match           = regex("const DefaultVersion = \"(.*)\"", file("${path.module}/../../../version/version.go"))[0]
   stack_version   = format("%s-SNAPSHOT", local.match)
@@ -36,9 +48,9 @@ locals {
 
 resource "ec_deployment" "deployment" {
   name                   = format("fleet server PR-%s-%s", var.pull_request, var.git_commit)
-  region                 = "gcp-us-west2"
+  region                 = var.ess_region
   version                = local.stack_version
-  deployment_template_id = "gcp-general-purpose"
+  deployment_template_id = var.deployment_template_id
 
   tags = {
     "source_repo"     = "elastic/fleet-server"


### PR DESCRIPTION
## What is the problem this PR solves?

FIPS cloud tests are not in the correct environment.

## How does this PR solve the problem?

Redirect FIPS cloud e2e tests to use FHR-Staging.
Use bk plugins instead of hooks for setting the EC_API key. Add region and deployment template vars to cloude2e terraform.

## Related issues

- Relates https://github.com/elastic/elastic-agent/pull/9198