### PR TITLE
bk: run faster builds

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -44,6 +44,12 @@ spec:
     spec:
       repository: elastic/fleet-server
       pipeline_file: ".buildkite/pipeline.yml"
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite
+              - .go-version
+            cleanup_sparse_state: true
       # patterns for tags are required to trigger the step that publishes the docker.elastic.co/package-registry/distribution images
       # step with key: "release-package-registry"
       branch_configuration: "main 9.* 8.* 7.* v9.* v8.* v7.*"
@@ -96,6 +102,12 @@ spec:
     spec:
       repository: elastic/fleet-server
       pipeline_file: ".buildkite/pipeline.package.mbp.yml"
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite
+              - .go-version
+            cleanup_sparse_state: true
       provider_settings:
         build_pull_request_forks: false
         build_pull_requests: true
@@ -151,6 +163,12 @@ spec:
     spec:
       repository: elastic/fleet-server
       pipeline_file: .buildkite/pipeline.fleet-server-tests.yaml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite
+              - .go-version
+            cleanup_sparse_state: true
       branch_configuration: "main"
       skip_intermediate_builds: false
       provider_settings:
@@ -188,6 +206,12 @@ spec:
     spec:
       repository: elastic/fleet-server
       pipeline_file: .buildkite/pipeline.perf-tests.yaml
+      initial_step_plugins:
+        - sparse-checkout#v1.6.0:
+            paths:
+              - .buildkite
+              - .go-version
+            cleanup_sparse_state: true
       branch_configuration: "main"
       provider_settings:
         build_pull_request_forks: false


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

Checkout faster when running the loading bk pipeline defined in the catalog-info

## How does this PR solve the problem?

Using the spare checkout for the .buildkite folder and the .go-version file

## How to test this PR locally

CI

## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [ ] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

- see https://github.com/elastic/kibana/pull/265568
- https://github.com/elastic/elastic-agent/pull/12082