### PR TITLE
Add support for windows/arm64 builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -82,7 +82,7 @@ steps:
       - label: "Package aarch64"
         key: "package-arm64-pr"
         env:
-          PLATFORMS: "linux/arm64,darwin/arm64"
+          PLATFORMS: "linux/arm64,darwin/arm64,windows/arm64"
         command: ".buildkite/scripts/release_test.sh"
         artifact_paths:
           - build/distributions/**

--- a/magefile.go
+++ b/magefile.go
@@ -124,6 +124,7 @@ var (
 		"linux/amd64",
 		"linux/arm64",
 		"windows/amd64",
+		"windows/arm64",
 	}
 	// plaformsFIPS is the list of all FIPS-capable platforms.
 	platformsFIPS = []string{


### PR DESCRIPTION
## What is the problem this PR solves?

Release windows/arm64 artifacts.

## How to test this PR locally

`PLATFORMS=windows/arm64 mage docker:release`