### PR TITLE
[ci] Increase runner sizing for E2E and integration testing steps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -208,6 +208,8 @@ steps:
         command: ".buildkite/scripts/integration_test.sh"
         agents:
           provider: "gcp"
+          image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "c2-standard-16"
         artifact_paths:
           - build/*.xml
         plugins:


### PR DESCRIPTION
Testing to see if using a larger instance size reduces failure rate of the E2E and integration testing steps (example: https://buildkite.com/elastic/fleet-server/builds/12352#019b9425-dd8e-41e3-9bfd-4638061805ee).