### PR TITLE
Symlink LICENSE.txt into pkg/api sub-module

### DIFF
--- a/pkg/api/LICENSE.txt
+++ b/pkg/api/LICENSE.txt
@@ -1,0 +1,1 @@
+../../LICENSE.txt


### PR DESCRIPTION
## Summary

- Adds a symlink from `pkg/api/LICENSE.txt` to the root `LICENSE.txt`
- The `pkg/api` sub-module is imported by consumers (elastic-agent, horde) as a Go module. Go license detection tools require a license file within the module directory — without it, NOTICE generation fails with `no licence file found for github.com/elastic/fleet-server/pkg/api`
- Unblocks https://github.com/elastic/elastic-agent/pull/14012

🤖 Generated with [Claude Code](https://claude.com/claude-code)