### PR TITLE
Doc: Add 9.1.6 release notes noting no user-facing changes

### DIFF
--- a/docs/release-notes/_snippets/9.1.6/breaking-changes.md
+++ b/docs/release-notes/_snippets/9.1.6/breaking-changes.md
@@ -1,0 +1,3 @@
+## 9.1.6 [fleet-server-9.1.6-breaking-changes]
+
+_No breaking changes._

--- a/docs/release-notes/_snippets/9.1.6/deprecations.md
+++ b/docs/release-notes/_snippets/9.1.6/deprecations.md
@@ -1,0 +1,3 @@
+## 9.1.6 [fleet-server-9.1.6-deprecations]
+
+_No deprecations._

--- a/docs/release-notes/_snippets/9.1.6/index.md
+++ b/docs/release-notes/_snippets/9.1.6/index.md
@@ -1,0 +1,3 @@
+## 9.1.6 [fleet-server-release-notes-9.1.6]
+
+_No new features, enhancements, or fixes._

--- a/docs/release-notes/_snippets/breaking-changes/9.1.md
+++ b/docs/release-notes/_snippets/breaking-changes/9.1.md
@@ -1,3 +1,6 @@
+:::{include} /release-notes/_snippets/9.1.6/breaking-changes.md
+:::
+
 :::{include} /release-notes/_snippets/9.1.5/breaking-changes.md
 :::
 

--- a/docs/release-notes/_snippets/deprecations/9.1.md
+++ b/docs/release-notes/_snippets/deprecations/9.1.md
@@ -1,3 +1,6 @@
+:::{include} /release-notes/_snippets/9.1.6/deprecations.md
+:::
+
 :::{include} /release-notes/_snippets/9.1.5/deprecations.md
 :::
 

--- a/docs/release-notes/_snippets/index/9.1.md
+++ b/docs/release-notes/_snippets/index/9.1.md
@@ -1,3 +1,6 @@
+:::{include} /release-notes/_snippets/9.1.6/index.md
+:::
+
 :::{include} /release-notes/_snippets/9.1.5/index.md
 :::
 


### PR DESCRIPTION
Manual update to release notes indicating that there are no user-facing changes for 9.1.6

Related: [Fleet and Agent 9.1.6 release notes](https://github.com/elastic/docs-content/issues/3615)
