### PR TITLE
Fix timing issue  in TestCheckinWithPolicyIDRevision

### DIFF
--- a/testing/e2e/api_version/client_api_current.go
+++ b/testing/e2e/api_version/client_api_current.go
@@ -608,11 +608,12 @@ func (tester *ClientAPITester) TestCheckinWithPolicyIDRevision() {
 	tester.Require().Equal(policyID, policyChange.Policy.Id)
 	tester.Require().Equal(revIDX, int64(policyChange.Policy.Revision))
 
+	// Wait longer than the checkin bulk flush interval (10s default) since checkin 3 returns immediately.
 	tester.Require().EventuallyWithT(func(c *assert.CollectT) {
 		agent := tester.GetAgent(ctx, agentID)
 		assert.Equal(c, policyID, agent.AgentPolicyID)
 		assert.Equal(c, newRevIDX, int64(agent.Revision))
-	}, time.Second*10, time.Second)
+	}, time.Second*20, time.Second)
 
 	// Update policy
 	// Get the policy then "update" it without changing anything - revision ID should increment
@@ -721,11 +722,12 @@ func (tester *ClientAPITester) TestCheckinWithPolicyIDRevision() {
 	checkin = resp.JSON200
 	tester.Require().NotEmpty(checkin.Actions, "Expected action in response")
 
+	// Wait longer than the checkin bulk flush interval (10s default) since checkin 6 returns immediately.
 	tester.Require().EventuallyWithT(func(c *assert.CollectT) {
 		agent := tester.GetAgent(ctx, agentID)
 		require.Equal(c, policyID, agent.AgentPolicyID)
 		require.Equal(c, prevRev, int64(agent.Revision))
-	}, time.Second*10, time.Second)
+	}, time.Second*20, time.Second)
 
 	// agent is now recorded as on a previous revision - check to make sure a checkin without AgentPolicyId and revision result in a POLICY_CHANGE action
 	tester.T().Logf("test checkin 7: agent %s with no policy or revision", agentID)


### PR DESCRIPTION
Increase verification time to 20s (from 10s) so that it is longer then the 10s flush time for the checkin.