### PR TITLE
Fix missing `authAgent` in `UploadChunk`

### DIFF
--- a/changelog/fragments/1778534244-fix-missing-authagent-in-uploadchunk.yaml
+++ b/changelog/fragments/1778534244-fix-missing-authagent-in-uploadchunk.yaml
@@ -1,0 +1,46 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: security
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: fix missing authagent in uploadchunk
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: |
+  Validate that the uploading agent of the chunk has the permissions to write that chunk.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: fleet-server
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/api/api.go
+++ b/internal/pkg/api/api.go
@@ -188,11 +188,6 @@ func (a *apiServer) UploadChunk(w http.ResponseWriter, r *http.Request, id strin
 	zlog := hlog.FromRequest(r).With().Str(LogAgentID, id).Logger()
 	w.Header().Set("Content-Type", "application/json")
 
-	if _, err := a.ut.authAPIKey(r, a.ut.bulker, a.ut.cache); err != nil {
-		cntUploadChunk.IncError(err)
-		ErrorResp(w, r, err)
-		return
-	}
 	if err := a.ut.handleUploadChunk(zlog, w, r, id, chunkNum, params.XChunkSHA2); err != nil {
 		cntUploadChunk.IncError(err)
 		ErrorResp(w, r, err)

--- a/internal/pkg/api/handleUpload.go
+++ b/internal/pkg/api/handleUpload.go
@@ -139,6 +139,11 @@ func (ut *UploadT) handleUploadChunk(zlog zerolog.Logger, w http.ResponseWriter,
 		return err
 	}
 
+	// Validate that the requesting agent owns this upload session
+	if _, err := ut.authAgent(r, &upinfo.AgentID, ut.bulker, ut.cache); err != nil {
+		return fmt.Errorf("error authenticating for chunk upload: %w", err)
+	}
+
 	// prevent over-sized chunks
 	data := http.MaxBytesReader(w, r.Body, file.MaxChunkSize)
 

--- a/internal/pkg/api/handleUpload_test.go
+++ b/internal/pkg/api/handleUpload_test.go
@@ -388,6 +388,75 @@ func TestUploadBeginFileSize(t *testing.T) {
   Chunk data upload route
 */
 
+func TestChunkUploadRequiresMatchingAuth(t *testing.T) {
+	data := []byte("filedata")
+	hasher := sha256.New()
+	_, err := hasher.Write(data)
+	require.NoError(t, err)
+	hash := hex.EncodeToString(hasher.Sum(nil))
+	mockUploadID := "abc123"
+
+	tests := []struct {
+		Name              string
+		AuthSuccess       bool
+		AgentFromAPIKey   string
+		AgentInFileRecord string
+		ExpectStatus      int
+	}{
+		{"Agent ID matching API Key succeeds", true, "foo", "foo", http.StatusOK},
+		{"Agent ID in upload not matching API Key should reject", true, "oneID", "differentID", http.StatusForbidden},
+		{"Bad auth should reject request", false, "", "foo", http.StatusUnauthorized},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			hr, rt, fakebulk, _ := prepareUploaderMock(t)
+			mockUploadInfoResult(fakebulk, file.Info{
+				DocID:     "bar." + tc.AgentInFileRecord,
+				ID:        mockUploadID,
+				ChunkSize: file.MaxChunkSize,
+				Total:     10,
+				Count:     1,
+				Start:     time.Now(),
+				Status:    file.StatusProgress,
+				Source:    "agent",
+				AgentID:   tc.AgentInFileRecord,
+				ActionID:  "bar",
+			})
+
+			if !tc.AuthSuccess {
+				rt.ut.authAPIKey = func(r *http.Request, b bulk.Bulk, c cache.Cache) (*apikey.APIKey, error) {
+					return nil, apikey.ErrInvalidToken
+				}
+				rt.ut.authAgent = func(r *http.Request, s *string, b bulk.Bulk, c cache.Cache) (*model.Agent, error) {
+					return nil, apikey.ErrInvalidToken
+				}
+			} else {
+				rt.ut.authAgent = func(r *http.Request, s *string, b bulk.Bulk, c cache.Cache) (*model.Agent, error) {
+					if *s != tc.AgentFromAPIKey {
+						return nil, ErrAgentIdentity
+					}
+					return &model.Agent{
+						ESDocument: model.ESDocument{
+							Id: tc.AgentFromAPIKey,
+						},
+						Agent: &model.AgentMetadata{
+							ID: tc.AgentFromAPIKey,
+						},
+					}, nil
+				}
+			}
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPut, "/api/fleet/uploads/"+mockUploadID+"/0", bytes.NewReader(data))
+			req.Header.Set("X-Chunk-SHA2", hash)
+			hr.ServeHTTP(rec, req)
+
+			assert.Equal(t, tc.ExpectStatus, rec.Code)
+		})
+	}
+}
+
 func TestChunkUploadRouteParams(t *testing.T) {
 	data := []byte("filedata")
 	hasher := sha256.New()

--- a/internal/pkg/cache/cache.go
+++ b/internal/pkg/cache/cache.go
@@ -202,6 +202,7 @@ func (c *CacheT) ValidAPIKey(key APIKey) bool {
 		switch v {
 		case "":
 			c.log.Trace().Str("id", key.ID).Msg("ApiKey cache HIT on disabled KEY")
+			ok = false
 		case key.Key:
 			c.log.Trace().Str("id", key.ID).Msg("ApiKey cache HIT")
 		default:

--- a/internal/pkg/cache/cache_test.go
+++ b/internal/pkg/cache/cache_test.go
@@ -8,6 +8,7 @@ package cache
 
 import (
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
@@ -17,46 +18,46 @@ import (
 )
 
 func TestValidAPIKeyDisabledKey(t *testing.T) {
-	cfg := config.Cache{
-		NumCounters: 100,
-		MaxCost:     100000,
-		APIKeyTTL:   5 * time.Minute,
-	}
-	c, err := New(cfg)
-	require.NoError(t, err)
+	synctest.Test(t, func(t *testing.T) {
+		cfg := config.Cache{
+			NumCounters: 100,
+			MaxCost:     100000,
+			APIKeyTTL:   5 * time.Minute,
+		}
+		c, err := New(cfg)
+		require.NoError(t, err)
+		defer c.cache.Close() // stop ristretto background goroutines before bubble exits
 
-	key := APIKey{ID: "test-id", Key: "test-key"}
+		key := APIKey{ID: "test-id", Key: "test-key"}
 
-	// Cache the key as disabled
-	c.SetAPIKey(key, false)
-	// ristretto is async; wait for value to be available
-	time.Sleep(10 * time.Millisecond)
+		c.SetAPIKey(key, false)
+		synctest.Wait()
 
-	// A disabled key must not be considered valid
-	assert.False(t, c.ValidAPIKey(key), "disabled API key should not be valid")
+		assert.False(t, c.ValidAPIKey(key), "disabled API key should not be valid")
+	})
 }
 
 func TestValidAPIKeyEnabledKey(t *testing.T) {
-	cfg := config.Cache{
-		NumCounters: 100,
-		MaxCost:     100000,
-		APIKeyTTL:   5 * time.Minute,
-	}
-	c, err := New(cfg)
-	require.NoError(t, err)
+	synctest.Test(t, func(t *testing.T) {
+		cfg := config.Cache{
+			NumCounters: 100,
+			MaxCost:     100000,
+			APIKeyTTL:   5 * time.Minute,
+		}
+		c, err := New(cfg)
+		require.NoError(t, err)
+		defer c.cache.Close()
 
-	key := APIKey{ID: "test-id", Key: "test-key"}
+		key := APIKey{ID: "test-id", Key: "test-key"}
 
-	// Cache the key as enabled
-	c.SetAPIKey(key, true)
-	time.Sleep(10 * time.Millisecond)
+		c.SetAPIKey(key, true)
+		synctest.Wait()
 
-	// Matching key should be valid
-	assert.True(t, c.ValidAPIKey(key), "enabled API key with matching key should be valid")
+		assert.True(t, c.ValidAPIKey(key), "enabled API key with matching key should be valid")
 
-	// Wrong key value should not be valid
-	wrongKey := APIKey{ID: "test-id", Key: "wrong-key"}
-	assert.False(t, c.ValidAPIKey(wrongKey), "API key with mismatched key value should not be valid")
+		wrongKey := APIKey{ID: "test-id", Key: "wrong-key"}
+		assert.False(t, c.ValidAPIKey(wrongKey), "API key with mismatched key value should not be valid")
+	})
 }
 
 func TestValidAPIKeyMiss(t *testing.T) {
@@ -70,6 +71,5 @@ func TestValidAPIKeyMiss(t *testing.T) {
 
 	key := APIKey{ID: "nonexistent", Key: "test-key"}
 
-	// Key not in cache should not be valid
 	assert.False(t, c.ValidAPIKey(key), "API key not in cache should not be valid")
 }

--- a/internal/pkg/cache/cache_test.go
+++ b/internal/pkg/cache/cache_test.go
@@ -1,0 +1,73 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidAPIKeyDisabledKey(t *testing.T) {
+	cfg := config.Cache{
+		NumCounters: 100,
+		MaxCost:     100000,
+		APIKeyTTL:   5 * time.Minute,
+	}
+	c, err := New(cfg)
+	require.NoError(t, err)
+
+	key := APIKey{ID: "test-id", Key: "test-key"}
+
+	// Cache the key as disabled
+	c.SetAPIKey(key, false)
+	// ristretto is async; wait for value to be available
+	time.Sleep(10 * time.Millisecond)
+
+	// A disabled key must not be considered valid
+	assert.False(t, c.ValidAPIKey(key), "disabled API key should not be valid")
+}
+
+func TestValidAPIKeyEnabledKey(t *testing.T) {
+	cfg := config.Cache{
+		NumCounters: 100,
+		MaxCost:     100000,
+		APIKeyTTL:   5 * time.Minute,
+	}
+	c, err := New(cfg)
+	require.NoError(t, err)
+
+	key := APIKey{ID: "test-id", Key: "test-key"}
+
+	// Cache the key as enabled
+	c.SetAPIKey(key, true)
+	time.Sleep(10 * time.Millisecond)
+
+	// Matching key should be valid
+	assert.True(t, c.ValidAPIKey(key), "enabled API key with matching key should be valid")
+
+	// Wrong key value should not be valid
+	wrongKey := APIKey{ID: "test-id", Key: "wrong-key"}
+	assert.False(t, c.ValidAPIKey(wrongKey), "API key with mismatched key value should not be valid")
+}
+
+func TestValidAPIKeyMiss(t *testing.T) {
+	cfg := config.Cache{
+		NumCounters: 100,
+		MaxCost:     100000,
+		APIKeyTTL:   5 * time.Minute,
+	}
+	c, err := New(cfg)
+	require.NoError(t, err)
+
+	key := APIKey{ID: "nonexistent", Key: "test-key"}
+
+	// Key not in cache should not be valid
+	assert.False(t, c.ValidAPIKey(key), "API key not in cache should not be valid")
+}

--- a/internal/pkg/cache/cache_test.go
+++ b/internal/pkg/cache/cache_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !integration
+
 package cache
 
 import (


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

In the `UploadChunk` the `authAgent` was not being called to validate that the uploading agent of the chunk has the permissions to write that chunk. It validated that there was a valid API key, it just didn't validate that the agent with the valid API key is the agent that should be uploading the chunk.

In `ValidAPIKey` a disabled API key was considered valid even once disabled.

## How does this PR solve the problem?

It adds the `authAgent` check to the `UploadChunk`.

It sets `ok = false` when the API key is disabled in `CacheT.ValidAPIKey`.

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [x] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- ~~[ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)
