### PR TITLE
Skip ES compatibility checks for SNAPSHOT builds

### DIFF
--- a/internal/pkg/ver/check.go
+++ b/internal/pkg/ver/check.go
@@ -53,30 +53,6 @@ func CheckCompatibility(ctx context.Context, esCli *elasticsearch.Client, fleetV
 	return esVersion, checkCompatibility(ctx, fleetVersion, esVersion)
 }
 
-func checkCompatibility(ctx context.Context, fleetVersion, esVersion string) error {
-	verConst, err := buildVersionConstraint(fleetVersion)
-	if err != nil {
-		zerolog.Ctx(ctx).Error().Err(err).Str("fleet_version", fleetVersion).Msg("failed to build constraint")
-		return err
-	}
-
-	ver, err := parseVersion(esVersion)
-	if err != nil {
-		return err
-	}
-
-	if !verConst.Check(ver) {
-		zerolog.Ctx(ctx).Error().
-			Err(ErrUnsupportedVersion).
-			Str("constraint", verConst.String()).
-			Str("reported", ver.String()).
-			Msg("failed elasticsearch version check")
-		return ErrUnsupportedVersion
-	}
-	zerolog.Ctx(ctx).Info().Str("fleet_version", fleetVersion).Str("elasticsearch_version", esVersion).Msg("Elasticsearch compatibility check successful")
-	return nil
-}
-
 func buildVersionConstraint(fleetVersion string) (version.Constraints, error) {
 	ver, err := parseVersion(fleetVersion)
 	if err != nil {

--- a/internal/pkg/ver/es_check.go
+++ b/internal/pkg/ver/es_check.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 //go:build !snapshot
 
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one

--- a/internal/pkg/ver/es_check.go
+++ b/internal/pkg/ver/es_check.go
@@ -1,0 +1,39 @@
+//go:build !snapshot
+
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// Package ver will ensure fleet-server and Elasticsearch are running compatible versions.
+// Versions are compatible when Elasticsearch's version is greater then or equal to fleet-server's version
+package ver
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+)
+
+func checkCompatibility(ctx context.Context, fleetVersion, esVersion string) error {
+	verConst, err := buildVersionConstraint(fleetVersion)
+	if err != nil {
+		zerolog.Ctx(ctx).Error().Err(err).Str("fleet_version", fleetVersion).Msg("failed to build constraint")
+		return err
+	}
+
+	ver, err := parseVersion(esVersion)
+	if err != nil {
+		return err
+	}
+
+	if !verConst.Check(ver) {
+		zerolog.Ctx(ctx).Error().
+			Err(ErrUnsupportedVersion).
+			Str("constraint", verConst.String()).
+			Str("reported", ver.String()).
+			Msg("failed elasticsearch version check")
+		return ErrUnsupportedVersion
+	}
+	zerolog.Ctx(ctx).Info().Str("fleet_version", fleetVersion).Str("elasticsearch_version", esVersion).Msg("Elasticsearch compatibility check successful")
+	return nil
+}

--- a/internal/pkg/ver/es_check.go
+++ b/internal/pkg/ver/es_check.go
@@ -4,12 +4,6 @@
 
 //go:build !snapshot
 
-// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
-
-// Package ver will ensure fleet-server and Elasticsearch are running compatible versions.
-// Versions are compatible when Elasticsearch's version is greater then or equal to fleet-server's version
 package ver
 
 import (

--- a/internal/pkg/ver/es_check_snapshot.go
+++ b/internal/pkg/ver/es_check_snapshot.go
@@ -4,12 +4,6 @@
 
 //go:build snapshot
 
-// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
-
-// Package ver will ensure fleet-server and Elasticsearch are running compatible versions.
-// Versions are compatible when Elasticsearch's version is greater then or equal to fleet-server's version
 package ver
 
 import (

--- a/internal/pkg/ver/es_check_snapshot.go
+++ b/internal/pkg/ver/es_check_snapshot.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 //go:build snapshot
 
 // Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one

--- a/internal/pkg/ver/es_check_snapshot.go
+++ b/internal/pkg/ver/es_check_snapshot.go
@@ -1,0 +1,20 @@
+//go:build snapshot
+
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// Package ver will ensure fleet-server and Elasticsearch are running compatible versions.
+// Versions are compatible when Elasticsearch's version is greater then or equal to fleet-server's version
+package ver
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+)
+
+func checkCompatibility(ctx context.Context, fleetVersion, esVersion string) error {
+	zerolog.Ctx(ctx).Info().Str("fleet_version", fleetVersion).Str("elasticsearch_version", esVersion).Msg("SNAPSHOT build skipping Elasticsearch compatibility check")
+	return nil
+}

--- a/internal/pkg/ver/es_check_snapshot_test.go
+++ b/internal/pkg/ver/es_check_snapshot_test.go
@@ -1,0 +1,66 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build snapshot
+
+package ver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	testlog "github.com/elastic/fleet-server/v7/internal/pkg/testing/log"
+)
+
+func TestCheckCompatibilityInternal(t *testing.T) {
+	tests := []struct {
+		name         string
+		fleetVersion string
+		esVersion    string
+	}{
+		{
+			name:         "empty fleet and elasticsearch version",
+			fleetVersion: "",
+			esVersion:    "",
+		},
+		{
+			name:         "same version",
+			fleetVersion: "7.13.0",
+			esVersion:    "7.13.0",
+		},
+		{
+			name:         "new fleet-server patch",
+			fleetVersion: "7.13.2",
+			esVersion:    "7.13.1",
+		},
+		{
+			name:         "new es minor",
+			fleetVersion: "7.13.2",
+			esVersion:    "7.14.2",
+		},
+		{
+			name:         "new es major",
+			fleetVersion: "7.15.2",
+			esVersion:    "8.0.0",
+		},
+		{
+			name:         "new fleet-server minor",
+			fleetVersion: "7.14.0",
+			esVersion:    "7.13.1",
+		},
+		{
+			name:         "new fleet-server major",
+			fleetVersion: "8.0.0",
+			esVersion:    "7.18.0",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testlog.SetLogger(t).WithContext(t.Context())
+			err := checkCompatibility(ctx, tc.fleetVersion, tc.esVersion)
+			require.NoError(t, err, "expected snapshot version check should always succeed")
+		})
+	}
+}

--- a/internal/pkg/ver/es_check_test.go
+++ b/internal/pkg/ver/es_check_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !snapshot
+
 package ver
 
 import (


### PR DESCRIPTION
## What is the problem this PR solves?

Builds can fail on version updates (i.e., we bump main from 9.4.0 -> 9.5.0) because the version of fleet-server will be greater than the version of elasticsearch.

## How does this PR solve the problem?

Skip ES compatibility checks for SNAPSHOT builds.
This allows a 9.5.0-SNAPSHOT build to connect to a previous ES version