### PR TITLE
[CI] Re-add `-1`  to retrieve immutable artifact for `microsoft/go`

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -58,7 +58,7 @@ with_msft_go() {
 
     # Use a temporary folder to house the Go SDK downloaded from Microsoft
     tempfolder=$(mktemp -d)
-    MSFT_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$(cat .go-version).${platform_type}-${arch_type}.tar.gz
+    MSFT_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$(cat .go-version)-1.${platform_type}-${arch_type}.tar.gz
     retry 5 $(curl -sL -o - $MSFT_DOWNLOAD_URL | tar -xz -f - -C ${tempfolder}/)
     export PATH="${PATH}:${tempfolder}/go/bin"
     go version


### PR DESCRIPTION
Prior to changes made in https://github.com/elastic/fleet-server/commit/db5f46bc7955114e508f9e73dcd7d30daf798ab6#diff-68c0021e761ebe6b8a42d32dfdf3dda2200f0f2fee50106c85c9aea530ccf3c3L58, the `MSFT_DOWNLOAD_URL` appended a `-1` to retrieve the immutable version of the MSFT build of Go ([source](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/Downloads.md#downloading-a-specific-version)).

This re-adds that suffix to resolve the `Package FIPS x86_64 snapshot` [CI failures](https://buildkite.com/elastic/fleet-server-package-mbp/builds/2621#019a024b-d614-456f-a34f-46f0251930d0):

```shell

$ .buildkite/scripts/package.sh snapshot
--
  | Adding PATH to the environment variables...
  | Setting up microsoft/go
  |  
  | gzip: stdin: unexpected end of file
  | tar: Child returned status 1
  | tar: Error is not recoverable: exiting now
  | .buildkite/scripts/common.sh: line 64: go: command not found
```