### PR TITLE
fix(ci): unshallow repo before merge in post-checkout hook

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -24,6 +24,10 @@ checkout_merge() {
     git config user.name "github-merged-pr-post-checkout"
     git config user.email "auto-merge@buildkite"
 
+    # sparse-checkout creates a shallow clone without full commit history;
+    # unshallow so git can find the common ancestor needed for the merge
+    git fetch --unshallow 2>/dev/null || git fetch --depth=2147483647 2>/dev/null || true
+
     git merge --no-edit "${BUILDKITE_COMMIT}" || {
         local merge_result=$?
         echo "Merge failed: ${merge_result}"

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -26,7 +26,7 @@ checkout_merge() {
 
     # sparse-checkout creates a shallow clone without full commit history;
     # unshallow so git can find the common ancestor needed for the merge
-    git fetch --unshallow 2>/dev/null || git fetch --depth=2147483647 2>/dev/null || true
+    git fetch --unshallow 2>/dev/null || true
 
     git merge --no-edit "${BUILDKITE_COMMIT}" || {
         local merge_result=$?


### PR DESCRIPTION
## Problem

Follow-up to #7029, which added the `sparse-checkout#v1.6.0` Buildkite plugin to `catalog-info.yaml`. Once merged, Buildkite updated its pipeline configuration globally, so **all** builds — including PRs targeting non-`main` branches — now use sparse checkout.

The sparse clone fetches only ~180 git objects (the `.buildkite` and `.go-version` file trees), with no commit-ancestry chain. When `.buildkite/hooks/post-checkout` then fetches the target branch fully and calls `git merge "${BUILDKITE_COMMIT}"`, git cannot walk back through the truncated history to find the common ancestor and fails with:

```
fatal: refusing to merge unrelated histories
```

This broke all open PRs targeting non-`main` branches (e.g. backport PRs to `8.19` such as #7036, #7030).

## Fix

Unshallow the repository before attempting the merge, so git can resolve the merge base correctly. If `--unshallow` fails, the clone is not shallow and full history is already present, so we just continue.

## Test plan

- [ ] Verify that PRs targeting `8.19` (e.g. #7036, #7030) pass the Buildkite `post-checkout` step after this is merged and the same fix is backported to `8.19`

🤖 Generated with [Claude Code](https://claude.com/claude-code)