### PR TITLE
[docs] Add stub page for Markdown release notes

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -1,0 +1,7 @@
+project: Fleet Server docs
+products:
+  - id: fleet
+exclude:
+  - "*.md"
+toc:
+  - toc: release-notes

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,0 +1,3 @@
+# Fleet Server release notes
+
+_Work in progress_

--- a/docs/release-notes/toc.yml
+++ b/docs/release-notes/toc.yml
@@ -1,0 +1,2 @@
+toc:
+  - file: index.md


### PR DESCRIPTION
Related to https://github.com/elastic/fleet-server/pull/5374

Adds a stub page for the Fleet Server Markdown release notes to prevent failing docs checks on `main` while we wait for https://github.com/elastic/fleet-server/pull/5374 to be reviewed/merged. 