### PR TITLE
fix: report server capabilities in OpAMP responses

### DIFF
--- a/changelog/fragments/1776103950-report-opamp-server-capabilities.yaml
+++ b/changelog/fragments/1776103950-report-opamp-server-capabilities.yaml
@@ -1,0 +1,4 @@
+kind: bug-fix
+summary: Report server capabilities in OpAMP ServerToAgent responses as required by the spec
+component: fleet-server
+issue: https://github.com/elastic/fleet-server/issues/6785

--- a/docs/opamp.md
+++ b/docs/opamp.md
@@ -14,14 +14,13 @@ Fleet-server implements a subset of the [OpAMP specification](https://github.com
 
 ### Server-to-agent features not implemented
 
-Fleet-server operates in monitoring-only mode. The `ServerToAgent` response only contains `instance_uid`; all other fields are unset.
+Fleet-server operates in monitoring-only mode.
 
 - **No remote configuration.** The spec defines `ServerToAgent.remote_config` for pushing configuration to agents.
 - **No connection settings management.** The spec defines `ServerToAgent.connection_settings` for offering new connection settings, TLS certificates, etc.
 - **No package management.** The spec defines `ServerToAgent.packages_available` for offering downloadable packages and updates.
 - **No server-initiated commands.** The spec defines `ServerToAgent.command` (e.g., restart).
 - **No `ServerToAgent.flags`.** The spec defines `ReportFullState` for requesting full agent state re-delivery.
-- **No `ServerToAgent.capabilities`.** The spec says the server MUST report its capabilities bitmask in the first response. Fleet-server does not set this field.
 - **No `ServerToAgent.agent_identification`.** The spec allows the server to reassign the agent's `instance_uid`.
 - **No custom messages.** The spec defines `custom_capabilities` and `custom_message` for extensible server-to-agent communication.
 
@@ -42,7 +41,6 @@ The following fields are ignored:
 - **Auto-enrollment.** The spec does not define enrollment. Fleet-server auto-enrolls unknown agents on first message using the enrollment API key's associated policy, creating a document in the `.fleet-agents` index with type `OPAMP`.
 - **Health-to-status mapping.** Fleet-server maps `ComponentHealth` to simplified statuses (`online`, `error`, `degraded`). The spec's nested `component_health_map` is not traversed; only the top-level health is used.
 - **Sensitive value redaction.** Fleet-server redacts keys containing `password`, `token`, `key`, `secret`, `auth`, `certificate`, or `passphrase` from the effective config before persisting.
-- **YAML-to-JSON conversion.** Fleet-server parses the effective config body as YAML and re-serializes it to JSON for storage.
 
 ### Capabilities
 

--- a/internal/pkg/api/handleOpAMP.go
+++ b/internal/pkg/api/handleOpAMP.go
@@ -36,7 +36,6 @@ import (
 
 const (
 	kOpAMPMod          = "opAMP"
-	statusDisconnected = "disconnected"
 	serverCapabilities = uint64(protobufs.ServerCapabilities_ServerCapabilities_AcceptsStatus |
 		protobufs.ServerCapabilities_ServerCapabilities_AcceptsEffectiveConfig)
 )
@@ -194,7 +193,7 @@ func (oa *OpAMPT) handleMessage(zlog zerolog.Logger, apiKey *apikey.APIKey) func
 				}
 			}
 			zlog.Debug().Msg("agent disconnect received")
-			_ = oa.bc.CheckIn(instanceUID.String(), checkin.WithStatus(statusDisconnected))
+			_ = oa.bc.CheckIn(instanceUID.String(), checkin.WithStatus(string(CheckinRequestStatusDisconnected)))
 			return &protobufs.ServerToAgent{
 				InstanceUid: instanceUID.Bytes(),
 			}
@@ -361,14 +360,14 @@ func (oa *OpAMPT) updateAgent(zlog zerolog.Logger, agent *model.Agent, aToS *pro
 
 	initialOpts := make([]checkin.Option, 0)
 
-	status := "online"
+	status := CheckinRequestStatusOnline
 
 	// Extract the health status from the health message if it exists.
 	if aToS.Health != nil {
 		if !aToS.Health.Healthy {
-			status = "error"
+			status = CheckinRequestStatusError
 		} else if aToS.Health.Status == "StatusRecoverableError" {
-			status = "degraded"
+			status = CheckinRequestStatusDegraded
 		}
 
 		// Extract the last_checkin_message from the health message if it exists.
@@ -384,7 +383,7 @@ func (oa *OpAMPT) updateAgent(zlog zerolog.Logger, agent *model.Agent, aToS *pro
 		initialOpts = append(initialOpts, checkin.WithHealth(healthBytes))
 	}
 
-	initialOpts = append(initialOpts, checkin.WithStatus(status))
+	initialOpts = append(initialOpts, checkin.WithStatus(string(status)))
 	initialOpts = append(initialOpts, checkin.WithSequenceNum(aToS.SequenceNum))
 
 	capabilities := decodeCapabilities(aToS.Capabilities)
@@ -541,7 +540,9 @@ func ProtobufKVToRawMessage(zlog zerolog.Logger, kv []*protobufs.KeyValue) (json
 }
 
 func isActiveStatus(status string) bool {
-	return status == "online" || status == "error" || status == "degraded"
+	return status == string(CheckinRequestStatusOnline) ||
+		status == string(CheckinRequestStatusError) ||
+		status == string(CheckinRequestStatusDegraded)
 }
 
 // decodeCapabilities converts capability bitmask to human-readable strings

--- a/internal/pkg/api/handleOpAMP.go
+++ b/internal/pkg/api/handleOpAMP.go
@@ -37,6 +37,8 @@ import (
 const (
 	kOpAMPMod          = "opAMP"
 	statusDisconnected = "disconnected"
+	serverCapabilities = uint64(protobufs.ServerCapabilities_ServerCapabilities_AcceptsStatus |
+		protobufs.ServerCapabilities_ServerCapabilities_AcceptsEffectiveConfig)
 )
 
 type OpAMPT struct {
@@ -198,7 +200,9 @@ func (oa *OpAMPT) handleMessage(zlog zerolog.Logger, apiKey *apikey.APIKey) func
 			}
 		}
 
+		sendCapabilities := false
 		if agent == nil {
+			sendCapabilities = true
 			if agent, err = oa.enrollAgent(zlog, instanceUID.String(), message, apiKey); err != nil {
 				return &protobufs.ServerToAgent{
 					InstanceUid: instanceUID.Bytes(),
@@ -208,6 +212,8 @@ func (oa *OpAMPT) handleMessage(zlog zerolog.Logger, apiKey *apikey.APIKey) func
 					},
 				}
 			}
+		} else if !isActiveStatus(agent.LastCheckinStatus) {
+			sendCapabilities = true
 		}
 
 		if err := oa.updateAgent(zlog, agent, message); err != nil {
@@ -220,9 +226,11 @@ func (oa *OpAMPT) handleMessage(zlog zerolog.Logger, apiKey *apikey.APIKey) func
 			}
 		}
 
-		// Empty message for now since we're only using OpAMP for monitoring.
 		sToA := protobufs.ServerToAgent{
 			InstanceUid: instanceUID.Bytes(),
+		}
+		if sendCapabilities {
+			sToA.Capabilities = serverCapabilities
 		}
 
 		return &sToA
@@ -530,6 +538,10 @@ func ProtobufKVToRawMessage(zlog zerolog.Logger, kv []*protobufs.KeyValue) (json
 	}
 
 	return json.RawMessage(b), nil
+}
+
+func isActiveStatus(status string) bool {
+	return status == "online" || status == "error" || status == "degraded"
 }
 
 // decodeCapabilities converts capability bitmask to human-readable strings

--- a/internal/pkg/api/handleOpAMP_test.go
+++ b/internal/pkg/api/handleOpAMP_test.go
@@ -252,7 +252,7 @@ func TestUpdateAgentWithAgentToServerMessage(t *testing.T) {
 	require.Equal(t, "agent-123", checker.id)
 
 	pending := pendingFromOptions(t, checker.opts)
-	require.Equal(t, "degraded", getUnexportedField(pending, "status").String())
+	require.Equal(t, string(CheckinRequestStatusDegraded), getUnexportedField(pending, "status").String())
 	require.Equal(t, "boom", getUnexportedField(pending, "message").String())
 	require.Equal(t, uint64(7), getUnexportedField(pending, "sequenceNum").Uint())
 
@@ -289,7 +289,7 @@ func TestHandleMessageAgentDisconnect(t *testing.T) {
 			getBulker: func(t *testing.T) *ftesting.MockBulk {
 				t.Helper()
 				bulker := ftesting.NewMockBulk()
-				agent := model.Agent{LastCheckinStatus: "online"}
+				agent := model.Agent{LastCheckinStatus: string(CheckinRequestStatusOnline)}
 				agentBytes, err := json.Marshal(agent)
 				require.NoError(t, err)
 				bulker.On("Search", mock.Anything, dl.FleetAgents, mock.Anything, mock.Anything).
@@ -338,7 +338,7 @@ func TestHandleMessageAgentDisconnect(t *testing.T) {
 				require.Equal(t, agentUID.String(), checker.id)
 
 				pending := pendingFromOptions(t, checker.opts)
-				require.Equal(t, statusDisconnected, getUnexportedField(pending, "status").String())
+				require.Equal(t, string(CheckinRequestStatusDisconnected), getUnexportedField(pending, "status").String())
 			}
 		})
 	}
@@ -393,7 +393,7 @@ func TestHandleMessageCapabilities(t *testing.T) {
 			getBulker: func(t *testing.T) *ftesting.MockBulk {
 				t.Helper()
 				bulker := ftesting.NewMockBulk()
-				agent := model.Agent{LastCheckinStatus: "disconnected"}
+				agent := model.Agent{LastCheckinStatus: string(CheckinRequestStatusDisconnected)}
 				agentBytes, err := json.Marshal(agent)
 				require.NoError(t, err)
 				bulker.On("Search", mock.Anything, dl.FleetAgents, mock.Anything, mock.Anything).
@@ -407,7 +407,7 @@ func TestHandleMessageCapabilities(t *testing.T) {
 			getBulker: func(t *testing.T) *ftesting.MockBulk {
 				t.Helper()
 				bulker := ftesting.NewMockBulk()
-				agent := model.Agent{LastCheckinStatus: "online"}
+				agent := model.Agent{LastCheckinStatus: string(CheckinRequestStatusOnline)}
 				agentBytes, err := json.Marshal(agent)
 				require.NoError(t, err)
 				bulker.On("Search", mock.Anything, dl.FleetAgents, mock.Anything, mock.Anything).

--- a/internal/pkg/api/handleOpAMP_test.go
+++ b/internal/pkg/api/handleOpAMP_test.go
@@ -141,12 +141,12 @@ func TestProtobufKVToRawMessage(t *testing.T) {
 func TestEnrollAgentWithAgentToServerMessage(t *testing.T) {
 	bulker := ftesting.NewMockBulk()
 
-	enrollKey := model.EnrollmentAPIKey{
+	enrollKey := model.EnrollmentAPIKey{ //nolint:gosec // fake api key used in test
 		APIKeyID: "enroll-key-id",
 		PolicyID: "policy-123",
 		Active:   true,
 	}
-	enrollKeyBytes, err := json.Marshal(enrollKey)
+	enrollKeyBytes, err := json.Marshal(enrollKey) //nolint:gosec // fake api key used in test
 	require.NoError(t, err)
 
 	bulker.On("Search", mock.Anything, dl.FleetEnrollmentAPIKeys, mock.Anything, mock.Anything).
@@ -364,7 +364,7 @@ func TestHandleMessageCapabilities(t *testing.T) {
 					PolicyID: "policy-123",
 					Active:   true,
 				}
-				enrollKeyBytes, err := json.Marshal(enrollKey)
+				enrollKeyBytes, err := json.Marshal(enrollKey) //nolint:gosec // fake api key used in test
 				require.NoError(t, err)
 				bulker.On("Search", mock.Anything, dl.FleetEnrollmentAPIKeys, mock.Anything, mock.Anything).
 					Return(&es.ResultT{HitsT: es.HitsT{Hits: []es.HitT{{Source: enrollKeyBytes}}}}, nil)

--- a/internal/pkg/api/handleOpAMP_test.go
+++ b/internal/pkg/api/handleOpAMP_test.go
@@ -344,6 +344,102 @@ func TestHandleMessageAgentDisconnect(t *testing.T) {
 	}
 }
 
+func TestHandleMessageCapabilities(t *testing.T) {
+	const testAPIKeyID = "test-key"
+
+	cases := []struct {
+		name      string
+		getBulker func(t *testing.T) *ftesting.MockBulk
+		wantCaps  uint64
+	}{
+		{
+			name: "new enrollment sends capabilities",
+			getBulker: func(t *testing.T) *ftesting.MockBulk {
+				t.Helper()
+				bulker := ftesting.NewMockBulk()
+				bulker.On("Search", mock.Anything, dl.FleetAgents, mock.Anything, mock.Anything).
+					Return(&es.ResultT{HitsT: es.HitsT{Hits: []es.HitT{}}}, nil)
+				enrollKey := model.EnrollmentAPIKey{
+					APIKeyID: testAPIKeyID,
+					PolicyID: "policy-123",
+					Active:   true,
+				}
+				enrollKeyBytes, err := json.Marshal(enrollKey)
+				require.NoError(t, err)
+				bulker.On("Search", mock.Anything, dl.FleetEnrollmentAPIKeys, mock.Anything, mock.Anything).
+					Return(&es.ResultT{HitsT: es.HitsT{Hits: []es.HitT{{Source: enrollKeyBytes}}}}, nil)
+				bulker.On("Create", mock.Anything, dl.FleetAgents, mock.Anything, mock.Anything, mock.Anything).
+					Return("doc-id", nil)
+				return bulker
+			},
+			wantCaps: serverCapabilities,
+		},
+		{
+			name: "offline agent sends capabilities",
+			getBulker: func(t *testing.T) *ftesting.MockBulk {
+				t.Helper()
+				bulker := ftesting.NewMockBulk()
+				agent := model.Agent{LastCheckinStatus: "offline"}
+				agentBytes, err := json.Marshal(agent)
+				require.NoError(t, err)
+				bulker.On("Search", mock.Anything, dl.FleetAgents, mock.Anything, mock.Anything).
+					Return(&es.ResultT{HitsT: es.HitsT{Hits: []es.HitT{{ID: "agent-123", Source: agentBytes}}}}, nil)
+				return bulker
+			},
+			wantCaps: serverCapabilities,
+		},
+		{
+			name: "disconnected agent sends capabilities",
+			getBulker: func(t *testing.T) *ftesting.MockBulk {
+				t.Helper()
+				bulker := ftesting.NewMockBulk()
+				agent := model.Agent{LastCheckinStatus: "disconnected"}
+				agentBytes, err := json.Marshal(agent)
+				require.NoError(t, err)
+				bulker.On("Search", mock.Anything, dl.FleetAgents, mock.Anything, mock.Anything).
+					Return(&es.ResultT{HitsT: es.HitsT{Hits: []es.HitT{{ID: "agent-123", Source: agentBytes}}}}, nil)
+				return bulker
+			},
+			wantCaps: serverCapabilities,
+		},
+		{
+			name: "online agent does not send capabilities",
+			getBulker: func(t *testing.T) *ftesting.MockBulk {
+				t.Helper()
+				bulker := ftesting.NewMockBulk()
+				agent := model.Agent{LastCheckinStatus: "online"}
+				agentBytes, err := json.Marshal(agent)
+				require.NoError(t, err)
+				bulker.On("Search", mock.Anything, dl.FleetAgents, mock.Anything, mock.Anything).
+					Return(&es.ResultT{HitsT: es.HitsT{Hits: []es.HitT{{ID: "agent-123", Source: agentBytes}}}}, nil)
+				return bulker
+			},
+			wantCaps: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bulker := tc.getBulker(t)
+			checker := &mockCheckin{}
+			oa := &OpAMPT{bulk: bulker, bc: checker}
+
+			agentUID := uuid.Must(uuid.NewV7())
+			zlog := zerolog.New(io.Discard)
+			apiKey := &apikey.APIKey{ID: testAPIKeyID}
+
+			handler := oa.handleMessage(zlog, apiKey)
+			msg := &protobufs.AgentToServer{
+				InstanceUid: agentUID.Bytes(),
+			}
+
+			resp := handler(t.Context(), nil, msg)
+
+			require.Nil(t, resp.ErrorResponse)
+			require.Equal(t, tc.wantCaps, resp.Capabilities)
+		})
+	}
+}
+
 type mockCheckin struct {
 	id   string
 	opts []checkin.Option

--- a/internal/pkg/api/handleOpAMP_test.go
+++ b/internal/pkg/api/handleOpAMP_test.go
@@ -279,6 +279,7 @@ func TestUpdateAgentWithAgentToServerMessage(t *testing.T) {
 }
 
 func TestHandleMessageAgentDisconnect(t *testing.T) {
+	//nolint:dupl // test cases
 	cases := []struct {
 		name      string
 		getBulker func(t *testing.T) *ftesting.MockBulk
@@ -347,6 +348,7 @@ func TestHandleMessageAgentDisconnect(t *testing.T) {
 func TestHandleMessageCapabilities(t *testing.T) {
 	const testAPIKeyID = "test-key"
 
+	//nolint:dupl // test cases
 	cases := []struct {
 		name      string
 		getBulker func(t *testing.T) *ftesting.MockBulk

--- a/internal/pkg/api/openapi.gen.go
+++ b/internal/pkg/api/openapi.gen.go
@@ -62,10 +62,11 @@ const (
 
 // Defines values for CheckinRequestStatus.
 const (
-	CheckinRequestStatusDegraded CheckinRequestStatus = "degraded"
-	CheckinRequestStatusError    CheckinRequestStatus = "error"
-	CheckinRequestStatusOnline   CheckinRequestStatus = "online"
-	CheckinRequestStatusStarting CheckinRequestStatus = "starting"
+	CheckinRequestStatusDegraded     CheckinRequestStatus = "degraded"
+	CheckinRequestStatusDisconnected CheckinRequestStatus = "disconnected"
+	CheckinRequestStatusError        CheckinRequestStatus = "error"
+	CheckinRequestStatusOnline       CheckinRequestStatus = "online"
+	CheckinRequestStatusStarting     CheckinRequestStatus = "starting"
 )
 
 // Defines values for EnrollRequestType.

--- a/model/openapi.yml
+++ b/model/openapi.yml
@@ -412,6 +412,7 @@ components:
             - error
             - degraded
             - starting
+            - disconnected # special state added for opamp compatibility
         message:
           description: State message, may be overridden or use the error message of a failing component.
           type: string

--- a/pkg/api/types.gen.go
+++ b/pkg/api/types.gen.go
@@ -59,10 +59,11 @@ const (
 
 // Defines values for CheckinRequestStatus.
 const (
-	CheckinRequestStatusDegraded CheckinRequestStatus = "degraded"
-	CheckinRequestStatusError    CheckinRequestStatus = "error"
-	CheckinRequestStatusOnline   CheckinRequestStatus = "online"
-	CheckinRequestStatusStarting CheckinRequestStatus = "starting"
+	CheckinRequestStatusDegraded     CheckinRequestStatus = "degraded"
+	CheckinRequestStatusDisconnected CheckinRequestStatus = "disconnected"
+	CheckinRequestStatusError        CheckinRequestStatus = "error"
+	CheckinRequestStatusOnline       CheckinRequestStatus = "online"
+	CheckinRequestStatusStarting     CheckinRequestStatus = "starting"
 )
 
 // Defines values for EnrollRequestType.


### PR DESCRIPTION
## What is the problem this PR solves?

The OpAMP spec requires the server to report its capabilities bitmask in the first `ServerToAgent` response. Fleet-server was not setting this field, so agents could not discover what the server supports.

## How does this PR solve the problem?

Send the `serverCapabilities` bitmask (`AcceptsStatus`, `AcceptsEffectiveConfig`) in the `ServerToAgent` response when an agent enrolls or reconnects from a non-active status (offline, disconnected). Active agents (online, error, degraded) do not receive capabilities on every message to reduce response size. An `isActiveStatus` helper determines which statuses are considered active.

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [x] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Closes #6785