### PR TITLE
Remove `CODEOWNERS` exception for `dev-tools/integration/.env`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,6 @@
 # Team responsible for Fleet Server
 * @elastic/elastic-agent-control-plane
 
-# Allow to auto-merge PRs with Mergify
-dev-tools/integration/.env
-
 /.github/workflows @elastic/observablt-ci
 /.github/workflows/golangci-lint.yml @elastic/elastic-agent-control-plane
 /docs/release-notes @elastic/ingest-docs


### PR DESCRIPTION
This exception was added in https://github.com/elastic/fleet-server/pull/1473 with the intent to handle these bumps using automerges.

We can investigate solutions to auto-merge these bump PR. But to improve visibility for now, enforce codeowner reviews so someone from the rotation is notified.