### PR TITLE
docs: document certificate_reload setting in reference config (8.19)

### DIFF
--- a/fleet-server.reference.yml
+++ b/fleet-server.reference.yml
@@ -101,6 +101,11 @@ fleet:
 #        certificate: /creds/cert.pem
 #        key: /creds/key.pem
 #        key_passphrase_path: /creds/key.pem
+#        certificate_reload:
+#          enabled: false    # Disabled by default; set to true to enable periodic reload
+#          reload_interval: 5s  # How often to re-read cert/key files from disk.
+#                               # After rotation, new certs are picked up within
+#                               # this interval on the next TLS handshake.
 #
 #     # timeouts controls various api timeouts
 #     timeouts:


### PR DESCRIPTION
## What is the problem this PR solves?

The `certificate_reload` configuration setting was added to these branches (via #7068) but was not documented in the reference config, leaving operators unaware it exists or how to use it.

## How does this PR solve the problem?

Adds the `certificate_reload` block to `fleet-server.reference.yml` with accurate defaults: `enabled: false` (since hot-reload is disabled by default on this branch) and `reload_interval: 5s`.

## How to test this PR locally

No code changes; review the reference config diff to confirm the comment accurately reflects the behavior introduced in #7068.

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files

## Related issues

- Relates #7068