### PR TITLE
PoC: Use jsontext package to stream components from checkin requests

### DIFF
--- a/NOTICE-fips.txt
+++ b/NOTICE-fips.txt
@@ -1564,6 +1564,43 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 --------------------------------------------------------------------------------
+Dependency : github.com/go-json-experiment/json
+Version: v0.0.0-20260520185125-572e7c383686
+Licence type (autodetected): BSD-3-Clause
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/github.com/go-json-experiment/json@v0.0.0-20260520185125-572e7c383686/LICENSE:
+
+Copyright (c) 2020 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+--------------------------------------------------------------------------------
 Dependency : github.com/gofrs/uuid/v5
 Version: v5.4.0
 Licence type (autodetected): MIT

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1564,6 +1564,43 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 --------------------------------------------------------------------------------
+Dependency : github.com/go-json-experiment/json
+Version: v0.0.0-20260520185125-572e7c383686
+Licence type (autodetected): BSD-3-Clause
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/github.com/go-json-experiment/json@v0.0.0-20260520185125-572e7c383686/LICENSE:
+
+Copyright (c) 2020 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+--------------------------------------------------------------------------------
 Dependency : github.com/gofrs/uuid/v5
 Version: v5.4.0
 Licence type (autodetected): MIT

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/elastic/go-ucfg v0.9.1
 	github.com/fxamacker/cbor/v2 v2.9.2
 	github.com/go-chi/chi/v5 v5.2.5
+	github.com/go-json-experiment/json v0.0.0-20260520185125-572e7c383686
 	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/fxamacker/cbor/v2 v2.9.2 h1:X4Ksno9+x3cz0TZv69ec1hxP/+tymuR8PXQJyDwfh
 github.com/fxamacker/cbor/v2 v2.9.2/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/go-json-experiment/json v0.0.0-20260520185125-572e7c383686 h1:NZBJxCpbHS1gzS6xAmyxbJznosZIIPk9IB42v62UvKA=
+github.com/go-json-experiment/json v0.0.0-20260520185125-572e7c383686/go.mod h1:tphK2c80bpPhMOI4v6bIc2xWywPfbqi1Z06+RcrMkDg=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -181,12 +181,12 @@ func (ct *CheckinT) validateRequest(zlog zerolog.Logger, w http.ResponseWriter, 
 	span, ctx := apm.StartSpan(r.Context(), "validateRequest", "validate")
 	defer span.End()
 
-	body := r.Body
-	// Limit the size of the body to prevent malicious agent from exhausting RAM in server
-	if ct.cfg.Limits.CheckinLimit.MaxBody > 0 {
-		body = http.MaxBytesReader(w, body, ct.cfg.Limits.CheckinLimit.MaxBody)
+	// Checkin requests that have unknown size or that are too large will use the streaming validation approach
+	if r.ContentLength == -1 || r.ContentLength > ct.cfg.Limits.CheckinLimit.MaxBody {
+		return ct.validateRequestStream(zlog, w, r, start, agent)
 	}
-	readCounter := datacounter.NewReaderCounter(body)
+
+	readCounter := datacounter.NewReaderCounter(r.Body)
 
 	// Decompress the body when the client signals Content-Encoding: gzip.
 	var bodyReader io.Reader = readCounter

--- a/internal/pkg/api/handleCheckinStream.go
+++ b/internal/pkg/api/handleCheckinStream.go
@@ -1,0 +1,281 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package api
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/go-json-experiment/json/jsontext"
+
+	"github.com/miolini/datacounter"
+	"github.com/rs/zerolog"
+	"go.elastic.co/apm/v2"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/checkin"
+	"github.com/elastic/fleet-server/v7/internal/pkg/model"
+)
+
+// componentFlushThreshold is the number of component bytes accumulated before
+// issuing a partial ES update while still reading the request body.
+const componentFlushThreshold int64 = 4 * 1024 * 1024
+
+// streamParseCheckinRequest decodes a CheckinRequest from r using jsontext streaming.
+// It is specifically meant to stream the components array into a sequence of intermediate ES updates
+// so the the fleet-server does not have to decode a large request into memory at once (in order to avoid OOM issues).
+// it return a CheckinRequest without Components, and the unhealthyReason parsed from the components (if any)
+func (ct *CheckinT) streamParseCheckinRequest(r io.Reader, threshold int64, agent *model.Agent) (CheckinRequest, *[]string, error) {
+	dec := jsontext.NewDecoder(r)
+	var req CheckinRequest
+	var reason *[]string
+
+	tok, err := dec.ReadToken()
+	if err != nil {
+		return req, reason, fmt.Errorf("opening token: %w", err)
+	}
+	if tok.Kind() != jsontext.KindBeginObject {
+		return req, reason, fmt.Errorf("expected JSON object, got %s", tok.Kind().String())
+	}
+
+	for dec.PeekKind() != jsontext.KindEndObject {
+		keyTok, err := dec.ReadToken()
+		if err != nil {
+			return req, reason, fmt.Errorf("json read key: %w", err)
+		}
+		key := keyTok.String()
+
+		switch key {
+		case "components":
+			unhealthyReason, err := ct.streamComponentsArray(dec, threshold, agent)
+			if err != nil {
+				return req, reason, fmt.Errorf("json error streaming components: %w", err)
+			}
+			reason = unhealthyReason
+		default:
+			val, err := dec.ReadValue()
+			if err != nil {
+				return req, reason, fmt.Errorf("json read error %q: %w", key, err)
+			}
+			if err := assignCheckinRequestField(&req, key, val); err != nil {
+				return req, reason, fmt.Errorf("struct assign error %q: %w", key, err)
+			}
+		}
+	}
+
+	if _, err := dec.ReadToken(); err != nil {
+		return req, reason, fmt.Errorf("failed to read closing token: %w", err)
+	}
+	return req, reason, nil
+}
+
+// streamComponentsArray reads the components JSON array from dec.
+// It flushes partial arrays as intermediate updates to ES.
+// Returns the unhealthy reason collected from the components
+func (ct *CheckinT) streamComponentsArray(dec *jsontext.Decoder, threshold int64, agent *model.Agent) (*[]string, error) {
+	if dec.PeekKind() == jsontext.KindNull {
+		// FIXME need to clean component list in ES if we ever get here
+		// If this ever happens it means that the content length was either set to -1
+		// or some other part of the request is greater than the checkin body limit
+		// there is no guard against the latter from occurring
+		if _, err := dec.ReadToken(); err != nil { // consume null
+			return nil, err
+		}
+		return nil, nil
+	}
+
+	arrTok, err := dec.ReadToken()
+	if err != nil {
+		return nil, err
+	}
+	if arrTok.Kind() != jsontext.KindBeginArray {
+		return nil, fmt.Errorf("expected array, got %c", arrTok.Kind())
+	}
+
+	var (
+		components  = make([]model.ComponentsItems, 0, 100) // 100 is arbitrary to pre allocate some space
+		reason      []string
+		flushNum    int
+		accumulated int64
+	)
+
+	for dec.PeekKind() != jsontext.KindEndArray {
+		val, err := dec.ReadValue()
+		if err != nil {
+			return nil, fmt.Errorf("read component element: %w", err)
+		}
+		accumulated += int64(len(val))
+
+		var component model.ComponentsItems
+		if err := json.Unmarshal(val, &component); err != nil {
+			return nil, fmt.Errorf("parse component element: %w", err)
+		}
+
+		components = append(components, component)
+
+		if accumulated >= threshold {
+			reason = append(reason, calcUnhealthyReason(components)...)
+			if err := ct.bc.CheckIn(agent.Id, checkin.WithComponentsStream(components, flushNum)); err != nil {
+				return nil, fmt.Errorf("partial component update failed: %w", err)
+			}
+			flushNum++
+			clear(components)           // zero elements
+			components = components[:0] // set len to 0 without removing capacity
+			accumulated = 0
+		}
+	}
+
+	// Consume closing ]
+	if _, err := dec.ReadToken(); err != nil {
+		return nil, err
+	}
+
+	if flushNum == 0 && len(components) == 0 {
+		// FIXME update ES with no components here too
+		return nil, nil
+	}
+	if len(components) > 0 {
+		reason = append(reason, calcUnhealthyReason(components)...)
+		if err := ct.bc.CheckIn(agent.Id, checkin.WithComponentsStream(components, flushNum)); err != nil {
+			return nil, fmt.Errorf("partial component update failed: %w", err)
+		}
+	}
+	return &reason, nil
+}
+
+// assignCheckinRequestField unmarshals val into the named field of req.
+// Unknown fields are silently ignored, matching standard JSON decoder behaviour.
+func assignCheckinRequestField(req *CheckinRequest, key string, val jsontext.Value) error {
+	switch key {
+	case "ack_token":
+		var v string
+		if err := json.Unmarshal(val, &v); err != nil {
+			return err
+		}
+		req.AckToken = &v
+	case "agent_policy_id":
+		var v string
+		if err := json.Unmarshal(val, &v); err != nil {
+			return err
+		}
+		req.AgentPolicyId = &v
+	case "local_metadata":
+		req.LocalMetadata = json.RawMessage(val.Clone())
+	case "message":
+		return json.Unmarshal(val, &req.Message)
+	case "policy_revision_idx":
+		return json.Unmarshal(val, &req.PolicyRevisionIdx)
+	case "poll_timeout":
+		var v string
+		if err := json.Unmarshal(val, &v); err != nil {
+			return err
+		}
+		req.PollTimeout = &v
+	case kStatusMod:
+		return json.Unmarshal(val, &req.Status)
+	case "upgrade":
+		req.Upgrade = json.RawMessage(val.Clone())
+	case "upgrade_details":
+		req.UpgradeDetails = new(UpgradeDetails)
+		return json.Unmarshal(val, req.UpgradeDetails)
+	}
+	return nil
+}
+
+// validateRequestStream is the streaming request validator.
+// It uses jsontext to parse the request body token-by-token, specifically to handle
+// the components array seperatly from other attributes.
+// When validating the request stream, ES will receive intermediate updates to the components
+// array before things like status are set.
+// The return validatdCheckin object will have the Components attribute set to nil.
+//
+// FIXME: go v1.27+ this is a PoC to demonstrate stream-read behaviour only
+func (ct *CheckinT) validateRequestStream(zlog zerolog.Logger, w http.ResponseWriter, r *http.Request, start time.Time, agent *model.Agent) (validatedCheckin, error) {
+	span, ctx := apm.StartSpan(r.Context(), "validateRequestStream", "validate")
+	defer span.End()
+
+	readCounter := datacounter.NewReaderCounter(r.Body)
+
+	var bodyReader io.Reader = readCounter
+	if r.Header.Get("Content-Encoding") == kEncodingGzip {
+		gr, err := gzip.NewReader(readCounter)
+		if err != nil {
+			return validatedCheckin{}, &BadRequestErr{msg: "unable to create gzip reader for request body", nextErr: err}
+		}
+		defer gr.Close()
+		bodyReader = gr
+	}
+
+	req, unhealthyReason, err := ct.streamParseCheckinRequest(bodyReader, componentFlushThreshold, agent)
+	if err != nil {
+		return validatedCheckin{}, &BadRequestErr{msg: "unable to decode checkin request", nextErr: err}
+	}
+	cntCheckin.bodyIn.Add(readCounter.Count())
+
+	if unhealthyReason == nil {
+		// fallback to agent doc if no reason found
+		unhealthyReason = &agent.UnhealthyReason
+		if agent.UnhealthyReason == nil && (agent.LastCheckinStatus == FailedStatus || agent.LastCheckinStatus == DegradedStatus) {
+			// set to other if no reason found, and agent is not healthy
+			unhealthyReason = &([]string{"other"})
+		}
+	}
+
+	if req.Status == CheckinRequestStatus("") {
+		return validatedCheckin{}, &BadRequestErr{msg: "checkin status missing"}
+	}
+	if len(req.Message) == 0 {
+		zlog.Warn().Msg("checkin request method is empty.")
+	}
+
+	var pDur time.Duration
+	if req.PollTimeout != nil {
+		pDur, err = time.ParseDuration(*req.PollTimeout)
+		if err != nil {
+			return validatedCheckin{}, &BadRequestErr{msg: "poll_timeout cannot be parsed as duration", nextErr: err}
+		}
+	}
+
+	pollDuration := ct.cfg.Timeouts.CheckinLongPoll
+	if pDur != 0 {
+		pollDuration = max(min(pDur-(2*time.Minute), ct.cfg.Timeouts.CheckinMaxPoll), time.Minute)
+		wTime := pollDuration + time.Minute
+		rc := http.NewResponseController(w)
+		if err := rc.SetWriteDeadline(start.Add(wTime)); err != nil {
+			zlog.Warn().Err(err).Time("write_deadline", start.Add(wTime)).Msg("Unable to set checkin write deadline.")
+		} else {
+			zlog.Trace().Time("write_deadline", start.Add(wTime)).Msg("Request write deadline set.")
+		}
+	}
+	zlog.Trace().Dur("pollDuration", pollDuration).Msg("Request poll duration set.")
+
+	rawMeta, err := parseMeta(zlog, agent, &req)
+	if err != nil {
+		return validatedCheckin{}, &BadRequestErr{msg: "unable to parse meta", nextErr: err}
+	}
+
+	seqno, err := ct.resolveSeqNo(ctx, zlog, req, agent)
+	if err != nil {
+		return validatedCheckin{}, err
+	}
+
+	rawRollbacks, err := parseAvailableRollbacks(zlog, agent.Upgrade, &req)
+	if err != nil {
+		zlog.Warn().Err(err).Msg("unable to parse available rollbacks")
+		rawRollbacks = nil
+	}
+
+	return validatedCheckin{
+		req:                   &req,
+		dur:                   pollDuration,
+		rawMeta:               rawMeta,
+		seqno:                 seqno,
+		unhealthyReason:       unhealthyReason,
+		rawAvailableRollbacks: rawRollbacks,
+	}, nil
+}

--- a/internal/pkg/api/handleCheckinStream_test.go
+++ b/internal/pkg/api/handleCheckinStream_test.go
@@ -1,0 +1,186 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build !integration
+
+package api
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/checkin"
+	"github.com/elastic/fleet-server/v7/internal/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newStreamCheckinT returns a minimal CheckinT with only bc populated, which is
+// all that streamParseCheckinRequest / streamComponentsArray use.
+func newStreamCheckinT() *CheckinT {
+	return &CheckinT{
+		// CheckIn only locks a mutex and writes to the pending map, so a
+		// nil bulker is fine for unit tests that never call Run/flush.
+		bc: checkin.NewBulk(nil),
+	}
+}
+
+// newTestAgent returns a minimal Agent suitable for streaming-parse tests.
+func newTestAgent(id string) *model.Agent {
+	a := &model.Agent{}
+	a.Id = id
+	return a
+}
+
+// makeComponents returns a JSON array string of n minimal component objects.
+func makeComponents(n int) string {
+	elems := make([]string, n)
+	for i := range elems {
+		elems[i] = fmt.Sprintf(`{"id":"comp-%d","status":"online","message":"ok","units":[]}`, i)
+	}
+	return "[" + strings.Join(elems, ",") + "]"
+}
+
+// makeUnhealthyComponents returns a JSON array of n components all with FAILED
+// status and one input unit, so calcUnhealthyReason returns ["input"].
+func makeUnhealthyComponents(n int) string {
+	elems := make([]string, n)
+	for i := range elems {
+		elems[i] = fmt.Sprintf(
+			`{"id":"comp-%d","status":"FAILED","message":"bad","units":[{"id":"u-%d","type":"input","status":"FAILED","message":"err"}]}`,
+			i, i,
+		)
+	}
+	return "[" + strings.Join(elems, ",") + "]"
+}
+
+func TestStreamParseCheckinRequest_BasicFields(t *testing.T) {
+	ct := newStreamCheckinT()
+	body := `{
+		"status": "online",
+		"message": "running",
+		"ack_token": "tok123",
+		"poll_timeout": "30s"
+	}`
+
+	req, reason, err := ct.streamParseCheckinRequest(strings.NewReader(body), componentFlushThreshold, newTestAgent("a1"))
+	require.NoError(t, err)
+
+	assert.Equal(t, CheckinRequestStatus("online"), req.Status)
+	assert.Equal(t, "running", req.Message)
+	require.NotNil(t, req.AckToken)
+	assert.Equal(t, "tok123", *req.AckToken)
+	require.NotNil(t, req.PollTimeout)
+	assert.Equal(t, "30s", *req.PollTimeout)
+	assert.Nil(t, reason, "no components means nil reason")
+}
+
+func TestStreamParseCheckinRequest_NoComponents(t *testing.T) {
+	ct := newStreamCheckinT()
+	body := `{"status":"online","message":"ok"}`
+
+	_, reason, err := ct.streamParseCheckinRequest(strings.NewReader(body), componentFlushThreshold, newTestAgent("a1"))
+	require.NoError(t, err)
+	assert.Nil(t, reason)
+}
+
+func TestStreamParseCheckinRequest_ComponentsHealthy(t *testing.T) {
+	ct := newStreamCheckinT()
+	comps := makeComponents(3)
+	body := fmt.Sprintf(`{"status":"online","message":"ok","components":%s}`, comps)
+
+	_, reason, err := ct.streamParseCheckinRequest(strings.NewReader(body), componentFlushThreshold, newTestAgent("a1"))
+	require.NoError(t, err)
+	// All components are healthy: calcUnhealthyReason returns an empty slice.
+	// The pointer is non-nil because we appended to reason.
+	require.NotNil(t, reason)
+	assert.Empty(t, *reason)
+}
+
+func TestStreamParseCheckinRequest_ComponentsUnhealthy(t *testing.T) {
+	ct := newStreamCheckinT()
+	comps := makeUnhealthyComponents(2)
+	body := fmt.Sprintf(`{"status":"online","message":"ok","components":%s}`, comps)
+
+	_, reason, err := ct.streamParseCheckinRequest(strings.NewReader(body), componentFlushThreshold, newTestAgent("a1"))
+	require.NoError(t, err)
+	require.NotNil(t, reason)
+	assert.Equal(t, []string{"input"}, *reason)
+}
+
+func TestStreamParseCheckinRequest_ComponentsAboveThreshold(t *testing.T) {
+	ct := newStreamCheckinT()
+	// threshold=1 forces a flush after every element
+	comps := makeComponents(5)
+	body := fmt.Sprintf(`{"status":"online","message":"ok","components":%s}`, comps)
+
+	_, _, err := ct.streamParseCheckinRequest(strings.NewReader(body), 1, newTestAgent("a1"))
+	require.NoError(t, err)
+}
+
+func TestStreamParseCheckinRequest_ComponentsNullValue(t *testing.T) {
+	ct := newStreamCheckinT()
+	body := `{"status":"online","message":"ok","components":null}`
+
+	_, reason, err := ct.streamParseCheckinRequest(strings.NewReader(body), componentFlushThreshold, newTestAgent("a1"))
+	require.NoError(t, err)
+	assert.Nil(t, reason)
+}
+
+func TestStreamParseCheckinRequest_ComponentsEmptyArray(t *testing.T) {
+	ct := newStreamCheckinT()
+	body := `{"status":"online","message":"ok","components":[]}`
+
+	_, reason, err := ct.streamParseCheckinRequest(strings.NewReader(body), componentFlushThreshold, newTestAgent("a1"))
+	require.NoError(t, err)
+	assert.Nil(t, reason)
+}
+
+func TestStreamParseCheckinRequest_ComponentsBadShape(t *testing.T) {
+	ct := newStreamCheckinT()
+	// The components array contains a string instead of an object — should error.
+	body := `{"status":"online","message":"ok","components":["not-an-object"]}`
+
+	_, _, err := ct.streamParseCheckinRequest(strings.NewReader(body), componentFlushThreshold, newTestAgent("a1"))
+	require.Error(t, err)
+}
+
+func TestStreamParseCheckinRequest_LocalMetadata(t *testing.T) {
+	ct := newStreamCheckinT()
+	body := `{"status":"online","message":"ok","local_metadata":{"host":"myhost"}}`
+
+	req, _, err := ct.streamParseCheckinRequest(strings.NewReader(body), componentFlushThreshold, newTestAgent("a1"))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"host":"myhost"}`, string(req.LocalMetadata))
+}
+
+func TestStreamParseCheckinRequest_PolicyRevisionIdx(t *testing.T) {
+	ct := newStreamCheckinT()
+	body := `{"status":"online","message":"ok","policy_revision_idx":42}`
+
+	req, _, err := ct.streamParseCheckinRequest(strings.NewReader(body), componentFlushThreshold, newTestAgent("a1"))
+	require.NoError(t, err)
+	require.NotNil(t, req.PolicyRevisionIdx)
+	assert.Equal(t, int64(42), *req.PolicyRevisionIdx)
+}
+
+func TestStreamParseCheckinRequest_InvalidJSON(t *testing.T) {
+	ct := newStreamCheckinT()
+	_, _, err := ct.streamParseCheckinRequest(strings.NewReader(`not json`), componentFlushThreshold, newTestAgent("a1"))
+	require.Error(t, err)
+}
+
+func TestStreamParseCheckinRequest_MultipleFlushesAggregateReason(t *testing.T) {
+	ct := newStreamCheckinT()
+	// Two unhealthy components, threshold=1 forces a flush after each one.
+	// The reason across both batches should still be ["input"].
+	comps := makeUnhealthyComponents(2)
+	body := fmt.Sprintf(`{"status":"online","message":"ok","components":%s}`, comps)
+
+	_, reason, err := ct.streamParseCheckinRequest(strings.NewReader(body), 1, newTestAgent("a1"))
+	require.NoError(t, err)
+	require.NotNil(t, reason)
+	assert.Equal(t, []string{"input", "input"}, *reason)
+}

--- a/internal/pkg/checkin/bulk.go
+++ b/internal/pkg/checkin/bulk.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
 	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
+	"github.com/elastic/fleet-server/v7/internal/pkg/model"
 	"github.com/elastic/fleet-server/v7/internal/pkg/sqn"
 
 	"github.com/rs/zerolog"
@@ -161,6 +162,18 @@ func WithEffectiveConfig(effectiveConfig []byte) Option {
 	}
 }
 
+func WithComponentsStream(components []model.ComponentsItems, i int) Option {
+	return func(pending *pendingT) {
+		if pending.extra == nil {
+			pending.extra = &extraT{}
+		}
+		pending.extra.componentsStream = &componentStream{
+			flushNum:   i,
+			components: components,
+		}
+	}
+}
+
 func WithAvailableRollbacks(availableRollbacks []byte) Option {
 	return func(pending *pendingT) {
 		if pending.extra == nil {
@@ -180,6 +193,12 @@ type extraT struct {
 	health             []byte
 	capabilities       []string
 	effectiveConfig    []byte
+	componentsStream   *componentStream
+}
+
+type componentStream struct {
+	flushNum   int
+	components []model.ComponentsItems
 }
 
 // Minimize the size of this structure.
@@ -302,7 +321,8 @@ func (bc *Bulk) flush(ctx context.Context) error {
 	var needRefresh bool
 	for id, pendingData := range pending {
 		var body []byte
-		if pendingData.extra == nil {
+		switch {
+		case pendingData.extra == nil:
 			// agents that checkin without extra attributes are cachable
 			// Cacheable agents can share the same status, message, and unhealthy reason. Timestamps are ignored.
 			// This prevents an extra JSON serialization when agents have the same update body.
@@ -315,7 +335,7 @@ func (bc *Bulk) flush(ctx context.Context) error {
 				}
 				simpleCache[pendingData] = body
 			}
-		} else if pendingData.extra.deleteAudit {
+		case pendingData.extra.deleteAudit:
 			if pendingData.extra.seqNo.IsSet() {
 				needRefresh = true
 			}
@@ -336,7 +356,7 @@ func (bc *Bulk) flush(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("could not marshal script action: %w", err)
 			}
-		} else if pendingData.extra.effectiveConfig != nil {
+		case pendingData.extra.effectiveConfig != nil:
 			// effective_config is a nested JSON object. ES's {"doc": ...} partial
 			// update recursively merges objects, so keys removed from the config
 			// (e.g. deleted pipelines) would persist. For example, if the stored
@@ -363,7 +383,12 @@ func (bc *Bulk) flush(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("could not marshal script action: %w", err)
 			}
-		} else {
+		case pendingData.extra.componentsStream != nil:
+			if pendingData.extra.componentsStream.flushNum == 0 {
+				needRefresh = true
+			}
+			// TODO write the fleet-server -> ES intermediate update
+		default:
 			if pendingData.extra.seqNo.IsSet() {
 				needRefresh = true
 			}


### PR DESCRIPTION
# PoC DO NOT MERGE

## What is the problem this PR solves?

Checkin requests from agents running synthetic monitors can exceed the checkin request body size limit due to the length of the components attribute.

## How does this PR solve the problem?

Use the upcoming [jsontext](https://github.com/golang/go/issues/71497) package to handle parsing the json checkin request.
This allows the checkin validator to read the components array as a stream and issue intermediate updates to ES (set to flush once 4MB of objects have been read).

The fleet-server -> ES update function is currently missing from this PoC as it was intended to demo large request handling on the fleet-server.

This PoC is also missing other safeties - such as max size guards against the rest of the body.

## How to test this PR locally

N/A - this is a partial implementation that does not update the components list in ES

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/11981