### PR TITLE
Mark agent inactive on ack of MIGRATE action

### DIFF
--- a/internal/pkg/api/handleAck.go
+++ b/internal/pkg/api/handleAck.go
@@ -34,6 +34,7 @@ import (
 const (
 	TypeUnenroll = "UNENROLL"
 	TypeUpgrade  = "UPGRADE"
+	TypeMigrate  = "MIGRATE"
 )
 
 var (
@@ -305,7 +306,7 @@ func (ack *AckT) handleAckEvents(ctx context.Context, zlog zerolog.Logger, agent
 			setResult(n, http.StatusOK)
 		}
 
-		if event.Error == nil && action.Type == TypeUnenroll {
+		if event.Error == nil && (action.Type == TypeUnenroll || action.Type == TypeMigrate) {
 			unenrollIdxs = append(unenrollIdxs, n)
 		}
 		span.End()


### PR DESCRIPTION
Quick PR just marking agent inactive not only after UNENROLL is acked but also when it was migrated