### PR TITLE
feat: add configurable limit on concurrent bulk dispatch goroutines

### DIFF
--- a/internal/pkg/api/error.go
+++ b/internal/pkg/api/error.go
@@ -17,6 +17,7 @@ import (
 	"go.elastic.co/apm/v2"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
+	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
 	"github.com/elastic/fleet-server/v7/internal/pkg/es"
 	"github.com/elastic/fleet-server/v7/internal/pkg/file"
@@ -174,6 +175,15 @@ func NewHTTPErrResp(err error) HTTPErrResp {
 				http.StatusTooManyRequests,
 				"ElasticsearchAPIKeyAuthLimit",
 				"exceeded the elasticsearch api key auth limit",
+				zerolog.WarnLevel,
+			},
+		},
+		{
+			bulk.ErrTooManyDispatches,
+			HTTPErrResp{
+				http.StatusTooManyRequests,
+				"TooManyDispatches",
+				"too many pending dispatches",
 				zerolog.WarnLevel,
 			},
 		},

--- a/internal/pkg/api/error.go
+++ b/internal/pkg/api/error.go
@@ -179,11 +179,11 @@ func NewHTTPErrResp(err error) HTTPErrResp {
 			},
 		},
 		{
-			bulk.ErrTooManyDispatches,
+			bulk.ErrTooManyBulkDispatches,
 			HTTPErrResp{
 				http.StatusTooManyRequests,
-				"TooManyDispatches",
-				"too many pending dispatches",
+				"TooManyBulkDispatches",
+				"too many pending bulk dispatches",
 				zerolog.WarnLevel,
 			},
 		},

--- a/internal/pkg/bulk/dispatch_limit_test.go
+++ b/internal/pkg/bulk/dispatch_limit_test.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestDispatchRejectsWhenLimitReached(t *testing.T) {
@@ -43,9 +45,7 @@ func TestDispatchRejectsWhenLimitReached(t *testing.T) {
 	blk.buf.WriteString(`{"index":"test"}`)
 	resp := b.dispatch(context.Background(), blk)
 
-	if resp.err != ErrTooManyBulkDispatches {
-		t.Fatalf("expected ErrTooManyBulkDispatches, got: %v", resp.err)
-	}
+	require.ErrorIs(t, resp.err, ErrTooManyBulkDispatches)
 
 	// Clean up: drain the channel to unblock the goroutines.
 	for i := 0; i < limit; i++ {
@@ -71,14 +71,10 @@ func TestDispatchAllowsWhenUnderLimit(t *testing.T) {
 	}()
 
 	resp := b.dispatch(context.Background(), blk)
-	if resp.err != nil {
-		t.Fatalf("expected no error, got: %v", resp.err)
-	}
+	require.NoError(t, resp.err)
 
 	// Counter should be back to 0 after dispatch completes.
-	if pending := b.pendingBulkDispatches.Load(); pending != 0 {
-		t.Fatalf("expected 0 pending bulk dispatches, got: %d", pending)
-	}
+	require.Equal(t, int64(0), b.pendingBulkDispatches.Load())
 }
 
 func TestDispatchNoLimitWhenZero(t *testing.T) {
@@ -94,12 +90,8 @@ func TestDispatchNoLimitWhenZero(t *testing.T) {
 	}()
 
 	resp := b.dispatch(context.Background(), blk)
-	if resp.err != nil {
-		t.Fatalf("expected no error, got: %v", resp.err)
-	}
+	require.NoError(t, resp.err)
 
 	// Counter should not have been touched (0 means disabled).
-	if pending := b.pendingBulkDispatches.Load(); pending != 0 {
-		t.Fatalf("expected 0 pending bulk dispatches, got: %d", pending)
-	}
+	require.Equal(t, int64(0), b.pendingBulkDispatches.Load())
 }

--- a/internal/pkg/bulk/dispatch_limit_test.go
+++ b/internal/pkg/bulk/dispatch_limit_test.go
@@ -25,11 +25,12 @@ func TestDispatchRejectsWhenLimitReached(t *testing.T) {
 
 	// Saturate the pending bulk dispatch limit with goroutines blocked on the full channel.
 	for i := int64(0); i < limit; i++ {
+		blk := b.newBlk(ActionSearch, optionsT{})
+		_, err := blk.buf.WriteString(`{"index":"test"}`)
+		require.NoError(t, err)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			blk := b.newBlk(ActionSearch, optionsT{})
-			blk.buf.WriteString(`{"index":"test"}`)
 			b.dispatch(context.Background(), blk)
 		}()
 	}
@@ -42,7 +43,8 @@ func TestDispatchRejectsWhenLimitReached(t *testing.T) {
 
 	// The next dispatch should be rejected immediately.
 	blk := b.newBlk(ActionSearch, optionsT{})
-	blk.buf.WriteString(`{"index":"test"}`)
+	_, err := blk.buf.WriteString(`{"index":"test"}`)
+	require.NoError(t, err)
 	resp := b.dispatch(context.Background(), blk)
 
 	require.ErrorIs(t, resp.err, ErrTooManyBulkDispatches)
@@ -62,7 +64,8 @@ func TestDispatchAllowsWhenUnderLimit(t *testing.T) {
 	b := NewBulker(nil, nil, WithBlockQueueSize(1), WithMaxPendingBulkDispatches(10))
 
 	blk := b.newBlk(ActionSearch, optionsT{})
-	blk.buf.WriteString(`{"index":"test"}`)
+	_, err := blk.buf.WriteString(`{"index":"test"}`)
+	require.NoError(t, err)
 
 	// Simulate the Run loop responding.
 	go func() {
@@ -82,7 +85,8 @@ func TestDispatchNoLimitWhenZero(t *testing.T) {
 	b := NewBulker(nil, nil, WithBlockQueueSize(1), WithMaxPendingBulkDispatches(0))
 
 	blk := b.newBlk(ActionSearch, optionsT{})
-	blk.buf.WriteString(`{"index":"test"}`)
+	_, err := blk.buf.WriteString(`{"index":"test"}`)
+	require.NoError(t, err)
 
 	go func() {
 		item := <-b.ch

--- a/internal/pkg/bulk/dispatch_limit_test.go
+++ b/internal/pkg/bulk/dispatch_limit_test.go
@@ -13,18 +13,18 @@ import (
 )
 
 func TestDispatchRejectsWhenLimitReached(t *testing.T) {
-	limit := 2
-	b := NewBulker(nil, nil, WithBlockQueueSize(limit+1), WithMaxPendingBulkDispatches(limit))
+	var limit int64 = 2
+	b := NewBulker(nil, nil, WithBlockQueueSize(int(limit)+1), WithMaxPendingBulkDispatches(limit))
 
 	// Fill the queue so dispatches block in Phase 1.
-	for i := 0; i < limit; i++ {
+	for i := int64(0); i < limit; i++ {
 		b.ch <- &bulkT{ch: make(chan respT, 1)}
 	}
 
 	var wg sync.WaitGroup
 
 	// Saturate the pending bulk dispatch limit with goroutines blocked on the full channel.
-	for i := 0; i < limit; i++ {
+	for i := int64(0); i < limit; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -36,7 +36,7 @@ func TestDispatchRejectsWhenLimitReached(t *testing.T) {
 
 	// Give the goroutines time to enter dispatch and increment the counter.
 	// They'll block on the channel send since it's full.
-	for b.pendingBulkDispatches.Load() < int64(limit) {
+	for b.pendingBulkDispatches.Load() < limit {
 		// spin until both goroutines are pending
 	}
 
@@ -48,10 +48,10 @@ func TestDispatchRejectsWhenLimitReached(t *testing.T) {
 	require.ErrorIs(t, resp.err, ErrTooManyBulkDispatches)
 
 	// Clean up: drain the channel to unblock the goroutines.
-	for i := 0; i < limit; i++ {
+	for i := int64(0); i < limit; i++ {
 		<-b.ch // remove the filler items
 	}
-	for i := 0; i < limit; i++ {
+	for i := int64(0); i < limit; i++ {
 		item := <-b.ch // receive the dispatch items
 		item.ch <- respT{}
 	}

--- a/internal/pkg/bulk/dispatch_limit_test.go
+++ b/internal/pkg/bulk/dispatch_limit_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestDispatchRejectsWhenLimitReached(t *testing.T) {
 	limit := 2
-	b := NewBulker(nil, nil, WithBlockQueueSize(limit+1), WithMaxPendingDispatches(limit))
+	b := NewBulker(nil, nil, WithBlockQueueSize(limit+1), WithMaxPendingBulkDispatches(limit))
 
 	// Fill the queue so dispatches block in Phase 1.
 	for i := 0; i < limit; i++ {
@@ -21,7 +21,7 @@ func TestDispatchRejectsWhenLimitReached(t *testing.T) {
 
 	var wg sync.WaitGroup
 
-	// Saturate the pending dispatch limit with goroutines blocked on the full channel.
+	// Saturate the pending bulk dispatch limit with goroutines blocked on the full channel.
 	for i := 0; i < limit; i++ {
 		wg.Add(1)
 		go func() {
@@ -34,7 +34,7 @@ func TestDispatchRejectsWhenLimitReached(t *testing.T) {
 
 	// Give the goroutines time to enter dispatch and increment the counter.
 	// They'll block on the channel send since it's full.
-	for b.pendingDispatches.Load() < int64(limit) {
+	for b.pendingBulkDispatches.Load() < int64(limit) {
 		// spin until both goroutines are pending
 	}
 
@@ -43,8 +43,8 @@ func TestDispatchRejectsWhenLimitReached(t *testing.T) {
 	blk.buf.WriteString(`{"index":"test"}`)
 	resp := b.dispatch(context.Background(), blk)
 
-	if resp.err != ErrTooManyDispatches {
-		t.Fatalf("expected ErrTooManyDispatches, got: %v", resp.err)
+	if resp.err != ErrTooManyBulkDispatches {
+		t.Fatalf("expected ErrTooManyBulkDispatches, got: %v", resp.err)
 	}
 
 	// Clean up: drain the channel to unblock the goroutines.
@@ -59,7 +59,7 @@ func TestDispatchRejectsWhenLimitReached(t *testing.T) {
 }
 
 func TestDispatchAllowsWhenUnderLimit(t *testing.T) {
-	b := NewBulker(nil, nil, WithBlockQueueSize(1), WithMaxPendingDispatches(10))
+	b := NewBulker(nil, nil, WithBlockQueueSize(1), WithMaxPendingBulkDispatches(10))
 
 	blk := b.newBlk(ActionSearch, optionsT{})
 	blk.buf.WriteString(`{"index":"test"}`)
@@ -76,14 +76,14 @@ func TestDispatchAllowsWhenUnderLimit(t *testing.T) {
 	}
 
 	// Counter should be back to 0 after dispatch completes.
-	if pending := b.pendingDispatches.Load(); pending != 0 {
-		t.Fatalf("expected 0 pending dispatches, got: %d", pending)
+	if pending := b.pendingBulkDispatches.Load(); pending != 0 {
+		t.Fatalf("expected 0 pending bulk dispatches, got: %d", pending)
 	}
 }
 
 func TestDispatchNoLimitWhenZero(t *testing.T) {
-	// With maxPendingDispatches=0, there should be no limit enforced.
-	b := NewBulker(nil, nil, WithBlockQueueSize(1), WithMaxPendingDispatches(0))
+	// With maxPendingBulkDispatches=0, there should be no limit enforced.
+	b := NewBulker(nil, nil, WithBlockQueueSize(1), WithMaxPendingBulkDispatches(0))
 
 	blk := b.newBlk(ActionSearch, optionsT{})
 	blk.buf.WriteString(`{"index":"test"}`)
@@ -99,7 +99,7 @@ func TestDispatchNoLimitWhenZero(t *testing.T) {
 	}
 
 	// Counter should not have been touched (0 means disabled).
-	if pending := b.pendingDispatches.Load(); pending != 0 {
-		t.Fatalf("expected 0 pending dispatches, got: %d", pending)
+	if pending := b.pendingBulkDispatches.Load(); pending != 0 {
+		t.Fatalf("expected 0 pending bulk dispatches, got: %d", pending)
 	}
 }

--- a/internal/pkg/bulk/dispatch_limit_test.go
+++ b/internal/pkg/bulk/dispatch_limit_test.go
@@ -1,0 +1,105 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package bulk
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestDispatchRejectsWhenLimitReached(t *testing.T) {
+	limit := 2
+	b := NewBulker(nil, nil, WithBlockQueueSize(limit+1), WithMaxPendingDispatches(limit))
+
+	// Fill the queue so dispatches block in Phase 1.
+	for i := 0; i < limit; i++ {
+		b.ch <- &bulkT{ch: make(chan respT, 1)}
+	}
+
+	var wg sync.WaitGroup
+
+	// Saturate the pending dispatch limit with goroutines blocked on the full channel.
+	for i := 0; i < limit; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			blk := b.newBlk(ActionSearch, optionsT{})
+			blk.buf.WriteString(`{"index":"test"}`)
+			b.dispatch(context.Background(), blk)
+		}()
+	}
+
+	// Give the goroutines time to enter dispatch and increment the counter.
+	// They'll block on the channel send since it's full.
+	for b.pendingDispatches.Load() < int64(limit) {
+		// spin until both goroutines are pending
+	}
+
+	// The next dispatch should be rejected immediately.
+	blk := b.newBlk(ActionSearch, optionsT{})
+	blk.buf.WriteString(`{"index":"test"}`)
+	resp := b.dispatch(context.Background(), blk)
+
+	if resp.err != ErrTooManyDispatches {
+		t.Fatalf("expected ErrTooManyDispatches, got: %v", resp.err)
+	}
+
+	// Clean up: drain the channel to unblock the goroutines.
+	for i := 0; i < limit; i++ {
+		<-b.ch // remove the filler items
+	}
+	for i := 0; i < limit; i++ {
+		item := <-b.ch // receive the dispatch items
+		item.ch <- respT{}
+	}
+	wg.Wait()
+}
+
+func TestDispatchAllowsWhenUnderLimit(t *testing.T) {
+	b := NewBulker(nil, nil, WithBlockQueueSize(1), WithMaxPendingDispatches(10))
+
+	blk := b.newBlk(ActionSearch, optionsT{})
+	blk.buf.WriteString(`{"index":"test"}`)
+
+	// Simulate the Run loop responding.
+	go func() {
+		item := <-b.ch
+		item.ch <- respT{}
+	}()
+
+	resp := b.dispatch(context.Background(), blk)
+	if resp.err != nil {
+		t.Fatalf("expected no error, got: %v", resp.err)
+	}
+
+	// Counter should be back to 0 after dispatch completes.
+	if pending := b.pendingDispatches.Load(); pending != 0 {
+		t.Fatalf("expected 0 pending dispatches, got: %d", pending)
+	}
+}
+
+func TestDispatchNoLimitWhenZero(t *testing.T) {
+	// With maxPendingDispatches=0, there should be no limit enforced.
+	b := NewBulker(nil, nil, WithBlockQueueSize(1), WithMaxPendingDispatches(0))
+
+	blk := b.newBlk(ActionSearch, optionsT{})
+	blk.buf.WriteString(`{"index":"test"}`)
+
+	go func() {
+		item := <-b.ch
+		item.ch <- respT{}
+	}()
+
+	resp := b.dispatch(context.Background(), blk)
+	if resp.err != nil {
+		t.Fatalf("expected no error, got: %v", resp.err)
+	}
+
+	// Counter should not have been touched (0 means disabled).
+	if pending := b.pendingDispatches.Load(); pending != 0 {
+		t.Fatalf("expected 0 pending dispatches, got: %d", pending)
+	}
+}

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -36,7 +36,7 @@ type APIKeyMetadata = apikey.APIKeyMetadata
 
 var (
 	ErrNoQuotes            = errors.New("quoted literal not supported")
-	ErrTooManyDispatches   = errors.New("too many pending dispatches")
+	ErrTooManyBulkDispatches = errors.New("too many pending bulk dispatches")
 )
 
 type MultiOp struct {
@@ -94,7 +94,7 @@ type Bulker struct {
 	apikeyLimit       *semaphore.Weighted
 	tracer            *apm.Tracer
 	cancelFn          context.CancelFunc
-	pendingDispatches atomic.Int64
+	pendingBulkDispatches atomic.Int64
 
 	remoteOutputConfigMap map[string]map[string]interface{}
 	bulkerMap             map[string]Bulk
@@ -110,7 +110,7 @@ const (
 	defaultAPIKeyMaxParallel   = 32
 	defaultApikeyMaxReqSize    = 100 * 1024 * 1024
 	defaultFlushContextTimeout   = time.Minute * 1
-	defaultMaxPendingDispatches  = 0 // 0 means no limit
+	defaultMaxPendingBulkDispatches = 0 // 0 means no limit
 )
 
 func NewBulker(es esapi.Transport, tracer *apm.Tracer, opts ...BulkOpt) *Bulker {
@@ -605,19 +605,19 @@ func (b *Bulker) validateBody(body []byte) error {
 func (b *Bulker) dispatch(ctx context.Context, blk *bulkT) respT {
 	start := time.Now()
 
-	// Check pending dispatch limit before blocking on the channel.
-	if limit := b.opts.maxPendingDispatches; limit > 0 {
-		pending := b.pendingDispatches.Add(1)
-		defer b.pendingDispatches.Add(-1)
+	// Check pending bulk dispatch limit before blocking on the channel.
+	if limit := b.opts.maxPendingBulkDispatches; limit > 0 {
+		pending := b.pendingBulkDispatches.Add(1)
+		defer b.pendingBulkDispatches.Add(-1)
 		if pending > int64(limit) {
 			zerolog.Ctx(ctx).Warn().
 				Str("mod", kModBulk).
 				Str("action", blk.action.String()).
 				Int64("pending", pending).
 				Int("limit", limit).
-				Msg("Dispatch rejected: too many pending")
+				Msg("Bulk dispatch rejected: too many pending")
 			b.freeBlk(blk)
-			return respT{err: ErrTooManyDispatches}
+			return respT{err: ErrTooManyBulkDispatches}
 		}
 	}
 

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
@@ -34,7 +35,8 @@ type SecurityInfo = apikey.SecurityInfo
 type APIKeyMetadata = apikey.APIKeyMetadata
 
 var (
-	ErrNoQuotes = errors.New("quoted literal not supported")
+	ErrNoQuotes            = errors.New("quoted literal not supported")
+	ErrTooManyDispatches   = errors.New("too many pending dispatches")
 )
 
 type MultiOp struct {
@@ -85,13 +87,14 @@ type Bulk interface {
 const kModBulk = "bulk"
 
 type Bulker struct {
-	es          esapi.Transport
-	ch          chan *bulkT
-	opts        bulkOptT
-	blkPool     sync.Pool
-	apikeyLimit *semaphore.Weighted
-	tracer      *apm.Tracer
-	cancelFn    context.CancelFunc
+	es                esapi.Transport
+	ch                chan *bulkT
+	opts              bulkOptT
+	blkPool           sync.Pool
+	apikeyLimit       *semaphore.Weighted
+	tracer            *apm.Tracer
+	cancelFn          context.CancelFunc
+	pendingDispatches atomic.Int64
 
 	remoteOutputConfigMap map[string]map[string]interface{}
 	bulkerMap             map[string]Bulk
@@ -106,7 +109,8 @@ const (
 	defaultBlockQueueSz        = 32 // Small capacity to allow multiOp to spin fast
 	defaultAPIKeyMaxParallel   = 32
 	defaultApikeyMaxReqSize    = 100 * 1024 * 1024
-	defaultFlushContextTimeout = time.Minute * 1
+	defaultFlushContextTimeout   = time.Minute * 1
+	defaultMaxPendingDispatches  = 0 // 0 means no limit
 )
 
 func NewBulker(es esapi.Transport, tracer *apm.Tracer, opts ...BulkOpt) *Bulker {
@@ -600,6 +604,22 @@ func (b *Bulker) validateBody(body []byte) error {
 
 func (b *Bulker) dispatch(ctx context.Context, blk *bulkT) respT {
 	start := time.Now()
+
+	// Check pending dispatch limit before blocking on the channel.
+	if limit := b.opts.maxPendingDispatches; limit > 0 {
+		pending := b.pendingDispatches.Add(1)
+		defer b.pendingDispatches.Add(-1)
+		if pending > int64(limit) {
+			zerolog.Ctx(ctx).Warn().
+				Str("mod", kModBulk).
+				Str("action", blk.action.String()).
+				Int64("pending", pending).
+				Int("limit", limit).
+				Msg("Dispatch rejected: too many pending")
+			b.freeBlk(blk)
+			return respT{err: ErrTooManyDispatches}
+		}
+	}
 
 	// Dispatch to bulk Run loop
 	select {

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -110,7 +110,7 @@ const (
 	defaultAPIKeyMaxParallel        = 32
 	defaultApikeyMaxReqSize         = 100 * 1024 * 1024
 	defaultFlushContextTimeout      = time.Minute * 1
-	defaultMaxPendingBulkDispatches = 0 // 0 means no limit
+	defaultMaxPendingBulkDispatches int64 = 0 // 0 means no limit
 )
 
 func NewBulker(es esapi.Transport, tracer *apm.Tracer, opts ...BulkOpt) *Bulker {
@@ -609,12 +609,12 @@ func (b *Bulker) dispatch(ctx context.Context, blk *bulkT) respT {
 	if limit := b.opts.maxPendingBulkDispatches; limit > 0 {
 		pending := b.pendingBulkDispatches.Add(1)
 		defer b.pendingBulkDispatches.Add(-1)
-		if pending > int64(limit) {
+		if pending > limit {
 			zerolog.Ctx(ctx).Warn().
 				Str("mod", kModBulk).
 				Str("action", blk.action.String()).
 				Int64("pending", pending).
-				Int("limit", limit).
+				Int64("limit", limit).
 				Msg("Bulk dispatch rejected: too many pending")
 			b.freeBlk(blk)
 			return respT{err: ErrTooManyBulkDispatches}

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -102,14 +102,14 @@ type Bulker struct {
 }
 
 const (
-	defaultFlushInterval            = time.Second * 5
-	defaultFlushThresholdCnt        = 32768
-	defaultFlushThresholdSz         = 1024 * 1024 * 10
-	defaultMaxPending               = 32
-	defaultBlockQueueSz             = 32 // Small capacity to allow multiOp to spin fast
-	defaultAPIKeyMaxParallel        = 32
-	defaultApikeyMaxReqSize         = 100 * 1024 * 1024
-	defaultFlushContextTimeout      = time.Minute * 1
+	defaultFlushInterval                  = time.Second * 5
+	defaultFlushThresholdCnt              = 32768
+	defaultFlushThresholdSz               = 1024 * 1024 * 10
+	defaultMaxPending                     = 32
+	defaultBlockQueueSz                   = 32 // Small capacity to allow multiOp to spin fast
+	defaultAPIKeyMaxParallel              = 32
+	defaultApikeyMaxReqSize               = 100 * 1024 * 1024
+	defaultFlushContextTimeout            = time.Minute * 1
 	defaultMaxPendingBulkDispatches int64 = 0 // 0 means no limit
 )
 

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -35,7 +35,7 @@ type SecurityInfo = apikey.SecurityInfo
 type APIKeyMetadata = apikey.APIKeyMetadata
 
 var (
-	ErrNoQuotes            = errors.New("quoted literal not supported")
+	ErrNoQuotes              = errors.New("quoted literal not supported")
 	ErrTooManyBulkDispatches = errors.New("too many pending bulk dispatches")
 )
 
@@ -87,13 +87,13 @@ type Bulk interface {
 const kModBulk = "bulk"
 
 type Bulker struct {
-	es                esapi.Transport
-	ch                chan *bulkT
-	opts              bulkOptT
-	blkPool           sync.Pool
-	apikeyLimit       *semaphore.Weighted
-	tracer            *apm.Tracer
-	cancelFn          context.CancelFunc
+	es                    esapi.Transport
+	ch                    chan *bulkT
+	opts                  bulkOptT
+	blkPool               sync.Pool
+	apikeyLimit           *semaphore.Weighted
+	tracer                *apm.Tracer
+	cancelFn              context.CancelFunc
 	pendingBulkDispatches atomic.Int64
 
 	remoteOutputConfigMap map[string]map[string]interface{}
@@ -102,14 +102,14 @@ type Bulker struct {
 }
 
 const (
-	defaultFlushInterval       = time.Second * 5
-	defaultFlushThresholdCnt   = 32768
-	defaultFlushThresholdSz    = 1024 * 1024 * 10
-	defaultMaxPending          = 32
-	defaultBlockQueueSz        = 32 // Small capacity to allow multiOp to spin fast
-	defaultAPIKeyMaxParallel   = 32
-	defaultApikeyMaxReqSize    = 100 * 1024 * 1024
-	defaultFlushContextTimeout   = time.Minute * 1
+	defaultFlushInterval            = time.Second * 5
+	defaultFlushThresholdCnt        = 32768
+	defaultFlushThresholdSz         = 1024 * 1024 * 10
+	defaultMaxPending               = 32
+	defaultBlockQueueSz             = 32 // Small capacity to allow multiOp to spin fast
+	defaultAPIKeyMaxParallel        = 32
+	defaultApikeyMaxReqSize         = 100 * 1024 * 1024
+	defaultFlushContextTimeout      = time.Minute * 1
 	defaultMaxPendingBulkDispatches = 0 // 0 means no limit
 )
 

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -81,16 +81,16 @@ func withAPMLinkedContext(ctx context.Context) Opt {
 // Bulk API options
 
 type bulkOptT struct {
-	flushInterval        time.Duration
-	flushThresholdCnt    int
-	flushThresholdSz     int
-	maxPending           int
-	blockQueueSz         int
-	apikeyMaxParallel    int
-	apikeyMaxReqSize     int
+	flushInterval            time.Duration
+	flushThresholdCnt        int
+	flushThresholdSz         int
+	maxPending               int
+	blockQueueSz             int
+	apikeyMaxParallel        int
+	apikeyMaxReqSize         int
 	maxPendingBulkDispatches int
-	policyTokens         []config.PolicyToken
-	bi                   build.Info
+	policyTokens             []config.PolicyToken
+	bi                       build.Info
 }
 
 type BulkOpt func(*bulkOptT)
@@ -169,15 +169,15 @@ func WithBi(bi build.Info) BulkOpt {
 
 func parseBulkOpts(opts ...BulkOpt) bulkOptT {
 	bopt := bulkOptT{
-		flushInterval:        defaultFlushInterval,
-		flushThresholdCnt:    defaultFlushThresholdCnt,
-		flushThresholdSz:     defaultFlushThresholdSz,
-		maxPending:           defaultMaxPending,
-		apikeyMaxParallel:    defaultAPIKeyMaxParallel,
-		blockQueueSz:         defaultBlockQueueSz,
-		apikeyMaxReqSize:     defaultApikeyMaxReqSize,
+		flushInterval:            defaultFlushInterval,
+		flushThresholdCnt:        defaultFlushThresholdCnt,
+		flushThresholdSz:         defaultFlushThresholdSz,
+		maxPending:               defaultMaxPending,
+		apikeyMaxParallel:        defaultAPIKeyMaxParallel,
+		blockQueueSz:             defaultBlockQueueSz,
+		apikeyMaxReqSize:         defaultApikeyMaxReqSize,
 		maxPendingBulkDispatches: defaultMaxPendingBulkDispatches,
-		policyTokens:         []config.PolicyToken{}, // default is empty
+		policyTokens:             []config.PolicyToken{}, // default is empty
 	}
 
 	for _, f := range opts {

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -81,15 +81,16 @@ func withAPMLinkedContext(ctx context.Context) Opt {
 // Bulk API options
 
 type bulkOptT struct {
-	flushInterval     time.Duration
-	flushThresholdCnt int
-	flushThresholdSz  int
-	maxPending        int
-	blockQueueSz      int
-	apikeyMaxParallel int
-	apikeyMaxReqSize  int
-	policyTokens      []config.PolicyToken
-	bi                build.Info
+	flushInterval        time.Duration
+	flushThresholdCnt    int
+	flushThresholdSz     int
+	maxPending           int
+	blockQueueSz         int
+	apikeyMaxParallel    int
+	apikeyMaxReqSize     int
+	maxPendingDispatches int
+	policyTokens         []config.PolicyToken
+	bi                   build.Info
 }
 
 type BulkOpt func(*bulkOptT)
@@ -129,6 +130,14 @@ func WithBlockQueueSize(sz int) BulkOpt {
 	}
 }
 
+// WithMaxPendingDispatches sets the upper bound on concurrent dispatch goroutines.
+// When the limit is reached, new dispatches are rejected immediately. 0 means no limit.
+func WithMaxPendingDispatches(max int) BulkOpt {
+	return func(opt *bulkOptT) {
+		opt.maxPendingDispatches = max
+	}
+}
+
 // WithAPIKeyMaxParallel sets the number of api key operations outstanding
 func WithAPIKeyMaxParallel(max int) BulkOpt {
 	return func(opt *bulkOptT) {
@@ -160,14 +169,15 @@ func WithBi(bi build.Info) BulkOpt {
 
 func parseBulkOpts(opts ...BulkOpt) bulkOptT {
 	bopt := bulkOptT{
-		flushInterval:     defaultFlushInterval,
-		flushThresholdCnt: defaultFlushThresholdCnt,
-		flushThresholdSz:  defaultFlushThresholdSz,
-		maxPending:        defaultMaxPending,
-		apikeyMaxParallel: defaultAPIKeyMaxParallel,
-		blockQueueSz:      defaultBlockQueueSz,
-		apikeyMaxReqSize:  defaultApikeyMaxReqSize,
-		policyTokens:      []config.PolicyToken{}, // default is empty
+		flushInterval:        defaultFlushInterval,
+		flushThresholdCnt:    defaultFlushThresholdCnt,
+		flushThresholdSz:     defaultFlushThresholdSz,
+		maxPending:           defaultMaxPending,
+		apikeyMaxParallel:    defaultAPIKeyMaxParallel,
+		blockQueueSz:         defaultBlockQueueSz,
+		apikeyMaxReqSize:     defaultApikeyMaxReqSize,
+		maxPendingDispatches: defaultMaxPendingDispatches,
+		policyTokens:         []config.PolicyToken{}, // default is empty
 	}
 
 	for _, f := range opts {
@@ -185,6 +195,7 @@ func (o *bulkOptT) MarshalZerologObject(e *zerolog.Event) {
 	e.Int("blockQueueSz", o.blockQueueSz)
 	e.Int("apikeyMaxParallel", o.apikeyMaxParallel)
 	e.Int("apikeyMaxReqSize", o.apikeyMaxReqSize)
+	e.Int("maxPendingDispatches", o.maxPendingDispatches)
 }
 
 // BulkOptsFromCfg transforms config to a slize of BulkOpt
@@ -208,6 +219,7 @@ func BulkOptsFromCfg(cfg *config.Config) []BulkOpt {
 		WithMaxPending(bulkCfg.FlushMaxPending),
 		WithAPIKeyMaxParallel(maxKeyParallel),
 		WithAPIKeyMaxRequestSize(cfg.Output.Elasticsearch.MaxContentLength),
+		WithMaxPendingDispatches(bulkCfg.MaxPendingDispatches),
 		WithPolicyTokens(policyTokens),
 	}
 }

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -88,7 +88,7 @@ type bulkOptT struct {
 	blockQueueSz         int
 	apikeyMaxParallel    int
 	apikeyMaxReqSize     int
-	maxPendingDispatches int
+	maxPendingBulkDispatches int
 	policyTokens         []config.PolicyToken
 	bi                   build.Info
 }
@@ -130,11 +130,11 @@ func WithBlockQueueSize(sz int) BulkOpt {
 	}
 }
 
-// WithMaxPendingDispatches sets the upper bound on concurrent dispatch goroutines.
-// When the limit is reached, new dispatches are rejected immediately. 0 means no limit.
-func WithMaxPendingDispatches(max int) BulkOpt {
+// WithMaxPendingBulkDispatches sets the upper bound on concurrent bulk dispatch goroutines.
+// When the limit is reached, new bulk dispatches are rejected immediately. 0 means no limit.
+func WithMaxPendingBulkDispatches(max int) BulkOpt {
 	return func(opt *bulkOptT) {
-		opt.maxPendingDispatches = max
+		opt.maxPendingBulkDispatches = max
 	}
 }
 
@@ -176,7 +176,7 @@ func parseBulkOpts(opts ...BulkOpt) bulkOptT {
 		apikeyMaxParallel:    defaultAPIKeyMaxParallel,
 		blockQueueSz:         defaultBlockQueueSz,
 		apikeyMaxReqSize:     defaultApikeyMaxReqSize,
-		maxPendingDispatches: defaultMaxPendingDispatches,
+		maxPendingBulkDispatches: defaultMaxPendingBulkDispatches,
 		policyTokens:         []config.PolicyToken{}, // default is empty
 	}
 
@@ -195,7 +195,7 @@ func (o *bulkOptT) MarshalZerologObject(e *zerolog.Event) {
 	e.Int("blockQueueSz", o.blockQueueSz)
 	e.Int("apikeyMaxParallel", o.apikeyMaxParallel)
 	e.Int("apikeyMaxReqSize", o.apikeyMaxReqSize)
-	e.Int("maxPendingDispatches", o.maxPendingDispatches)
+	e.Int("maxPendingBulkDispatches", o.maxPendingBulkDispatches)
 }
 
 // BulkOptsFromCfg transforms config to a slize of BulkOpt
@@ -219,7 +219,7 @@ func BulkOptsFromCfg(cfg *config.Config) []BulkOpt {
 		WithMaxPending(bulkCfg.FlushMaxPending),
 		WithAPIKeyMaxParallel(maxKeyParallel),
 		WithAPIKeyMaxRequestSize(cfg.Output.Elasticsearch.MaxContentLength),
-		WithMaxPendingDispatches(bulkCfg.MaxPendingDispatches),
+		WithMaxPendingBulkDispatches(bulkCfg.MaxPendingBulkDispatches),
 		WithPolicyTokens(policyTokens),
 	}
 }

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -88,7 +88,7 @@ type bulkOptT struct {
 	blockQueueSz             int
 	apikeyMaxParallel        int
 	apikeyMaxReqSize         int
-	maxPendingBulkDispatches int
+	maxPendingBulkDispatches int64
 	policyTokens             []config.PolicyToken
 	bi                       build.Info
 }
@@ -132,7 +132,7 @@ func WithBlockQueueSize(sz int) BulkOpt {
 
 // WithMaxPendingBulkDispatches sets the upper bound on concurrent bulk dispatch goroutines.
 // When the limit is reached, new bulk dispatches are rejected immediately. 0 means no limit.
-func WithMaxPendingBulkDispatches(max int) BulkOpt {
+func WithMaxPendingBulkDispatches(max int64) BulkOpt {
 	return func(opt *bulkOptT) {
 		opt.maxPendingBulkDispatches = max
 	}
@@ -195,7 +195,7 @@ func (o *bulkOptT) MarshalZerologObject(e *zerolog.Event) {
 	e.Int("blockQueueSz", o.blockQueueSz)
 	e.Int("apikeyMaxParallel", o.apikeyMaxParallel)
 	e.Int("apikeyMaxReqSize", o.apikeyMaxReqSize)
-	e.Int("maxPendingBulkDispatches", o.maxPendingBulkDispatches)
+	e.Int64("maxPendingBulkDispatches", o.maxPendingBulkDispatches)
 }
 
 // BulkOptsFromCfg transforms config to a slize of BulkOpt

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -49,7 +49,7 @@ type ServerBulk struct {
 	FlushThresholdCount      int           `config:"flush_threshold_cnt"`
 	FlushThresholdSize       int           `config:"flush_threshold_size"`
 	FlushMaxPending          int           `config:"flush_max_pending"`
-	MaxPendingBulkDispatches int           `config:"max_pending_bulk_dispatches"`
+	MaxPendingBulkDispatches int64         `config:"max_pending_bulk_dispatches"`
 }
 
 func (c *ServerBulk) InitDefaults() {

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -45,11 +45,11 @@ type ServerTLS struct {
 }
 
 type ServerBulk struct {
-	FlushInterval        time.Duration `config:"flush_interval"`
-	FlushThresholdCount  int           `config:"flush_threshold_cnt"`
-	FlushThresholdSize   int           `config:"flush_threshold_size"`
-	FlushMaxPending      int           `config:"flush_max_pending"`
-	MaxPendingBulkDispatches int       `config:"max_pending_bulk_dispatches"`
+	FlushInterval            time.Duration `config:"flush_interval"`
+	FlushThresholdCount      int           `config:"flush_threshold_cnt"`
+	FlushThresholdSize       int           `config:"flush_threshold_size"`
+	FlushMaxPending          int           `config:"flush_max_pending"`
+	MaxPendingBulkDispatches int           `config:"max_pending_bulk_dispatches"`
 }
 
 func (c *ServerBulk) InitDefaults() {

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -49,7 +49,7 @@ type ServerBulk struct {
 	FlushThresholdCount  int           `config:"flush_threshold_cnt"`
 	FlushThresholdSize   int           `config:"flush_threshold_size"`
 	FlushMaxPending      int           `config:"flush_max_pending"`
-	MaxPendingDispatches int           `config:"max_pending_dispatches"`
+	MaxPendingBulkDispatches int       `config:"max_pending_bulk_dispatches"`
 }
 
 func (c *ServerBulk) InitDefaults() {

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -45,10 +45,11 @@ type ServerTLS struct {
 }
 
 type ServerBulk struct {
-	FlushInterval       time.Duration `config:"flush_interval"`
-	FlushThresholdCount int           `config:"flush_threshold_cnt"`
-	FlushThresholdSize  int           `config:"flush_threshold_size"`
-	FlushMaxPending     int           `config:"flush_max_pending"`
+	FlushInterval        time.Duration `config:"flush_interval"`
+	FlushThresholdCount  int           `config:"flush_threshold_cnt"`
+	FlushThresholdSize   int           `config:"flush_threshold_size"`
+	FlushMaxPending      int           `config:"flush_max_pending"`
+	MaxPendingDispatches int           `config:"max_pending_dispatches"`
 }
 
 func (c *ServerBulk) InitDefaults() {


### PR DESCRIPTION
## What is the problem this PR solves?

During a 30k Serverless scale test, 22 of 39 fleet-server pods were OOMKilled. Analysis of the captured pod logs showed:

- An upgrade + policy reassignment storm caused checkin durations to spike from normal (~ms) to 5-45 seconds average.
- This created ~479 concurrent checkins per pod, each blocked in `dispatch()` waiting to enqueue onto the bulk engine's channel (capacity 32).
- Elasticsearch was **not** the bottleneck — ES had ~88% free heap after GC with sub-30ms pause times.
- Each blocked goroutine holds its stack (~4-8KB) plus the `bulkT` object. With no upper bound on concurrent dispatches, goroutines piled up until pods hit their memory limit (~154 Mi) and were killed.

## How does this PR solve the problem?

This adds an optional cap on concurrent dispatch goroutines to bound memory usage.

The limit check runs at the top of `dispatch()`, before blocking on the channel: https://github.com/elastic/fleet-server/blob/1f456fb664ec564e2066ba0d0f5a28e0c552471c/internal/pkg/bulk/engine.go#L608-L622

When the limit is reached, the dispatch is rejected immediately with `ErrTooManyDispatches`, which maps to HTTP 429 so agents retry on their next checkin interval: https://github.com/elastic/fleet-server/blob/1f456fb664ec564e2066ba0d0f5a28e0c552471c/internal/pkg/api/error.go#L181-L189

The limit is configurable via `max_pending_dispatches` in the bulk config: https://github.com/elastic/fleet-server/blob/1f456fb664ec564e2066ba0d0f5a28e0c552471c/internal/pkg/config/input.go#L52

The default is 0 (no limit) so existing deployments are unaffected. Operators opt in by setting a value appropriate for their deployment size.

## How to test this PR locally

```
go test -race ./internal/pkg/bulk/ -run TestDispatch -v
```

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [x] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Relates #6747

🤖 Generated with [Claude Code](https://claude.com/claude-code)