### PR TITLE
fix(ci): remove sparse-checkout from externally-triggered pipelines

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -163,12 +163,6 @@ spec:
     spec:
       repository: elastic/fleet-server
       pipeline_file: .buildkite/pipeline.fleet-server-tests.yaml
-      initial_step_plugins:
-        - sparse-checkout#v1.6.0:
-            paths:
-              - .buildkite
-              - .go-version
-            cleanup_sparse_state: true
       branch_configuration: "main"
       skip_intermediate_builds: false
       provider_settings:
@@ -206,12 +200,6 @@ spec:
     spec:
       repository: elastic/fleet-server
       pipeline_file: .buildkite/pipeline.perf-tests.yaml
-      initial_step_plugins:
-        - sparse-checkout#v1.6.0:
-            paths:
-              - .buildkite
-              - .go-version
-            cleanup_sparse_state: true
       branch_configuration: "main"
       provider_settings:
         build_pull_request_forks: false


### PR DESCRIPTION
<!-- Type of change: Bug -->

## What is the problem this PR solves?

Follow-up to #7029, which added `sparse-checkout#v1.6.0` as an `initial_step_plugins` to all four Buildkite pipelines in `catalog-info.yaml`.

The `fleet-server-tests` and `perf-tests` pipelines are configured with `trigger_mode: none` — they are triggered by external systems (the quality gate system and performance testing infrastructure respectively) rather than GitHub webhook events. Those external systems supply a short commit SHA as `BUILDKITE_COMMIT`. The sparse-checkout plugin tries to resolve that value via `git fetch origin <BUILDKITE_COMMIT>` against `elastic/fleet-server`. Per the git pack protocol spec ([gitprotocol-pack](https://www.kernel.org/pub/software/scm/git/docs/gitprotocol-pack.html)), "Clients MUST NOT mention an obj-id in a want command which did not appear in the response obtained through ref discovery" — a short SHA is never advertised in ref discovery, so the fetch fails (e.g. `fleet-server-tests` build [#4053](https://buildkite.com/elastic/fleet-server-tests/builds/4053)):

```
[INFO]: Fetching 76e500263c36 from origin
fatal: couldn't find remote ref 76e500263c36
[ERROR]: Failed to fetch 76e500263c36 from origin
```

By contrast, GitHub webhook-triggered builds always supply a full 40-character SHA (e.g. `fleet-server` build [#14698](https://buildkite.com/elastic/fleet-server/builds/14698)), which fetches cleanly:

```
$ git fetch -v --prune -- origin 0400cf321e29ce2c8659f5edceeabff560ab320f
From https://github.com/elastic/fleet-server
 * branch            0400cf321e29ce2c8659f5edceeabff560ab320f -> FETCH_HEAD
```

## How does this PR solve the problem?

Remove `initial_step_plugins` (sparse-checkout) from the `fleet-server-tests` and `perf-tests` pipeline entries. Neither pipeline uses fleet-server source code:

- `fleet-server-tests` runs quality gate tests against live cloud deployments using a pre-built Docker image
- `perf-tests` triggers performance benchmarks, also externally driven

Sparse checkout provides no benefit for these pipelines and breaks them when triggered externally.

## How to test this PR locally

No local testing needed — change is purely to Buildkite pipeline configuration. Verify by checking that the next `fleet-server-tests` build no longer fails at the sparse-checkout step.

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [x] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues

- Relates #7029