### PR TITLE
[docs] Set `file_type` to `asciidoc` in `config.changelog.yaml`

### DIFF
--- a/config.changelog.yaml
+++ b/config.changelog.yaml
@@ -1,0 +1,4 @@
+owner: elastic
+repo: fleet-server
+rendered_changelog_destination: changelog
+file_type: asciidoc


### PR DESCRIPTION
## What does this PR do?

Sets `file_type` to `asciidoc` in `config.changelog.yaml`. 

## Why is it important?

This should help us generate release notes in the right format without having to specify the `file_type` when running `render`.

## How to test this PR locally

From the `8.19` branch, run `elastic-agent-changelog-tool build --version 8.19.6` (just for testing purposes!), `elastic-agent-changelog-tool render --version 8.19.6`. This should create one YAML file and one AsciiDoc file in the changelog directory. 

## Related issues

N/A

cc @karenzone @ebeahan @pierrehilbert 