### PR TITLE
ci(gvm): use a different URL

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -45,7 +45,7 @@ with_go() {
     SETUP_GVM_VERSION=v0.5.2
     retry 5 curl -sL -o ${WORKSPACE}/gvm "https://github.com/andrewkroh/gvm/releases/download/${SETUP_GVM_VERSION}/gvm-${platform_type}-${arch_type}"
     chmod +x ${WORKSPACE}/gvm
-    eval "$(gvm $(cat .go-version))"
+    eval "$(gvm --url=https://go.dev/dl $(cat .go-version))"
     go version
     which go
     export PATH="${PATH}:$(go env GOPATH):$(go env GOPATH)/bin"


### PR DESCRIPTION

## What is the problem this PR solves?


https://storage.googleapis.com/golang/ is not working, see https://storage.googleapis.com/golang/go1.25.2.linux-amd64.tar.gz

<img width="1081" height="303" alt="image" src="https://github.com/user-attachments/assets/1d4fd8d2-e163-4e64-b9e8-1e4007e0b029" />

## How does this PR solve the problem?

Override the default URL for the golang binaries:

- https://github.com/andrewkroh/gvm/blob/45a2e1fafd175b53d4eb2493161ba4673426c1a1/gvm.go#L75-L77

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
