### PR TITLE
Add ingest-docs team as CODEOWNERS for release notes and docset.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,5 @@
 dev-tools/integration/.env
 
 /.github/workflows @elastic/observablt-ci
+/docs/release-notes @elastic/ingest-docs
+/docs/docset.yml @elastic/ingest-docs


### PR DESCRIPTION
Related to #5374 

Adds ingest-docs team as CODEOWNERS for `docs/release-notes` and `docset.yml`. I think someone with admin access in this repo will need to add the `@elastic/ingest-docs` team with write access.