### PR TITLE
Reset trace headers for bulk items when returning to pool

### DIFF
--- a/changelog/fragments/1755810145-Reset-trace-headers-on-bulk-items-when-returning-to-pool.yaml
+++ b/changelog/fragments/1755810145-Reset-trace-headers-on-bulk-items-when-returning-to-pool.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# Change summary; a 80ish characters long description of the change.
+summary: Reset trace links on bulk items when returning to pool
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: fleet-server
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/changelog/fragments/1755810145-Reset-trace-headers-on-bulk-items-when-returning-to-pool.yaml
+++ b/changelog/fragments/1755810145-Reset-trace-headers-on-bulk-items-when-returning-to-pool.yaml
@@ -25,7 +25,7 @@ component: fleet-server
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-#pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/fleet-server/pull/5317
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.

--- a/internal/pkg/bulk/block.go
+++ b/internal/pkg/bulk/block.go
@@ -73,6 +73,7 @@ func (blk *bulkT) reset() {
 	blk.idx = 0
 	blk.buf.Reset()
 	blk.next = nil
+	blk.spanLink = nil
 }
 
 type respT struct {


### PR DESCRIPTION
## What is the problem this PR solves?

Bulker items can have a previous item's trace links.

## How does this PR solve the problem?

Clear the reference to the trace link in the block's reset method. This method is called before a block is put back in the sync.Pool.

Note that this fix would only apply to functions using the bulker without a transaction tied to their context.