### PR TITLE
Use integration/.env ELASTICSEARCH_VERSION as stack version for cloude2e

### DIFF
--- a/dev-tools/cloud/terraform/outputs.tf
+++ b/dev-tools/cloud/terraform/outputs.tf
@@ -1,5 +1,5 @@
 output "stack_version" {
-  value       = local.stack_version
+  value       = data.ec_stack.latest.version
   description = "Stack version"
 }
 


### PR DESCRIPTION
## What is the problem this PR solves?

Cloude2e tests fail on version updates as fleet-server's default version is higher than the latest available cloud version.

## How does this PR solve the problem?

Use integration/.env ELASTICSEARCH_VERSION as stack version for cloude2e