### PR TITLE
Fix issue where checkin fails to update elasticsearch once marked with audit orphaned

### DIFF
--- a/changelog/fragments/1762210175-fix-issue-prevent-checkin-local_metadata-from-being-updated.yaml
+++ b/changelog/fragments/1762210175-fix-issue-prevent-checkin-local_metadata-from-being-updated.yaml
@@ -1,0 +1,48 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix issue prevent checkin local_metadata from being updated
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+    Once an Elastic Agent is marked with audit unenrolled Fleet Server fails to update the document in
+    Elasticsearch when it checks in. This fixes that issue an now the Fleet Server will be able to update the
+    document in Elasticsearch reflecting the actual status of the Elastic Agent.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: fleet-server
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/checkin/bulk.go
+++ b/internal/pkg/checkin/bulk.go
@@ -402,12 +402,10 @@ func encodeParams(now string, data pendingT) (map[string]json.RawMessage, error)
 	seqNo, err = json.Marshal(data.extra.seqNo)
 	Err = errors.Join(Err, err)
 	if data.extra.meta != nil {
-		meta, err = json.Marshal(data.extra.meta)
-		Err = errors.Join(Err, err)
+		meta = data.extra.meta
 	}
 	if data.extra.components != nil {
-		components, err = json.Marshal(data.extra.components)
-		Err = errors.Join(Err, err)
+		components = data.extra.components
 	}
 	if Err != nil {
 		return nil, Err

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -65,7 +65,21 @@ const (
 	}`
 	checkinBody = `{
 	    "status": "online",
-	    "message": "checkin ok"
+	    "message": "checkin ok",
+		"local_metadata": {
+			"elastic": {
+				"agent": {
+					"version":"9.3.0"
+				}
+			}
+		},
+		"components": [
+			{
+				"id": "filestream-default",
+				"status": "Healthy",
+				"message": "Healthy"
+			}
+		]
 	}`
 )
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

Once an Elastic Agent is marked as orphaned it results in Fleet Server not being able to update the document in elasticsearch. This is because a painless script is used to update the document to remove the orphaned fields, this script was not passing the `local_metadata` or `components` fields correctly to the script resulting in the error.

## How does this PR solve the problem?

This fixes it by passing the `local_metadata` and `components` correctly to the painless script. It also includes a change in the tests that directly causes the same error, show that this fixes does indeed fix the issue.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer if anything special is needed for manual testing: commands, dependencies, steps, etc.
-->

`mage test:integration` will run the tests that will excise this path.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

- Closes #5674 
