### PR TITLE
fix: always set ReportFullState flag in OpAMP responses

### DIFF
--- a/changelog/fragments/1776112788-opamp-report-full-state-flag.yaml
+++ b/changelog/fragments/1776112788-opamp-report-full-state-flag.yaml
@@ -1,0 +1,4 @@
+kind: bug-fix
+summary: Set ReportFullState flag in OpAMP responses when drift is detected per the spec
+component: fleet-server
+issue: https://github.com/elastic/fleet-server/issues/6783

--- a/changelog/fragments/1776112788-opamp-report-full-state-flag.yaml
+++ b/changelog/fragments/1776112788-opamp-report-full-state-flag.yaml
@@ -1,4 +1,4 @@
 kind: bug-fix
-summary: Set ReportFullState flag in OpAMP responses when drift is detected per the spec
+summary: Always Set ReportFullState flag in OpAMP responses
 component: fleet-server
 issue: https://github.com/elastic/fleet-server/issues/6783

--- a/docs/opamp.md
+++ b/docs/opamp.md
@@ -40,7 +40,7 @@ The following fields are ignored:
 - **Auto-enrollment.** The spec does not define enrollment. Fleet-server auto-enrolls unknown agents on first message using the enrollment API key's associated policy, creating a document in the `.fleet-agents` index with type `OPAMP`.
 - **Health-to-status mapping.** Fleet-server maps `ComponentHealth` to simplified statuses (`online`, `error`, `degraded`). The spec's nested `component_health_map` is not traversed; only the top-level health is used.
 - **Sensitive value redaction.** Fleet-server redacts keys containing `password`, `token`, `key`, `secret`, `auth`, `certificate`, or `passphrase` from the effective config before persisting.
-- **Always requests full state.** Fleet-server sets the `ReportFullState` flag in every `ServerToAgent` response, requesting the agent to include all status fields on every message.
+- **Always requests full state.** Fleet-server sets the `ReportFullState` flag in every `ServerToAgent` response, requesting the agent to include all status fields on every message. This is an intentional change intended to improve reliability by having constant load in order avoid irapid changes in workload.
 
 ### Throttling
 

--- a/docs/opamp.md
+++ b/docs/opamp.md
@@ -40,7 +40,7 @@ The following fields are ignored:
 - **Auto-enrollment.** The spec does not define enrollment. Fleet-server auto-enrolls unknown agents on first message using the enrollment API key's associated policy, creating a document in the `.fleet-agents` index with type `OPAMP`.
 - **Health-to-status mapping.** Fleet-server maps `ComponentHealth` to simplified statuses (`online`, `error`, `degraded`). The spec's nested `component_health_map` is not traversed; only the top-level health is used.
 - **Sensitive value redaction.** Fleet-server redacts keys containing `password`, `token`, `key`, `secret`, `auth`, `certificate`, or `passphrase` from the effective config before persisting.
-- **Always requests full state.** Fleet-server sets the `ReportFullState` flag in every `ServerToAgent` response, requesting the agent to include all status fields on every message. This is an intentional change intended to improve reliability by having constant load in order avoid irapid changes in workload.
+- **Always requests full state.** Fleet-server sets the `ReportFullState` flag in every `ServerToAgent` response, requesting the agent to include all status fields on every message. This is an intentional change intended to improve reliability by having constant load in order avoid rapid changes in workload.
 
 ### Throttling
 

--- a/docs/opamp.md
+++ b/docs/opamp.md
@@ -40,6 +40,7 @@ The following fields are ignored:
 - **Auto-enrollment.** The spec does not define enrollment. Fleet-server auto-enrolls unknown agents on first message using the enrollment API key's associated policy, creating a document in the `.fleet-agents` index with type `OPAMP`.
 - **Health-to-status mapping.** Fleet-server maps `ComponentHealth` to simplified statuses (`online`, `error`, `degraded`). The spec's nested `component_health_map` is not traversed; only the top-level health is used.
 - **Sensitive value redaction.** Fleet-server redacts keys containing `password`, `token`, `key`, `secret`, `auth`, `certificate`, or `passphrase` from the effective config before persisting.
+- **Always requests full state.** Fleet-server sets the `ReportFullState` flag in every `ServerToAgent` response, requesting the agent to include all status fields on every message.
 
 ### Throttling
 

--- a/docs/opamp.md
+++ b/docs/opamp.md
@@ -20,7 +20,6 @@ Fleet-server operates in monitoring-only mode.
 - **No connection settings management.** The spec defines `ServerToAgent.connection_settings` for offering new connection settings, TLS certificates, etc.
 - **No package management.** The spec defines `ServerToAgent.packages_available` for offering downloadable packages and updates.
 - **No server-initiated commands.** The spec defines `ServerToAgent.command` (e.g., restart).
-- **No `ServerToAgent.flags`.** The spec defines `ReportFullState` for requesting full agent state re-delivery.
 - **No `ServerToAgent.agent_identification`.** The spec allows the server to reassign the agent's `instance_uid`.
 - **No custom messages.** The spec defines `custom_capabilities` and `custom_message` for extensible server-to-agent communication.
 

--- a/internal/pkg/api/handleOpAMP.go
+++ b/internal/pkg/api/handleOpAMP.go
@@ -217,8 +217,8 @@ func (oa *OpAMPT) handleMessage(zlog zerolog.Logger, apiKey *apikey.APIKey) func
 			sendCapabilities = true
 		}
 
-		if !newlyEnrolled && message.SequenceNum != uint64(agent.SequenceNum)+1 {
-			zlog.Warn().
+		if !newlyEnrolled && message.SequenceNum != uint64(agent.SequenceNum)+1 { //nolint:gosec // agent seq num will not be negative
+			zlog.Debug().
 				Int64("stored_seq", agent.SequenceNum).
 				Uint64("msg_seq", message.SequenceNum).
 				Str("last_status", agent.LastCheckinStatus).

--- a/internal/pkg/api/handleOpAMP.go
+++ b/internal/pkg/api/handleOpAMP.go
@@ -200,8 +200,10 @@ func (oa *OpAMPT) handleMessage(zlog zerolog.Logger, apiKey *apikey.APIKey) func
 		}
 
 		sendCapabilities := false
+		newlyEnrolled := false
 		if agent == nil {
 			sendCapabilities = true
+			newlyEnrolled = true
 			if agent, err = oa.enrollAgent(zlog, instanceUID.String(), message, apiKey); err != nil {
 				return &protobufs.ServerToAgent{
 					InstanceUid: instanceUID.Bytes(),
@@ -214,6 +216,8 @@ func (oa *OpAMPT) handleMessage(zlog zerolog.Logger, apiKey *apikey.APIKey) func
 		} else if !isActiveStatus(agent.LastCheckinStatus) {
 			sendCapabilities = true
 		}
+
+		requestFullState := shouldRequestFullState(agent, message, newlyEnrolled)
 
 		if err := oa.updateAgent(zlog, agent, message); err != nil {
 			return &protobufs.ServerToAgent{
@@ -230,6 +234,16 @@ func (oa *OpAMPT) handleMessage(zlog zerolog.Logger, apiKey *apikey.APIKey) func
 		}
 		if sendCapabilities {
 			sToA.Capabilities = serverCapabilities
+		}
+
+		if requestFullState {
+			sToA.Flags |= uint64(protobufs.ServerToAgentFlags_ServerToAgentFlags_ReportFullState)
+			zlog.Debug().
+				Int64("stored_seq", agent.SequenceNum).
+				Uint64("msg_seq", message.SequenceNum).
+				Bool("newly_enrolled", newlyEnrolled).
+				Str("last_status", agent.LastCheckinStatus).
+				Msg("requesting full state report from agent")
 		}
 
 		return &sToA
@@ -545,6 +559,58 @@ func isActiveStatus(status string) bool {
 	return status == string(CheckinRequestStatusOnline) ||
 		status == string(CheckinRequestStatusError) ||
 		status == string(CheckinRequestStatusDegraded)
+}
+
+// hasFullStatus returns true if the AgentToServer message includes all fields
+// expected for a complete status report given the agent's declared capabilities.
+// Capabilities must be non-zero. AgentDescription and Health are always required.
+// Each "Reports*" capability implies its corresponding field must be present.
+func hasFullStatus(aToS *protobufs.AgentToServer) bool {
+	if aToS.Capabilities == 0 {
+		return false
+	}
+	if aToS.AgentDescription == nil || aToS.Health == nil {
+		return false
+	}
+
+	caps := aToS.Capabilities
+	checks := []struct {
+		cap   uint64
+		field bool // true if the field IS present
+	}{
+		{uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsEffectiveConfig), aToS.EffectiveConfig != nil},
+		{uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsRemoteConfig), aToS.RemoteConfigStatus != nil},
+		{uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsPackageStatuses), aToS.PackageStatuses != nil},
+		{uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsAvailableComponents), aToS.AvailableComponents != nil},
+		{uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus), aToS.ConnectionSettingsStatus != nil},
+	}
+	for _, c := range checks {
+		if caps&c.cap != 0 && !c.field {
+			return false
+		}
+	}
+	return true
+}
+
+// shouldRequestFullState determines whether the server should set the
+// ReportFullState flag in its response. False positives are harmless (the agent
+// resends full state) and expected when the stored sequence number lags due to
+// batched writes (flush interval is ~10s).
+func shouldRequestFullState(agent *model.Agent, aToS *protobufs.AgentToServer, newlyEnrolled bool) bool {
+	// Newly enrolled agent should send full status on first message.
+	if newlyEnrolled {
+		return !hasFullStatus(aToS)
+	}
+
+	// Sequence gap: seq_num is not exactly stored + 1.
+	// Disconnected agents are exempt if seq is 0 (known restart) or continues normally.
+	var storedSeq uint64
+	if agent.SequenceNum > 0 {
+		storedSeq = uint64(agent.SequenceNum)
+	}
+	hasGap := aToS.SequenceNum != storedSeq+1
+	isRestart := agent.LastCheckinStatus == string(CheckinRequestStatusDisconnected) && aToS.SequenceNum == 0
+	return hasGap && !isRestart
 }
 
 // decodeCapabilities converts capability bitmask to human-readable strings

--- a/internal/pkg/api/handleOpAMP.go
+++ b/internal/pkg/api/handleOpAMP.go
@@ -217,7 +217,13 @@ func (oa *OpAMPT) handleMessage(zlog zerolog.Logger, apiKey *apikey.APIKey) func
 			sendCapabilities = true
 		}
 
-		requestFullState := shouldRequestFullState(agent, message, newlyEnrolled)
+		if !newlyEnrolled && message.SequenceNum != uint64(agent.SequenceNum)+1 {
+			zlog.Warn().
+				Int64("stored_seq", agent.SequenceNum).
+				Uint64("msg_seq", message.SequenceNum).
+				Str("last_status", agent.LastCheckinStatus).
+				Msg("sequence number drift detected")
+		}
 
 		if err := oa.updateAgent(zlog, agent, message); err != nil {
 			return &protobufs.ServerToAgent{
@@ -231,19 +237,10 @@ func (oa *OpAMPT) handleMessage(zlog zerolog.Logger, apiKey *apikey.APIKey) func
 
 		sToA := protobufs.ServerToAgent{
 			InstanceUid: instanceUID.Bytes(),
+			Flags:       uint64(protobufs.ServerToAgentFlags_ServerToAgentFlags_ReportFullState),
 		}
 		if sendCapabilities {
 			sToA.Capabilities = serverCapabilities
-		}
-
-		if requestFullState {
-			sToA.Flags |= uint64(protobufs.ServerToAgentFlags_ServerToAgentFlags_ReportFullState)
-			zlog.Debug().
-				Int64("stored_seq", agent.SequenceNum).
-				Uint64("msg_seq", message.SequenceNum).
-				Bool("newly_enrolled", newlyEnrolled).
-				Str("last_status", agent.LastCheckinStatus).
-				Msg("requesting full state report from agent")
 		}
 
 		return &sToA
@@ -559,58 +556,6 @@ func isActiveStatus(status string) bool {
 	return status == string(CheckinRequestStatusOnline) ||
 		status == string(CheckinRequestStatusError) ||
 		status == string(CheckinRequestStatusDegraded)
-}
-
-// hasFullStatus returns true if the AgentToServer message includes all fields
-// expected for a complete status report given the agent's declared capabilities.
-// Capabilities must be non-zero. AgentDescription and Health are always required.
-// Each "Reports*" capability implies its corresponding field must be present.
-func hasFullStatus(aToS *protobufs.AgentToServer) bool {
-	if aToS.Capabilities == 0 {
-		return false
-	}
-	if aToS.AgentDescription == nil || aToS.Health == nil {
-		return false
-	}
-
-	caps := aToS.Capabilities
-	checks := []struct {
-		cap   uint64
-		field bool // true if the field IS present
-	}{
-		{uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsEffectiveConfig), aToS.EffectiveConfig != nil},
-		{uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsRemoteConfig), aToS.RemoteConfigStatus != nil},
-		{uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsPackageStatuses), aToS.PackageStatuses != nil},
-		{uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsAvailableComponents), aToS.AvailableComponents != nil},
-		{uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus), aToS.ConnectionSettingsStatus != nil},
-	}
-	for _, c := range checks {
-		if caps&c.cap != 0 && !c.field {
-			return false
-		}
-	}
-	return true
-}
-
-// shouldRequestFullState determines whether the server should set the
-// ReportFullState flag in its response. False positives are harmless (the agent
-// resends full state) and expected when the stored sequence number lags due to
-// batched writes (flush interval is ~10s).
-func shouldRequestFullState(agent *model.Agent, aToS *protobufs.AgentToServer, newlyEnrolled bool) bool {
-	// Newly enrolled agent should send full status on first message.
-	if newlyEnrolled {
-		return !hasFullStatus(aToS)
-	}
-
-	// Sequence gap: seq_num is not exactly stored + 1.
-	// Disconnected agents are exempt if seq is 0 (known restart) or continues normally.
-	var storedSeq uint64
-	if agent.SequenceNum > 0 {
-		storedSeq = uint64(agent.SequenceNum)
-	}
-	hasGap := aToS.SequenceNum != storedSeq+1
-	isRestart := agent.LastCheckinStatus == string(CheckinRequestStatusDisconnected) && aToS.SequenceNum == 0
-	return hasGap && !isRestart
 }
 
 // decodeCapabilities converts capability bitmask to human-readable strings

--- a/internal/pkg/api/handleOpAMP_test.go
+++ b/internal/pkg/api/handleOpAMP_test.go
@@ -544,3 +544,305 @@ func getUnexportedField(v reflect.Value, name string) reflect.Value {
 	field := v.FieldByName(name)
 	return reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem()
 }
+
+func TestHasFullStatus(t *testing.T) {
+	baseCaps := uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsStatus)
+
+	cases := []struct {
+		name string
+		msg  *protobufs.AgentToServer
+		want bool
+	}{
+		{
+			name: "capabilities unset",
+			msg: &protobufs.AgentToServer{
+				Capabilities:     0,
+				AgentDescription: &protobufs.AgentDescription{},
+				Health:           &protobufs.ComponentHealth{},
+			},
+			want: false,
+		},
+		{
+			name: "base fields only, no conditional capabilities",
+			msg: &protobufs.AgentToServer{
+				Capabilities:     baseCaps,
+				AgentDescription: &protobufs.AgentDescription{},
+				Health:           &protobufs.ComponentHealth{},
+			},
+			want: true,
+		},
+		{
+			name: "missing AgentDescription",
+			msg: &protobufs.AgentToServer{
+				Capabilities: baseCaps,
+				Health:       &protobufs.ComponentHealth{},
+			},
+			want: false,
+		},
+		{
+			name: "missing Health",
+			msg: &protobufs.AgentToServer{
+				Capabilities:     baseCaps,
+				AgentDescription: &protobufs.AgentDescription{},
+			},
+			want: false,
+		},
+		{
+			name: "ReportsEffectiveConfig capability without EffectiveConfig",
+			msg: &protobufs.AgentToServer{
+				Capabilities:     baseCaps | uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsEffectiveConfig),
+				AgentDescription: &protobufs.AgentDescription{},
+				Health:           &protobufs.ComponentHealth{},
+			},
+			want: false,
+		},
+		{
+			name: "ReportsEffectiveConfig capability with EffectiveConfig",
+			msg: &protobufs.AgentToServer{
+				Capabilities:     baseCaps | uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsEffectiveConfig),
+				AgentDescription: &protobufs.AgentDescription{},
+				Health:           &protobufs.ComponentHealth{},
+				EffectiveConfig:  &protobufs.EffectiveConfig{},
+			},
+			want: true,
+		},
+		{
+			name: "ReportsRemoteConfig capability without RemoteConfigStatus",
+			msg: &protobufs.AgentToServer{
+				Capabilities:     baseCaps | uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsRemoteConfig),
+				AgentDescription: &protobufs.AgentDescription{},
+				Health:           &protobufs.ComponentHealth{},
+			},
+			want: false,
+		},
+		{
+			name: "ReportsPackageStatuses capability without PackageStatuses",
+			msg: &protobufs.AgentToServer{
+				Capabilities:     baseCaps | uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsPackageStatuses),
+				AgentDescription: &protobufs.AgentDescription{},
+				Health:           &protobufs.ComponentHealth{},
+			},
+			want: false,
+		},
+		{
+			name: "ReportsAvailableComponents capability without AvailableComponents",
+			msg: &protobufs.AgentToServer{
+				Capabilities:     baseCaps | uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsAvailableComponents),
+				AgentDescription: &protobufs.AgentDescription{},
+				Health:           &protobufs.ComponentHealth{},
+			},
+			want: false,
+		},
+		{
+			name: "ReportsConnectionSettingsStatus capability without ConnectionSettingsStatus",
+			msg: &protobufs.AgentToServer{
+				Capabilities:     baseCaps | uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus),
+				AgentDescription: &protobufs.AgentDescription{},
+				Health:           &protobufs.ComponentHealth{},
+			},
+			want: false,
+		},
+		{
+			name: "multiple capabilities all fields present",
+			msg: &protobufs.AgentToServer{
+				Capabilities: baseCaps |
+					uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsEffectiveConfig) |
+					uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsRemoteConfig),
+				AgentDescription:   &protobufs.AgentDescription{},
+				Health:             &protobufs.ComponentHealth{},
+				EffectiveConfig:    &protobufs.EffectiveConfig{},
+				RemoteConfigStatus: &protobufs.RemoteConfigStatus{},
+			},
+			want: true,
+		},
+		{
+			name: "all fields missing",
+			msg:  &protobufs.AgentToServer{},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, hasFullStatus(tc.msg))
+		})
+	}
+}
+
+func TestShouldRequestFullState(t *testing.T) {
+	baseCaps := uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsStatus)
+
+	fullStatusMsg := func(seqNum uint64) *protobufs.AgentToServer {
+		return &protobufs.AgentToServer{
+			SequenceNum:      seqNum,
+			Capabilities:     baseCaps,
+			AgentDescription: &protobufs.AgentDescription{},
+			Health:           &protobufs.ComponentHealth{},
+		}
+	}
+
+	cases := []struct {
+		name          string
+		agent         *model.Agent
+		msg           *protobufs.AgentToServer
+		newlyEnrolled bool
+		want          bool
+	}{
+		{
+			name:          "sequence gap - missed message",
+			agent:         &model.Agent{SequenceNum: 5, LastCheckinStatus: "online"},
+			msg:           &protobufs.AgentToServer{SequenceNum: 7, Capabilities: baseCaps},
+			newlyEnrolled: false,
+			want:          true,
+		},
+		{
+			name:          "sequence gap - out of order",
+			agent:         &model.Agent{SequenceNum: 5, LastCheckinStatus: "online"},
+			msg:           &protobufs.AgentToServer{SequenceNum: 3, Capabilities: baseCaps},
+			newlyEnrolled: false,
+			want:          true,
+		},
+		{
+			name:          "no sequence gap - sequential",
+			agent:         &model.Agent{SequenceNum: 5, LastCheckinStatus: "online"},
+			msg:           fullStatusMsg(6),
+			newlyEnrolled: false,
+			want:          false,
+		},
+		{
+			name:          "new enrollment without full status",
+			agent:         &model.Agent{},
+			msg:           &protobufs.AgentToServer{SequenceNum: 1, Capabilities: baseCaps},
+			newlyEnrolled: true,
+			want:          true,
+		},
+		{
+			name:          "new enrollment with full status",
+			agent:         &model.Agent{},
+			msg:           fullStatusMsg(1),
+			newlyEnrolled: true,
+			want:          false,
+		},
+		{
+			name:          "reconnect from disconnect seq 0",
+			agent:         &model.Agent{LastCheckinStatus: "disconnected", SequenceNum: 10},
+			msg:           &protobufs.AgentToServer{SequenceNum: 0, Capabilities: baseCaps},
+			newlyEnrolled: false,
+			want:          false,
+		},
+		{
+			name:          "reconnect from disconnect seq continues",
+			agent:         &model.Agent{LastCheckinStatus: "disconnected", SequenceNum: 10},
+			msg:           &protobufs.AgentToServer{SequenceNum: 11, Capabilities: baseCaps},
+			newlyEnrolled: false,
+			want:          false,
+		},
+		{
+			name:          "reconnect from disconnect unexpected seq",
+			agent:         &model.Agent{LastCheckinStatus: "disconnected", SequenceNum: 10},
+			msg:           &protobufs.AgentToServer{SequenceNum: 5, Capabilities: baseCaps},
+			newlyEnrolled: false,
+			want:          true,
+		},
+		{
+			name:          "stored seq 0 incoming seq 0",
+			agent:         &model.Agent{SequenceNum: 0, LastCheckinStatus: "online"},
+			msg:           &protobufs.AgentToServer{SequenceNum: 0, Capabilities: baseCaps},
+			newlyEnrolled: false,
+			want:          true,
+		},
+		{
+			name:          "stored seq 0 incoming seq 1 - happy path",
+			agent:         &model.Agent{SequenceNum: 0, LastCheckinStatus: "online"},
+			msg:           fullStatusMsg(1),
+			newlyEnrolled: false,
+			want:          false,
+		},
+		{
+			name:          "online agent with gap",
+			agent:         &model.Agent{SequenceNum: 5, LastCheckinStatus: "online"},
+			msg:           &protobufs.AgentToServer{SequenceNum: 7, Capabilities: baseCaps},
+			newlyEnrolled: false,
+			want:          true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, shouldRequestFullState(tc.agent, tc.msg, tc.newlyEnrolled))
+		})
+	}
+}
+
+func TestHandleMessageReportFullState(t *testing.T) {
+	baseCaps := uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsStatus)
+
+	//nolint:dupl // test cases
+	cases := []struct {
+		name      string
+		getBulker func(t *testing.T) *ftesting.MockBulk
+		msg       *protobufs.AgentToServer
+		wantFlags uint64
+	}{
+		{
+			name: "sequence gap sets ReportFullState flag",
+			getBulker: func(t *testing.T) *ftesting.MockBulk {
+				t.Helper()
+				bulker := ftesting.NewMockBulk()
+				agent := model.Agent{
+					LastCheckinStatus: "online",
+					SequenceNum:       5,
+				}
+				agentBytes, err := json.Marshal(agent)
+				require.NoError(t, err)
+				bulker.On("Search", mock.Anything, dl.FleetAgents, mock.Anything, mock.Anything).
+					Return(&es.ResultT{HitsT: es.HitsT{Hits: []es.HitT{{ID: "agent-123", Source: agentBytes}}}}, nil)
+				return bulker
+			},
+			msg: &protobufs.AgentToServer{
+				SequenceNum:  7, // gap: expected 6
+				Capabilities: baseCaps,
+			},
+			wantFlags: uint64(protobufs.ServerToAgentFlags_ServerToAgentFlags_ReportFullState),
+		},
+		{
+			name: "sequential sequence number does not set flag",
+			getBulker: func(t *testing.T) *ftesting.MockBulk {
+				t.Helper()
+				bulker := ftesting.NewMockBulk()
+				agent := model.Agent{
+					LastCheckinStatus: "online",
+					SequenceNum:       5,
+				}
+				agentBytes, err := json.Marshal(agent)
+				require.NoError(t, err)
+				bulker.On("Search", mock.Anything, dl.FleetAgents, mock.Anything, mock.Anything).
+					Return(&es.ResultT{HitsT: es.HitsT{Hits: []es.HitT{{ID: "agent-123", Source: agentBytes}}}}, nil)
+				return bulker
+			},
+			msg: &protobufs.AgentToServer{
+				SequenceNum:      6, // expected: 5 + 1
+				Capabilities:     baseCaps,
+				AgentDescription: &protobufs.AgentDescription{},
+				Health:           &protobufs.ComponentHealth{Healthy: true},
+			},
+			wantFlags: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bulker := tc.getBulker(t)
+			checker := &mockCheckin{}
+			oa := &OpAMPT{bulk: bulker, bc: checker}
+
+			agentUID := uuid.Must(uuid.NewV7())
+			tc.msg.InstanceUid = agentUID.Bytes()
+			zlog := zerolog.New(io.Discard)
+			apiKey := &apikey.APIKey{ID: "test-key"}
+
+			handler := oa.handleMessage(zlog, apiKey)
+			resp := handler(t.Context(), nil, tc.msg)
+
+			require.Nil(t, resp.ErrorResponse)
+			require.Equal(t, tc.wantFlags, resp.Flags)
+		})
+	}
+}

--- a/internal/pkg/api/handleOpAMP_test.go
+++ b/internal/pkg/api/handleOpAMP_test.go
@@ -550,25 +550,11 @@ func TestHandleMessageReportFullState(t *testing.T) {
 	wantFlags := uint64(protobufs.ServerToAgentFlags_ServerToAgentFlags_ReportFullState)
 
 	cases := []struct {
-		name      string
-		getBulker func(t *testing.T) *ftesting.MockBulk
-		msg       *protobufs.AgentToServer
+		name string
+		msg  *protobufs.AgentToServer
 	}{
 		{
 			name: "flag is set on sequence gap",
-			getBulker: func(t *testing.T) *ftesting.MockBulk {
-				t.Helper()
-				bulker := ftesting.NewMockBulk()
-				agent := model.Agent{
-					LastCheckinStatus: "online",
-					SequenceNum:       5,
-				}
-				agentBytes, err := json.Marshal(agent)
-				require.NoError(t, err)
-				bulker.On("Search", mock.Anything, dl.FleetAgents, mock.Anything, mock.Anything).
-					Return(&es.ResultT{HitsT: es.HitsT{Hits: []es.HitT{{ID: "agent-123", Source: agentBytes}}}}, nil)
-				return bulker
-			},
 			msg: &protobufs.AgentToServer{
 				SequenceNum:  7, // gap: expected 6
 				Capabilities: baseCaps,
@@ -576,19 +562,6 @@ func TestHandleMessageReportFullState(t *testing.T) {
 		},
 		{
 			name: "flag is set on sequential message",
-			getBulker: func(t *testing.T) *ftesting.MockBulk {
-				t.Helper()
-				bulker := ftesting.NewMockBulk()
-				agent := model.Agent{
-					LastCheckinStatus: "online",
-					SequenceNum:       5,
-				}
-				agentBytes, err := json.Marshal(agent)
-				require.NoError(t, err)
-				bulker.On("Search", mock.Anything, dl.FleetAgents, mock.Anything, mock.Anything).
-					Return(&es.ResultT{HitsT: es.HitsT{Hits: []es.HitT{{ID: "agent-123", Source: agentBytes}}}}, nil)
-				return bulker
-			},
 			msg: &protobufs.AgentToServer{
 				SequenceNum:  6, // sequential
 				Capabilities: baseCaps,
@@ -597,7 +570,15 @@ func TestHandleMessageReportFullState(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			bulker := tc.getBulker(t)
+			bulker := ftesting.NewMockBulk()
+			agent := model.Agent{
+				LastCheckinStatus: "online",
+				SequenceNum:       5,
+			}
+			agentBytes, err := json.Marshal(agent)
+			require.NoError(t, err)
+			bulker.On("Search", mock.Anything, dl.FleetAgents, mock.Anything, mock.Anything).
+				Return(&es.ResultT{HitsT: es.HitsT{Hits: []es.HitT{{ID: "agent-123", Source: agentBytes}}}}, nil)
 			checker := &mockCheckin{}
 			oa := &OpAMPT{bulk: bulker, bc: checker}
 

--- a/internal/pkg/api/handleOpAMP_test.go
+++ b/internal/pkg/api/handleOpAMP_test.go
@@ -545,245 +545,17 @@ func getUnexportedField(v reflect.Value, name string) reflect.Value {
 	return reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem()
 }
 
-func TestHasFullStatus(t *testing.T) {
-	baseCaps := uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsStatus)
-
-	cases := []struct {
-		name string
-		msg  *protobufs.AgentToServer
-		want bool
-	}{
-		{
-			name: "capabilities unset",
-			msg: &protobufs.AgentToServer{
-				Capabilities:     0,
-				AgentDescription: &protobufs.AgentDescription{},
-				Health:           &protobufs.ComponentHealth{},
-			},
-			want: false,
-		},
-		{
-			name: "base fields only, no conditional capabilities",
-			msg: &protobufs.AgentToServer{
-				Capabilities:     baseCaps,
-				AgentDescription: &protobufs.AgentDescription{},
-				Health:           &protobufs.ComponentHealth{},
-			},
-			want: true,
-		},
-		{
-			name: "missing AgentDescription",
-			msg: &protobufs.AgentToServer{
-				Capabilities: baseCaps,
-				Health:       &protobufs.ComponentHealth{},
-			},
-			want: false,
-		},
-		{
-			name: "missing Health",
-			msg: &protobufs.AgentToServer{
-				Capabilities:     baseCaps,
-				AgentDescription: &protobufs.AgentDescription{},
-			},
-			want: false,
-		},
-		{
-			name: "ReportsEffectiveConfig capability without EffectiveConfig",
-			msg: &protobufs.AgentToServer{
-				Capabilities:     baseCaps | uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsEffectiveConfig),
-				AgentDescription: &protobufs.AgentDescription{},
-				Health:           &protobufs.ComponentHealth{},
-			},
-			want: false,
-		},
-		{
-			name: "ReportsEffectiveConfig capability with EffectiveConfig",
-			msg: &protobufs.AgentToServer{
-				Capabilities:     baseCaps | uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsEffectiveConfig),
-				AgentDescription: &protobufs.AgentDescription{},
-				Health:           &protobufs.ComponentHealth{},
-				EffectiveConfig:  &protobufs.EffectiveConfig{},
-			},
-			want: true,
-		},
-		{
-			name: "ReportsRemoteConfig capability without RemoteConfigStatus",
-			msg: &protobufs.AgentToServer{
-				Capabilities:     baseCaps | uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsRemoteConfig),
-				AgentDescription: &protobufs.AgentDescription{},
-				Health:           &protobufs.ComponentHealth{},
-			},
-			want: false,
-		},
-		{
-			name: "ReportsPackageStatuses capability without PackageStatuses",
-			msg: &protobufs.AgentToServer{
-				Capabilities:     baseCaps | uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsPackageStatuses),
-				AgentDescription: &protobufs.AgentDescription{},
-				Health:           &protobufs.ComponentHealth{},
-			},
-			want: false,
-		},
-		{
-			name: "ReportsAvailableComponents capability without AvailableComponents",
-			msg: &protobufs.AgentToServer{
-				Capabilities:     baseCaps | uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsAvailableComponents),
-				AgentDescription: &protobufs.AgentDescription{},
-				Health:           &protobufs.ComponentHealth{},
-			},
-			want: false,
-		},
-		{
-			name: "ReportsConnectionSettingsStatus capability without ConnectionSettingsStatus",
-			msg: &protobufs.AgentToServer{
-				Capabilities:     baseCaps | uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsConnectionSettingsStatus),
-				AgentDescription: &protobufs.AgentDescription{},
-				Health:           &protobufs.ComponentHealth{},
-			},
-			want: false,
-		},
-		{
-			name: "multiple capabilities all fields present",
-			msg: &protobufs.AgentToServer{
-				Capabilities: baseCaps |
-					uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsEffectiveConfig) |
-					uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsRemoteConfig),
-				AgentDescription:   &protobufs.AgentDescription{},
-				Health:             &protobufs.ComponentHealth{},
-				EffectiveConfig:    &protobufs.EffectiveConfig{},
-				RemoteConfigStatus: &protobufs.RemoteConfigStatus{},
-			},
-			want: true,
-		},
-		{
-			name: "all fields missing",
-			msg:  &protobufs.AgentToServer{},
-			want: false,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, hasFullStatus(tc.msg))
-		})
-	}
-}
-
-func TestShouldRequestFullState(t *testing.T) {
-	baseCaps := uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsStatus)
-
-	fullStatusMsg := func(seqNum uint64) *protobufs.AgentToServer {
-		return &protobufs.AgentToServer{
-			SequenceNum:      seqNum,
-			Capabilities:     baseCaps,
-			AgentDescription: &protobufs.AgentDescription{},
-			Health:           &protobufs.ComponentHealth{},
-		}
-	}
-
-	cases := []struct {
-		name          string
-		agent         *model.Agent
-		msg           *protobufs.AgentToServer
-		newlyEnrolled bool
-		want          bool
-	}{
-		{
-			name:          "sequence gap - missed message",
-			agent:         &model.Agent{SequenceNum: 5, LastCheckinStatus: "online"},
-			msg:           &protobufs.AgentToServer{SequenceNum: 7, Capabilities: baseCaps},
-			newlyEnrolled: false,
-			want:          true,
-		},
-		{
-			name:          "sequence gap - out of order",
-			agent:         &model.Agent{SequenceNum: 5, LastCheckinStatus: "online"},
-			msg:           &protobufs.AgentToServer{SequenceNum: 3, Capabilities: baseCaps},
-			newlyEnrolled: false,
-			want:          true,
-		},
-		{
-			name:          "no sequence gap - sequential",
-			agent:         &model.Agent{SequenceNum: 5, LastCheckinStatus: "online"},
-			msg:           fullStatusMsg(6),
-			newlyEnrolled: false,
-			want:          false,
-		},
-		{
-			name:          "new enrollment without full status",
-			agent:         &model.Agent{},
-			msg:           &protobufs.AgentToServer{SequenceNum: 1, Capabilities: baseCaps},
-			newlyEnrolled: true,
-			want:          true,
-		},
-		{
-			name:          "new enrollment with full status",
-			agent:         &model.Agent{},
-			msg:           fullStatusMsg(1),
-			newlyEnrolled: true,
-			want:          false,
-		},
-		{
-			name:          "reconnect from disconnect seq 0",
-			agent:         &model.Agent{LastCheckinStatus: "disconnected", SequenceNum: 10},
-			msg:           &protobufs.AgentToServer{SequenceNum: 0, Capabilities: baseCaps},
-			newlyEnrolled: false,
-			want:          false,
-		},
-		{
-			name:          "reconnect from disconnect seq continues",
-			agent:         &model.Agent{LastCheckinStatus: "disconnected", SequenceNum: 10},
-			msg:           &protobufs.AgentToServer{SequenceNum: 11, Capabilities: baseCaps},
-			newlyEnrolled: false,
-			want:          false,
-		},
-		{
-			name:          "reconnect from disconnect unexpected seq",
-			agent:         &model.Agent{LastCheckinStatus: "disconnected", SequenceNum: 10},
-			msg:           &protobufs.AgentToServer{SequenceNum: 5, Capabilities: baseCaps},
-			newlyEnrolled: false,
-			want:          true,
-		},
-		{
-			name:          "stored seq 0 incoming seq 0",
-			agent:         &model.Agent{SequenceNum: 0, LastCheckinStatus: "online"},
-			msg:           &protobufs.AgentToServer{SequenceNum: 0, Capabilities: baseCaps},
-			newlyEnrolled: false,
-			want:          true,
-		},
-		{
-			name:          "stored seq 0 incoming seq 1 - happy path",
-			agent:         &model.Agent{SequenceNum: 0, LastCheckinStatus: "online"},
-			msg:           fullStatusMsg(1),
-			newlyEnrolled: false,
-			want:          false,
-		},
-		{
-			name:          "online agent with gap",
-			agent:         &model.Agent{SequenceNum: 5, LastCheckinStatus: "online"},
-			msg:           &protobufs.AgentToServer{SequenceNum: 7, Capabilities: baseCaps},
-			newlyEnrolled: false,
-			want:          true,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, shouldRequestFullState(tc.agent, tc.msg, tc.newlyEnrolled))
-		})
-	}
-}
-
 func TestHandleMessageReportFullState(t *testing.T) {
 	baseCaps := uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsStatus)
+	wantFlags := uint64(protobufs.ServerToAgentFlags_ServerToAgentFlags_ReportFullState)
 
-	//nolint:dupl // test cases
 	cases := []struct {
 		name      string
 		getBulker func(t *testing.T) *ftesting.MockBulk
 		msg       *protobufs.AgentToServer
-		wantFlags uint64
 	}{
 		{
-			name: "sequence gap sets ReportFullState flag",
+			name: "flag is set on sequence gap",
 			getBulker: func(t *testing.T) *ftesting.MockBulk {
 				t.Helper()
 				bulker := ftesting.NewMockBulk()
@@ -801,10 +573,9 @@ func TestHandleMessageReportFullState(t *testing.T) {
 				SequenceNum:  7, // gap: expected 6
 				Capabilities: baseCaps,
 			},
-			wantFlags: uint64(protobufs.ServerToAgentFlags_ServerToAgentFlags_ReportFullState),
 		},
 		{
-			name: "sequential sequence number does not set flag",
+			name: "flag is set on sequential message",
 			getBulker: func(t *testing.T) *ftesting.MockBulk {
 				t.Helper()
 				bulker := ftesting.NewMockBulk()
@@ -819,12 +590,9 @@ func TestHandleMessageReportFullState(t *testing.T) {
 				return bulker
 			},
 			msg: &protobufs.AgentToServer{
-				SequenceNum:      6, // expected: 5 + 1
-				Capabilities:     baseCaps,
-				AgentDescription: &protobufs.AgentDescription{},
-				Health:           &protobufs.ComponentHealth{Healthy: true},
+				SequenceNum:  6, // sequential
+				Capabilities: baseCaps,
 			},
-			wantFlags: 0,
 		},
 	}
 	for _, tc := range cases {
@@ -842,7 +610,7 @@ func TestHandleMessageReportFullState(t *testing.T) {
 			resp := handler(t.Context(), nil, tc.msg)
 
 			require.Nil(t, resp.ErrorResponse)
-			require.Equal(t, tc.wantFlags, resp.Flags)
+			require.Equal(t, wantFlags, resp.Flags)
 		})
 	}
 }


### PR DESCRIPTION
## What is the problem this PR solves?

Fleet-server does not use the OpAMP spec's `ServerToAgent.flags.ReportFullState` flag. Fleet-server will now always set the flag.

## How does this PR solve the problem?

Flag is set for every response, seq no drift is detected and logged as a warning.

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [x] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Closes #6783