### PR TITLE
[ci] Use `platform-ingest-*` Ubuntu images

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,8 +3,8 @@
 env:
   DOCKER_COMPOSE_VERSION: "1.25.5"
   TERRAFORM_VERSION: "1.6.4"
-  IMAGE_UBUNTU_X86_64: "family/core-ubuntu-2204"
-  IMAGE_UBUNTU_ARM_64: "core-ubuntu-2204-aarch64"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-elastic-agent-ubuntu-2204-1767879728"
+  IMAGE_UBUNTU_ARM_64: "platform-ingest-elastic-agent-ubuntu-2204-aarch64-1767879728"
   IMAGE_UBUNTU_X86_64_FIPS: "platform-ingest-fleet-server-ubuntu-2204-fips"
 
 # This section is used to define the plugins that will be used in the pipeline.
@@ -88,7 +88,7 @@ steps:
           - build/distributions/**
         agents:
           provider: "aws"
-          imagePrefix: "${IMAGE_UBUNTU_ARM_64}"
+          image: "${IMAGE_UBUNTU_ARM_64}"
           instanceType: "t4g.2xlarge"
         plugins:
           - *oidc_plugin
@@ -104,7 +104,7 @@ steps:
           - build/distributions/**
         agents:
           provider: "aws"
-          imagePrefix: "${IMAGE_UBUNTU_ARM_64}"
+          image: "${IMAGE_UBUNTU_ARM_64}"
           instanceType: "t4g.2xlarge"
         plugins:
           - *oidc_plugin


### PR DESCRIPTION
Starting on 2026-01-29, the generic `core-ubuntu-2204` images began to fail during the packaging steps in CI:

```shell
ERROR: failed to build: Error response from daemon: client version 1.52 is too new. Maximum supported API version is 1.43: driver not connecting
--
Error: running "docker build -t fleet-server-builder:1.25.6 --build-arg GO_VERSION=1.25.6 -f Dockerfile.build --build-arg SUFFIX=main-debian11 ." failed with exit code 1
```

To avoid upstream deps updating without notice or testing, switch to using the `platform-ingest-*` maintained CI images. This PR is to remove the failing CI checks and will be followed by the necessary changes to automated VM version bumps (like is done for [Elastic Agent)](https://github.com/elastic/elastic-agent/blob/main/.github/workflows/bump-vm-images.yml).