### PR TITLE
fix: switch Dockerfile of serverless image to debian trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 ARG GO_VERSION
-ARG SUFFIX
-FROM --platform=${BUILDPLATFORM:-linux} docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-${SUFFIX} AS builder
+FROM --platform=${BUILDPLATFORM:-linux} golang:${GO_VERSION}-trixie AS builder
 
 WORKDIR /fleet-server
 

--- a/magefile.go
+++ b/magefile.go
@@ -1051,9 +1051,17 @@ func (Docker) Publish() error {
 	if v, ok := os.LookupEnv(envDockerTag); ok && v != "" {
 		version = v
 	}
+	suffix := dockerSuffix
+	if runtime.GOARCH == "arm64" {
+		suffix = dockerArmSuffix
+	}
 	if isFIPS() {
 		dockerFile = dockerBuilderFIPS
 		image += "-fips"
+		suffix += "-fips"
+	}
+	if v, ok := os.LookupEnv(envDockerImage); ok && v != "" {
+		image = v
 	}
 	if v, ok := os.LookupEnv(envDockerImage); ok && v != "" {
 		image = v
@@ -1072,6 +1080,7 @@ func (Docker) Publish() error {
 		"--build-arg", "VERSION="+getVersion(),
 		"--build-arg", "GCFLAGS="+getGCFlags(),
 		"--build-arg", "LDFLAGS="+getLDFlags(),
+		"--build-arg", "SUFFIX="+suffix,
 		"-f", dockerFile,
 		"-t", image+":"+version,
 		".",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

PR [#5400](https://github.com/elastic/fleet-server/pull/5400) introduced building serverless images with `golang-crossbuild`.  
This caused failures in the `Publish docker image` step ([example](https://buildkite.com/elastic/fleet-server/builds/10400#01991afe-4fb0-4396-aa98-06474a3fc47b)) on `main` because the `docker:publish` mage target never sets the `SUFFIX` build-arg.

## How does this PR solve the problem?

This PR switches serverless images to `golang:${GO_VERSION}-trixie`, which removes the need for a suffix.  
I avoided `golang-crossbuild` because `docker:publish` relies on buildx for multi-platform builds, while `golang-crossbuild` uses image tags per arch. That mismatch could lead to hidden issues.  

I’m still unsure how the FIPS variant works with `docker:publish`, but it doesn’t appear to be actively used. I’ll sync with @michel-laterman on this.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

The target to run is `mage docker:publish` but this may end up pushing an image for you, so I would be very cautious before issuing that (remove the "--push" arg [here](https://github.com/elastic/fleet-server/blob/main/magefile.go#L1066)).

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
N/A
