### PR TITLE
[ci] Bump VM Image version to 1776780011

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,8 +3,8 @@
 env:
   DOCKER_COMPOSE_VERSION: "1.25.5"
   TERRAFORM_VERSION: "1.6.4"
-  IMAGE_UBUNTU_X86_64: "platform-ingest-elastic-agent-ubuntu-2204-1772525581"
-  IMAGE_UBUNTU_ARM_64: "platform-ingest-elastic-agent-ubuntu-2204-aarch64-1772525581"
+  IMAGE_UBUNTU_X86_64: "platform-ingest-elastic-agent-ubuntu-2204-1776780011"
+  IMAGE_UBUNTU_ARM_64: "platform-ingest-elastic-agent-ubuntu-2204-aarch64-1776780011"
   IMAGE_UBUNTU_X86_64_FIPS: "platform-ingest-fleet-server-ubuntu-2204-fips"
 
 # This section is used to define the plugins that will be used in the pipeline.


### PR DESCRIPTION
Applying same changes as https://github.com/elastic/elastic-agent/pull/13745 for fleet-server.