### PR TITLE
Improve bulker performance

### DIFF
--- a/changelog/fragments/1781177613-Improve-bulker-performance.yaml
+++ b/changelog/fragments/1781177613-Improve-bulker-performance.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Improve bulker performance
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: fleet-server
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/bulk/block.go
+++ b/internal/pkg/bulk/block.go
@@ -16,13 +16,14 @@ type Buf = danger.Buf
 // However, the multiOp API's will allocate directly in large blocks.
 
 type bulkT struct {
-	action   actionT    // requested actions
-	flags    flagsT     // execution flags
-	idx      int32      // idx of originating request, used in mulitOp
-	ch       chan respT // response channel, caller is waiting synchronously
-	buf      Buf        // json payload to be sent to elastic
-	next     *bulkT     // pointer to next bulkT, used for fast internal queueing
-	spanLink *apm.SpanLink
+	action      actionT    // requested actions
+	flags       flagsT     // execution flags
+	idx         int32      // idx of originating request, used in mulitOp
+	ch          chan respT // response channel, caller is waiting synchronously
+	buf         Buf        // json payload to be sent to elastic
+	next        *bulkT     // pointer to next bulkT, used for fast internal queueing
+	spanLink    apm.SpanLink
+	hasSpanLink bool
 }
 
 type flagsT int8
@@ -76,7 +77,8 @@ func (blk *bulkT) reset() {
 	blk.idx = 0
 	blk.buf.Reset()
 	blk.next = nil
-	blk.spanLink = nil
+	blk.spanLink = apm.SpanLink{}
+	blk.hasSpanLink = false
 }
 
 type respT struct {

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -301,12 +301,8 @@ func (b *Bulker) RemoteOutputConfigChanged(zlog zerolog.Logger, name string, new
 	defer b.remoteOutputMutex.RUnlock()
 	curCfg := b.remoteOutputConfigMap[name]
 
-	hasChanged := false
-
 	// when output config first added, not reporting change
-	if curCfg != nil && !reflect.DeepEqual(curCfg, newCfg) {
-		hasChanged = true
-	}
+	hasChanged := curCfg != nil && !reflect.DeepEqual(curCfg, newCfg)
 	return hasChanged
 }
 

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -5,6 +5,7 @@
 package bulk
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -87,11 +88,36 @@ type Bulk interface {
 
 const kModBulk = "bulk"
 
+var bulkSpanNames = func() [ActionFleetSearch + 1]string {
+	var names [ActionFleetSearch + 1]string
+	for i := range names {
+		names[i] = "Bulker: " + actionT(i).String()
+	}
+	return names
+}()
+
+var flushQueueTxNames = func() [kNumQueues]string {
+	var names [kNumQueues]string
+	for i := range names {
+		names[i] = "Flush queue " + queueT{ty: queueType(i)}.Type()
+	}
+	return names
+}()
+
+var flushSpanNames = func() [kNumQueues]string {
+	var names [kNumQueues]string
+	for i := range names {
+		names[i] = "Flush: " + queueT{ty: queueType(i)}.Type()
+	}
+	return names
+}()
+
 type Bulker struct {
 	es                    esapi.Transport
 	ch                    chan *bulkT
 	opts                  bulkOptT
 	blkPool               sync.Pool
+	flushBufPool          sync.Pool
 	apikeyLimit           *semaphore.Weighted
 	tracer                *apm.Tracer
 	cancelFn              context.CancelFunc
@@ -134,6 +160,7 @@ func NewBulker(es esapi.Transport, tracer *apm.Tracer, opts ...BulkOpt) *Bulker 
 		es:                    es,
 		ch:                    make(chan *bulkT, bopts.blockQueueSz),
 		blkPool:               sync.Pool{New: poolFunc},
+		flushBufPool:          sync.Pool{New: func() any { return new(bytes.Buffer) }},
 		apikeyLimit:           semaphore.NewWeighted(int64(bopts.apikeyMaxParallel)),
 		tracer:                tracer,
 		remoteOutputConfigMap: make(map[string]map[string]any),
@@ -496,7 +523,7 @@ func (b *Bulker) flushQueue(ctx context.Context, w *semaphore.Weighted, queue qu
 		defer cancel()
 
 		if b.tracer != nil {
-			trans := b.tracer.StartTransaction(fmt.Sprintf("Flush queue %s", queue.Type()), "bulker")
+			trans := b.tracer.StartTransaction(flushQueueTxNames[queue.ty], "bulker")
 			trans.Context.SetLabel("queue.size", queue.cnt)
 			trans.Context.SetLabel("queue.pending", queue.pending)
 			ctx = apm.ContextWithTransaction(ctx, trans)
@@ -565,6 +592,7 @@ func (b *Bulker) newBlk(action actionT, opts optionsT) *bulkT {
 		blk.flags.Set(flagRefresh)
 	}
 	blk.spanLink = opts.spanLink
+	blk.hasSpanLink = opts.hasSpanLink
 
 	return blk
 }

--- a/internal/pkg/bulk/flush_bench_test.go
+++ b/internal/pkg/bulk/flush_bench_test.go
@@ -1,0 +1,208 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package bulk
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"testing"
+)
+
+// fixedTransport returns a pre-built response body on every Perform call.
+// It has no per-request parsing logic, so it doesn't contribute allocations
+// or CPU time that would obscure changes to the flush functions under test.
+type fixedTransport struct {
+	body []byte
+}
+
+func (t *fixedTransport) Perform(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: 200,
+		Status:     "200 OK",
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Body:       io.NopCloser(bytes.NewReader(t.body)),
+	}, nil
+}
+
+// drainQueue empties the response channels written by a flush call so the
+// same queue can be reused in the next benchmark iteration.
+func drainQueue(queue queueT) {
+	for n := queue.head; n != nil; n = n.next {
+		<-n.ch
+	}
+}
+
+// --- BenchmarkFlushSearch ---
+
+func msearchResponse(n int) []byte {
+	var buf bytes.Buffer
+	buf.WriteString(`{"responses":[`)
+	for i := range n {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		buf.WriteString(`{"status":200,"took":1,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"hits":[]}}`)
+	}
+	buf.WriteString(`],"took":1}`)
+	return buf.Bytes()
+}
+
+func makeSearchQueue(b *testing.B, bulker *Bulker, n int) queueT {
+	b.Helper()
+	body := []byte(`{"query":{"match_all":{}}}`)
+	var head, tail *bulkT
+	var pending int
+	for i := range n {
+		blk := &bulkT{ch: make(chan respT, 1), idx: int32(i)}
+		if err := bulker.writeMsearchMeta(&blk.buf, "test", nil, nil, false); err != nil {
+			b.Fatal(err)
+		}
+		if err := bulker.writeMsearchBody(&blk.buf, body); err != nil {
+			b.Fatal(err)
+		}
+		pending += blk.buf.Len()
+		if tail != nil {
+			tail.next = blk
+		} else {
+			head = blk
+		}
+		tail = blk
+	}
+	return queueT{ty: kQueueSearch, cnt: n, head: head, pending: pending}
+}
+
+func BenchmarkFlushSearch(b *testing.B) {
+	for _, n := range []int{1, 8, 64, 4096, 32768} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			bulker := NewBulker(&fixedTransport{body: msearchResponse(n)}, nil)
+			queue := makeSearchQueue(b, bulker, n)
+			ctx := context.Background()
+			b.ResetTimer()
+			b.ReportAllocs()
+			for b.Loop() {
+				if err := bulker.flushSearch(ctx, queue); err != nil {
+					b.Fatal(err)
+				}
+				drainQueue(queue)
+			}
+		})
+	}
+}
+
+// --- BenchmarkFlushRead ---
+
+func mgetResponse(n int) []byte {
+	var buf bytes.Buffer
+	buf.WriteString(`{"docs":[`)
+	for i := range n {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		buf.WriteString(`{"_id":"`)
+		buf.WriteString(strconv.Itoa(i))
+		buf.WriteString(`","_version":1,"_seq_no":0,"found":true,"_source":{}}`)
+	}
+	buf.WriteString(`]}`)
+	return buf.Bytes()
+}
+
+func makeReadQueue(b *testing.B, bulker *Bulker, n int) queueT {
+	b.Helper()
+	var head, tail *bulkT
+	var pending int
+	for i := range n {
+		blk := &bulkT{ch: make(chan respT, 1), idx: int32(i)}
+		if err := bulker.writeMget(&blk.buf, "test", strconv.Itoa(i)); err != nil {
+			b.Fatal(err)
+		}
+		pending += blk.buf.Len()
+		if tail != nil {
+			tail.next = blk
+		} else {
+			head = blk
+		}
+		tail = blk
+	}
+	return queueT{ty: kQueueRead, cnt: n, head: head, pending: pending}
+}
+
+func BenchmarkFlushRead(b *testing.B) {
+	for _, n := range []int{1, 8, 64, 4096, 32768} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			bulker := NewBulker(&fixedTransport{body: mgetResponse(n)}, nil)
+			queue := makeReadQueue(b, bulker, n)
+			ctx := context.Background()
+			b.ResetTimer()
+			b.ReportAllocs()
+			for b.Loop() {
+				if err := bulker.flushRead(ctx, queue); err != nil {
+					b.Fatal(err)
+				}
+				drainQueue(queue)
+			}
+		})
+	}
+}
+
+// --- BenchmarkFlushAPIKeyUpdate ---
+
+func makeAPIKeyQueue(b *testing.B, bulker *Bulker, n int) queueT {
+	b.Helper()
+	roles := json.RawMessage(`{"fleet-server":{"cluster":["monitor"]}}`)
+	roleHash := "abc123"
+	var head, tail *bulkT
+	var pending int
+	for i := range n {
+		id := strconv.Itoa(i)
+		blk := &bulkT{ch: make(chan respT, 1), idx: int32(i)}
+		req := apiKeyUpdateRequest{
+			ID:        id,
+			Roles:     roles,
+			RolesHash: roleHash,
+		}
+		body, err := json.Marshal(req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := bulker.writeBulkMeta(&blk.buf, ActionUpdateAPIKey.String(), "", id, ""); err != nil {
+			b.Fatal(err)
+		}
+		if err := bulker.writeBulkBody(&blk.buf, ActionUpdateAPIKey, body); err != nil {
+			b.Fatal(err)
+		}
+		pending += blk.buf.Len()
+		if tail != nil {
+			tail.next = blk
+		} else {
+			head = blk
+		}
+		tail = blk
+	}
+	return queueT{ty: kQueueAPIKeyUpdate, cnt: n, head: head, pending: pending}
+}
+
+func BenchmarkFlushAPIKeyUpdate(b *testing.B) {
+	for _, n := range []int{1, 8, 64, 4096, 32768} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			bulker := NewBulker(&fixedTransport{body: []byte(`{}`)}, nil)
+			queue := makeAPIKeyQueue(b, bulker, n)
+			ctx := context.Background()
+			b.ResetTimer()
+			b.ReportAllocs()
+			for b.Loop() {
+				if err := bulker.flushUpdateAPIKey(ctx, queue); err != nil {
+					b.Fatal(err)
+				}
+				drainQueue(queue)
+			}
+		})
+	}
+}

--- a/internal/pkg/bulk/flush_bench_test.go
+++ b/internal/pkg/bulk/flush_bench_test.go
@@ -2,6 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
+//nolint:dupl // duplicate lines used in tests
 package bulk
 
 import (

--- a/internal/pkg/bulk/opApiKey.go
+++ b/internal/pkg/bulk/opApiKey.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"math"
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
@@ -110,30 +111,25 @@ func (b *Bulker) APIKeyUpdate(ctx context.Context, id, outputPolicyHash string, 
 // Even if the order was incorrect we end up with just a bit broader permission set, never too strict, so agent does not
 // end up with fewer permissions than it needs
 func (b *Bulker) flushUpdateAPIKey(ctx context.Context, queue queueT) error {
-	idsPerRole := make(map[string][]string)
-	roles := make(map[string]json.RawMessage)
-	rolePerID := make(map[string]string)
-	responses := make(map[int]int)
-	idxToID := make(map[int32]string)
-	IDToResponse := make(map[string]int)
+	idsPerRole := make(map[string][]string, queue.cnt)
+	roles := make(map[string]json.RawMessage, queue.cnt)
+	rolePerID := make(map[string]string, queue.cnt)
+	responses := make(map[int]int, queue.cnt)
+	idxToID := make(map[int32]string, queue.cnt)
+	IDToResponse := make(map[string]int, queue.cnt)
 	maxKeySize := 0
-	links := []apm.SpanLink{}
+	links := make([]apm.SpanLink, 0, queue.cnt)
 
 	// merge ids
 	for n := queue.head; n != nil; n = n.next {
 		content := n.buf.Bytes()
-		metaMap := make(map[string]any)
-		dec := json.NewDecoder(bytes.NewReader(content))
-		if err := dec.Decode(&metaMap); err != nil {
-			zerolog.Ctx(ctx).Error().
-				Err(err).
-				Str("mod", kModBulk).
-				Msg("Failed to unmarshal api key update meta map")
-			return err
+		_, body, ok := bytes.Cut(content, []byte("\n"))
+		if !ok {
+			return fmt.Errorf("invalid APIKeyUpdate buffer: missing meta separator")
 		}
 
-		var req *apiKeyUpdateRequest
-		if err := dec.Decode(&req); err != nil {
+		var req apiKeyUpdateRequest
+		if err := json.Unmarshal(body, &req); err != nil {
 			zerolog.Ctx(ctx).Error().
 				Err(err).
 				Str("mod", kModBulk).
@@ -152,8 +148,8 @@ func (b *Bulker) flushUpdateAPIKey(ctx context.Context, queue queueT) error {
 		if maxKeySize < len(req.ID) {
 			maxKeySize = len(req.ID)
 		}
-		if n.spanLink != nil {
-			links = append(links, *n.spanLink)
+		if n.hasSpanLink {
+			links = append(links, n.spanLink)
 		}
 	}
 

--- a/internal/pkg/bulk/opBulk.go
+++ b/internal/pkg/bulk/opBulk.go
@@ -47,9 +47,14 @@ func (b *Bulker) Delete(ctx context.Context, index, id string, opts ...Opt) erro
 }
 
 func (b *Bulker) waitBulkAction(ctx context.Context, action actionT, index, id string, body []byte, opts ...Opt) (*BulkIndexerResponseItem, error) {
-	span, ctx := apm.StartSpan(ctx, fmt.Sprintf("Bulker: %s", action.String()), "bulker")
+	span, ctx := apm.StartSpan(ctx, bulkSpanNames[action], "bulker")
 	defer span.End()
-	opt := b.parseOpts(append(opts, withAPMLinkedContext(ctx))...)
+	opt := b.parseOpts(opts...)
+	if tx := apm.TransactionFromContext(ctx); tx != nil {
+		tCtx := tx.TraceContext()
+		opt.spanLink = apm.SpanLink{Trace: tCtx.Trace, Span: tCtx.Span}
+		opt.hasSpanLink = true
+	}
 	blk := b.newBlk(action, opt)
 
 	// Serialize request
@@ -172,16 +177,18 @@ func (b *Bulker) flushBulk(ctx context.Context, queue queueT) error {
 
 	bufSz := max(queue.cnt*kRoughEstimatePerItem, queue.pending)
 
-	var buf bytes.Buffer
+	buf := b.flushBufPool.Get().(*bytes.Buffer)
+	buf.Reset()
 	buf.Grow(bufSz)
+	defer b.flushBufPool.Put(buf)
 
 	queueCnt := 0
-	links := []apm.SpanLink{}
+	links := make([]apm.SpanLink, 0, queue.cnt)
 	for n := queue.head; n != nil; n = n.next {
 		buf.Write(n.buf.Bytes())
 		queueCnt += 1
-		if n.spanLink != nil {
-			links = append(links, *n.spanLink)
+		if n.hasSpanLink {
+			links = append(links, n.spanLink)
 		}
 	}
 
@@ -190,7 +197,7 @@ func (b *Bulker) flushBulk(ctx context.Context, queue queueT) error {
 	if len(links) == 0 {
 		links = nil
 	}
-	span, ctx := apm.StartSpanOptions(ctx, fmt.Sprintf("Flush: %s", queue.Type()), queue.Type(), apm.SpanOptions{
+	span, ctx := apm.StartSpanOptions(ctx, flushSpanNames[queue.ty], queue.Type(), apm.SpanOptions{
 		Links: links,
 	})
 	defer span.End()

--- a/internal/pkg/bulk/opBulk.go
+++ b/internal/pkg/bulk/opBulk.go
@@ -177,7 +177,7 @@ func (b *Bulker) flushBulk(ctx context.Context, queue queueT) error {
 
 	bufSz := max(queue.cnt*kRoughEstimatePerItem, queue.pending)
 
-	buf := b.flushBufPool.Get().(*bytes.Buffer)
+	buf := b.flushBufPool.Get().(*bytes.Buffer) //nolint:errcheck // we control what is placed in the pool
 	buf.Reset()
 	buf.Grow(bufSz)
 	defer b.flushBufPool.Put(buf)

--- a/internal/pkg/bulk/opMulti.go
+++ b/internal/pkg/bulk/opMulti.go
@@ -91,7 +91,7 @@ func (b *Bulker) multiWaitBulkOp(ctx context.Context, action actionT, ops []Mult
 
 		bulk := &bulks[i]
 		bulk.ch = ch
-		bulk.idx = int32(i) //nolint:gosec
+		bulk.idx = int32(i)
 		bulk.action = action
 		bulk.buf.Set(bodySlice)
 		bulk.spanLink = spanLink

--- a/internal/pkg/bulk/opMulti.go
+++ b/internal/pkg/bulk/opMulti.go
@@ -91,7 +91,7 @@ func (b *Bulker) multiWaitBulkOp(ctx context.Context, action actionT, ops []Mult
 
 		bulk := &bulks[i]
 		bulk.ch = ch
-		bulk.idx = int32(i) //nolint:gosec // disable G115
+		bulk.idx = int32(i) //nolint:gosec
 		bulk.action = action
 		bulk.buf.Set(bodySlice)
 		bulk.spanLink = spanLink
@@ -117,7 +117,7 @@ func (b *Bulker) multiWaitBulkOp(ctx context.Context, action actionT, ops []Mult
 				lastErr = r.err
 			}
 			if r.data != nil {
-				items[r.idx] = *r.data.(*BulkIndexerResponseItem)
+				items[r.idx] = *r.data.(*BulkIndexerResponseItem) //nolint:errcheck // response data type is guaranteed by the bulk engine
 			}
 		case <-ctx.Done():
 			return nil, ctx.Err()

--- a/internal/pkg/bulk/opMulti.go
+++ b/internal/pkg/bulk/opMulti.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"errors"
 	"math"
+
+	"go.elastic.co/apm/v2"
 )
 
 // TODO: Are multi requests used by anything? a quick grep shows no hits outside the bulk package.
@@ -37,7 +39,17 @@ func (b *Bulker) multiWaitBulkOp(ctx context.Context, action actionT, ops []Mult
 		return nil, errors.New("too many bulk ops")
 	}
 
-	opt := b.parseOpts(append(opts, withAPMLinkedContext(ctx))...)
+	span, ctx := apm.StartSpan(ctx, bulkSpanNames[action], "bulker")
+	defer span.End()
+	opt := b.parseOpts(opts...)
+
+	var spanLink apm.SpanLink
+	hasSpanLink := false
+	if tx := apm.TransactionFromContext(ctx); tx != nil {
+		tCtx := tx.TraceContext()
+		spanLink = apm.SpanLink{Trace: tCtx.Trace, Span: tCtx.Span}
+		hasSpanLink = true
+	}
 
 	// Contract is that consumer never blocks, so must preallocate.
 	// Could consider making the response channel *respT to limit memory usage.
@@ -82,6 +94,8 @@ func (b *Bulker) multiWaitBulkOp(ctx context.Context, action actionT, ops []Mult
 		bulk.idx = int32(i) //nolint:gosec // disable G115
 		bulk.action = action
 		bulk.buf.Set(bodySlice)
+		bulk.spanLink = spanLink
+		bulk.hasSpanLink = hasSpanLink
 		if opt.Refresh {
 			bulk.flags.Set(flagRefresh)
 		}

--- a/internal/pkg/bulk/opRead.go
+++ b/internal/pkg/bulk/opRead.go
@@ -73,7 +73,7 @@ func (b *Bulker) flushRead(ctx context.Context, queue queueT) error {
 
 	bufSz := max(queue.cnt*kRoughEstimatePerItem, queue.pending+len(rSuffix))
 
-	buf := b.flushBufPool.Get().(*bytes.Buffer)
+	buf := b.flushBufPool.Get().(*bytes.Buffer) //nolint:errcheck // we control what is placed in the pool
 	buf.Reset()
 	buf.Grow(bufSz + len(rPrefix))
 	buf.WriteString(rPrefix)

--- a/internal/pkg/bulk/opRead.go
+++ b/internal/pkg/bulk/opRead.go
@@ -22,9 +22,14 @@ const (
 )
 
 func (b *Bulker) ReadRaw(ctx context.Context, index, id string, opts ...Opt) (*MgetResponseItem, error) {
-	span, ctx := apm.StartSpan(ctx, "Bulker: readRaw", "bulker")
+	span, ctx := apm.StartSpan(ctx, bulkSpanNames[ActionRead], "bulker")
 	defer span.End()
-	opt := b.parseOpts(append(opts, withAPMLinkedContext(ctx))...)
+	opt := b.parseOpts(opts...)
+	if tx := apm.TransactionFromContext(ctx); tx != nil {
+		tCtx := tx.TraceContext()
+		opt.spanLink = apm.SpanLink{Trace: tCtx.Trace, Span: tCtx.Span}
+		opt.hasSpanLink = true
+	}
 	blk := b.newBlk(ActionRead, opt)
 
 	// Serialize request
@@ -53,8 +58,6 @@ func (b *Bulker) ReadRaw(ctx context.Context, index, id string, opts ...Opt) (*M
 }
 
 func (b *Bulker) Read(ctx context.Context, index, id string, opts ...Opt) ([]byte, error) {
-	span, ctx := apm.StartSpan(ctx, "Bulker: read", "bulker")
-	defer span.End()
 	r, err := b.ReadRaw(ctx, index, id, opts...)
 	if err != nil {
 		return nil, err
@@ -70,23 +73,26 @@ func (b *Bulker) flushRead(ctx context.Context, queue queueT) error {
 
 	bufSz := max(queue.cnt*kRoughEstimatePerItem, queue.pending+len(rSuffix))
 
-	buf := bytes.NewBufferString(rPrefix)
-	buf.Grow(bufSz)
+	buf := b.flushBufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	buf.Grow(bufSz + len(rPrefix))
+	buf.WriteString(rPrefix)
+	defer b.flushBufPool.Put(buf)
 
 	// Each item a JSON array element followed by comma
 	queueCnt := 0
-	links := []apm.SpanLink{}
+	links := make([]apm.SpanLink, 0, queue.cnt)
 	for n := queue.head; n != nil; n = n.next {
 		buf.Write(n.buf.Bytes())
 		queueCnt += 1
-		if n.spanLink != nil {
-			links = append(links, *n.spanLink)
+		if n.hasSpanLink {
+			links = append(links, n.spanLink)
 		}
 	}
 	if len(links) == 0 {
 		links = nil
 	}
-	span, ctx := apm.StartSpanOptions(ctx, "Flush: read", "read", apm.SpanOptions{
+	span, ctx := apm.StartSpanOptions(ctx, flushSpanNames[queue.ty], queue.Type(), apm.SpanOptions{
 		Links: links,
 	})
 	defer span.End()

--- a/internal/pkg/bulk/opSearch.go
+++ b/internal/pkg/bulk/opSearch.go
@@ -20,9 +20,14 @@ import (
 )
 
 func (b *Bulker) Search(ctx context.Context, index string, body []byte, opts ...Opt) (*es.ResultT, error) {
-	span, ctx := apm.StartSpan(ctx, "Bulker: search", "bulker")
+	span, ctx := apm.StartSpan(ctx, bulkSpanNames[ActionSearch], "bulker")
 	defer span.End()
-	opt := b.parseOpts(append(opts, withAPMLinkedContext(ctx))...)
+	opt := b.parseOpts(opts...)
+	if tx := apm.TransactionFromContext(ctx); tx != nil {
+		tCtx := tx.TraceContext()
+		opt.spanLink = apm.SpanLink{Trace: tCtx.Trace, Span: tCtx.Span}
+		opt.hasSpanLink = true
+	}
 	action := ActionSearch
 
 	// Use /_fleet/_fleet_msearch fleet plugin endpoint if need to wait for checkpoints
@@ -127,22 +132,24 @@ func (b *Bulker) flushSearch(ctx context.Context, queue queueT) error {
 
 	bufSz := max(queue.cnt*kRoughEstimatePerItem, queue.pending)
 
-	var buf bytes.Buffer
+	buf := b.flushBufPool.Get().(*bytes.Buffer)
+	buf.Reset()
 	buf.Grow(bufSz)
+	defer b.flushBufPool.Put(buf)
 
 	queueCnt := 0
-	links := []apm.SpanLink{}
+	links := make([]apm.SpanLink, 0, queue.cnt)
 	for n := queue.head; n != nil; n = n.next {
 		buf.Write(n.buf.Bytes())
 		queueCnt += 1
-		if n.spanLink != nil {
-			links = append(links, *n.spanLink)
+		if n.hasSpanLink {
+			links = append(links, n.spanLink)
 		}
 	}
 	if len(links) == 0 {
 		links = nil
 	}
-	span, ctx := apm.StartSpanOptions(ctx, "Flush: search", "search", apm.SpanOptions{
+	span, ctx := apm.StartSpanOptions(ctx, flushSpanNames[queue.ty], queue.Type(), apm.SpanOptions{
 		Links: links,
 	})
 	defer span.End()

--- a/internal/pkg/bulk/opSearch.go
+++ b/internal/pkg/bulk/opSearch.go
@@ -79,7 +79,8 @@ func (b *Bulker) writeMsearchMeta(buf *Buf, index string, moreIndices []string, 
 			return err
 		}
 
-		indices := []string{index}
+		indices := make([]string, 0, 1+len(moreIndices))
+		indices = append(indices, index)
 		indices = append(indices, moreIndices...)
 
 		_, _ = buf.WriteString(`"index": `)
@@ -132,7 +133,7 @@ func (b *Bulker) flushSearch(ctx context.Context, queue queueT) error {
 
 	bufSz := max(queue.cnt*kRoughEstimatePerItem, queue.pending)
 
-	buf := b.flushBufPool.Get().(*bytes.Buffer)
+	buf := b.flushBufPool.Get().(*bytes.Buffer) //nolint:errcheck // we control what is placed in the pool
 	buf.Reset()
 	buf.Grow(bufSz)
 	defer b.flushBufPool.Put(buf)

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -5,7 +5,6 @@
 package bulk
 
 import (
-	"context"
 	"strconv"
 	"time"
 
@@ -25,7 +24,8 @@ type optionsT struct {
 	Indices            []string
 	WaitForCheckpoints []int64
 	IgnoreUnavailable  bool
-	spanLink           *apm.SpanLink
+	spanLink           apm.SpanLink
+	hasSpanLink        bool
 }
 
 type Opt func(*optionsT)
@@ -63,19 +63,6 @@ func WithWaitForCheckpoints(checkpoints []int64) Opt {
 	}
 }
 
-func withAPMLinkedContext(ctx context.Context) Opt {
-	return func(opt *optionsT) {
-		trace := apm.TransactionFromContext(ctx)
-		if trace == nil {
-			return
-		}
-		tCtx := trace.TraceContext()
-		opt.spanLink = &apm.SpanLink{
-			Trace: tCtx.Trace,
-			Span:  tCtx.Span,
-		}
-	}
-}
 
 //-----
 // Bulk API options

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -63,7 +63,6 @@ func WithWaitForCheckpoints(checkpoints []int64) Opt {
 	}
 }
 
-
 //-----
 // Bulk API options
 


### PR DESCRIPTION
## What is the problem this PR solves?

Improve bulker performance by lowering the number of allocations.

## How does this PR solve the problem?

### APM Improvements:

APM span handling has changed from using a pointer to a directly allocated span per bulkT (removing 1 heap allocation)

Replaced `withAPMLinkedContext` with direct inline extraction (avoids allocating a slice and closure)

Pre-allocate span links

Pre-compute span name arrays

Removed span in Read operation -> read always calls ReadRaw

#### Bug fix

Correctly trace calls in `opMulti.go`

### Other improvements

OpApiKey.go - use queue.cnt as a size hint to pre-allocate space

flushUpdateAPIKey - replace json.Decoder call that discards decoded bytes with a `bytes.Cut` in order to discard metadata.

## How to test this PR locally

Additional benchmarks have been added with dae7d64f6351578494fe2517458ae5c46b428c9d.

A benchstat comparison between dae7d64f6351578494fe2517458ae5c46b428c9d and 11ff6f2f6cfc9b2cf04a48175a1118f67e63991a produced the following results:

```
pkg: github.com/elastic/fleet-server/v7/internal/pkg/bulk
                           │ build/benchmark-baseline.out │       build/benchmark-new.out        │
                           │            sec/op            │    sec/op     vs base                │
MockBulk/1-12                                39.87µ ±  3%   37.81µ ±  1%   -5.17% (p=0.000 n=10)
MockBulk/8-12                                140.0µ ±  1%   134.8µ ±  1%   -3.68% (p=0.000 n=10)
MockBulk/64-12                               779.9µ ±  4%   768.7µ ±  1%        ~ (p=0.075 n=10)
MockBulk/4096-12                             55.96m ±  2%   57.92m ±  2%   +3.49% (p=0.005 n=10)
MockBulk/32768-12                            516.4m ±  4%   517.0m ±  1%        ~ (p=0.971 n=10)
DispatchAbortQueue-12                        108.9n ±  1%   107.0n ±  2%   -1.70% (p=0.016 n=10)
DispatchAbortResponse-12                     368.5n ± 18%   365.0n ± 20%        ~ (p=0.912 n=10)
DispatchSuccess-12                           413.1n ±  2%   410.2n ±  2%        ~ (p=0.190 n=10)
FlushSearch/1-12                             2.365µ ±  6%   1.696µ ±  5%  -28.29% (p=0.000 n=10)
FlushSearch/8-12                             5.776µ ±  1%   5.096µ ±  1%  -11.77% (p=0.000 n=10)
FlushSearch/64-12                            34.79µ ±  4%   30.62µ ±  1%  -11.99% (p=0.000 n=10)
FlushSearch/4096-12                          2.181m ±  2%   1.895m ±  5%  -13.08% (p=0.000 n=10)
FlushSearch/32768-12                         17.66m ±  3%   15.27m ±  1%  -13.51% (p=0.000 n=10)
FlushRead/1-12                               2.068µ ±  6%   1.418µ ±  2%  -31.41% (p=0.000 n=10)
FlushRead/8-12                               3.836µ ±  6%   3.070µ ±  8%  -19.97% (p=0.000 n=10)
FlushRead/64-12                              19.64µ ±  2%   15.30µ ±  1%  -22.09% (p=0.000 n=10)
FlushRead/4096-12                           1128.8µ ±  3%   884.7µ ± 10%  -21.62% (p=0.000 n=10)
FlushRead/32768-12                           8.912m ±  1%   7.076m ±  2%  -20.61% (p=0.000 n=10)
FlushAPIKeyUpdate/1-12                       3.610µ ±  3%   2.739µ ±  3%  -24.12% (p=0.000 n=10)
FlushAPIKeyUpdate/8-12                      17.710µ ±  1%   9.652µ ±  3%  -45.50% (p=0.000 n=10)
FlushAPIKeyUpdate/64-12                     140.98µ ±  1%   71.39µ ±  2%  -49.36% (p=0.000 n=10)
FlushAPIKeyUpdate/4096-12                    9.059m ±  2%   4.455m ±  1%  -50.82% (p=0.000 n=10)
FlushAPIKeyUpdate/32768-12                   78.15m ± 10%   40.12m ±  3%  -48.67% (p=0.000 n=10)
MultiUpdateMock/1-12                         797.6n ±  2%   751.8n ±  3%   -5.74% (p=0.000 n=10)
MultiUpdateMock/8-12                         3.390µ ±  1%   3.449µ ±  2%   +1.73% (p=0.005 n=10)
MultiUpdateMock/64-12                        18.09µ ±  1%   17.83µ ±  1%   -1.42% (p=0.001 n=10)
MultiUpdateMock/4096-12                      941.6µ ±  2%   926.7µ ±  1%   -1.58% (p=0.003 n=10)
MultiUpdateMock/32768-12                     7.441m ±  2%   7.293m ±  5%        ~ (p=0.353 n=10)
MultiUpdateMock/131072-12                    31.06m ±  1%   31.44m ±  2%   +1.24% (p=0.000 n=10)
geomean                                      123.0µ         102.4µ        -16.75%
```

```
                           │ build/benchmark-baseline.out │         build/benchmark-new.out         │
                           │             B/op             │     B/op       vs base                  │
MockBulk/1-12                            36.51Ki ±   0%     29.51Ki ±  0%  -19.16% (p=0.000 n=10)
MockBulk/8-12                            96.07Ki ±   0%     72.62Ki ±  0%  -24.41% (p=0.000 n=10)
MockBulk/64-12                           486.5Ki ±   0%     432.9Ki ±  0%  -11.00% (p=0.000 n=10)
MockBulk/4096-12                         28.89Mi ±   0%     28.28Mi ±  0%   -2.12% (p=0.000 n=10)
MockBulk/32768-12                        234.9Mi ±   0%     231.4Mi ±  2%   -1.49% (p=0.001 n=10)
DispatchAbortQueue-12                      0.000 ±   0%       0.000 ±  0%        ~ (p=1.000 n=10) ¹
DispatchAbortResponse-12                   102.0 ± 118%       114.0 ± 84%        ~ (p=0.725 n=10)
DispatchSuccess-12                         16.00 ±   0%       16.00 ±  0%        ~ (p=1.000 n=10) ¹
FlushSearch/1-12                         4.416Ki ±   0%     2.689Ki ±  0%  -39.10% (p=0.000 n=10)
FlushSearch/8-12                         5.789Ki ±   0%     3.977Ki ±  0%  -31.31% (p=0.000 n=10)
FlushSearch/64-12                        27.90Ki ±   0%     13.40Ki ±  0%  -51.97% (p=0.000 n=10)
FlushSearch/4096-12                     1610.5Ki ±   0%     683.1Ki ±  0%  -57.59% (p=0.000 n=10)
FlushSearch/32768-12                    12.565Mi ±   0%     5.349Mi ±  0%  -57.43% (p=0.000 n=10)
FlushRead/1-12                           4.453Ki ±   0%     2.492Ki ±  0%  -44.04% (p=0.000 n=10)
FlushRead/8-12                           5.227Ki ±   0%     3.148Ki ±  0%  -39.76% (p=0.000 n=10)
FlushRead/64-12                         25.664Ki ±   0%     9.148Ki ±  0%  -64.35% (p=0.000 n=10)
FlushRead/4096-12                       1322.4Ki ±   0%     386.7Ki ±  0%  -70.76% (p=0.000 n=10)
FlushRead/32768-12                      10.260Mi ±   0%     3.018Mi ±  0%  -70.58% (p=0.000 n=10)
FlushAPIKeyUpdate/1-12                   4.523Ki ±   0%     3.031Ki ±  0%  -32.99% (p=0.000 n=10)
FlushAPIKeyUpdate/8-12                  18.336Ki ±   0%     6.398Ki ±  0%  -65.10% (p=0.000 n=10)
FlushAPIKeyUpdate/64-12                 151.30Ki ±   0%     57.96Ki ±  0%  -61.69% (p=0.000 n=10)
FlushAPIKeyUpdate/4096-12                9.518Mi ±   0%     3.692Mi ±  0%  -61.22% (p=0.000 n=10)
FlushAPIKeyUpdate/32768-12               76.96Mi ±   0%     30.25Mi ±  0%  -60.70% (p=0.000 n=10)
MultiUpdateMock/1-12                       472.0 ±   0%       480.0 ±  0%   +1.69% (p=0.000 n=10)
MultiUpdateMock/8-12                     1.977Ki ±   0%     2.219Ki ±  0%  +12.25% (p=0.000 n=10)
MultiUpdateMock/64-12                    14.73Ki ±   0%     15.97Ki ±  0%   +8.44% (p=0.000 n=10)
MultiUpdateMock/4096-12                  880.2Ki ±   0%     976.2Ki ±  0%  +10.91% (p=0.000 n=10)
MultiUpdateMock/32768-12                 6.875Mi ±   0%     7.625Mi ±  0%  +10.91% (p=0.000 n=10)
MultiUpdateMock/131072-12                27.50Mi ±   0%     30.50Mi ±  0%  +10.91% (p=0.000 n=10)
geomean                                                 ²                  -34.32%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

```
                           │ build/benchmark-baseline.out │        build/benchmark-new.out        │
                           │          allocs/op           │  allocs/op   vs base                  │
MockBulk/1-12                                212.0 ± 0%      184.0 ± 0%  -13.21% (p=0.000 n=10)
MockBulk/8-12                                468.0 ± 0%      360.0 ± 0%  -23.08% (p=0.000 n=10)
MockBulk/64-12                              2.499k ± 0%     1.720k ± 0%  -31.17% (p=0.000 n=10)
MockBulk/4096-12                           148.42k ± 0%     99.23k ± 0%  -33.15% (p=0.000 n=10)
MockBulk/32768-12                          1224.3k ± 0%     831.4k ± 0%  -32.09% (p=0.000 n=10)
DispatchAbortQueue-12                        0.000 ± 0%      0.000 ± 0%        ~ (p=1.000 n=10) ¹
DispatchAbortResponse-12                     1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
DispatchSuccess-12                           1.000 ± 0%      1.000 ± 0%        ~ (p=1.000 n=10) ¹
FlushSearch/1-12                             21.00 ± 0%      19.00 ± 0%   -9.52% (p=0.000 n=10)
FlushSearch/8-12                             26.00 ± 0%      26.00 ± 0%        ~ (p=1.000 n=10) ¹
FlushSearch/64-12                            82.00 ± 0%      82.00 ± 0%        ~ (p=1.000 n=10) ¹
FlushSearch/4096-12                         4.114k ± 0%     4.114k ± 0%        ~ (p=1.000 n=10) ¹
FlushSearch/32768-12                        32.79k ± 0%     32.79k ± 0%        ~ (p=1.000 n=10) ¹
FlushRead/1-12                               22.00 ± 0%      19.00 ± 0%  -13.64% (p=0.000 n=10)
FlushRead/8-12                               27.00 ± 0%      26.00 ± 0%   -3.70% (p=0.000 n=10)
FlushRead/64-12                              83.00 ± 0%      82.00 ± 0%   -1.20% (p=0.000 n=10)
FlushRead/4096-12                           4.115k ± 0%     4.114k ± 0%   -0.02% (p=0.000 n=10)
FlushRead/32768-12                          32.79k ± 0%     32.79k ± 0%   -0.00% (p=0.000 n=10)
FlushAPIKeyUpdate/1-12                       46.00 ± 0%      30.00 ± 0%  -34.78% (p=0.000 n=10)
FlushAPIKeyUpdate/8-12                       238.0 ± 0%      103.0 ± 0%  -56.72% (p=0.000 n=10)
FlushAPIKeyUpdate/64-12                     1888.0 ± 0%      738.0 ± 0%  -60.91% (p=0.000 n=10)
FlushAPIKeyUpdate/4096-12                  118.94k ± 0%     45.18k ± 0%  -62.01% (p=0.000 n=10)
FlushAPIKeyUpdate/32768-12                  951.1k ± 0%     361.3k ± 0%  -62.02% (p=0.000 n=10)
MultiUpdateMock/1-12                         7.000 ± 0%      6.000 ± 0%  -14.29% (p=0.000 n=10)
MultiUpdateMock/8-12                         7.000 ± 0%      6.000 ± 0%  -14.29% (p=0.000 n=10)
MultiUpdateMock/64-12                        7.000 ± 0%      6.000 ± 0%  -14.29% (p=0.000 n=10)
MultiUpdateMock/4096-12                      7.000 ± 0%      6.000 ± 0%  -14.29% (p=0.000 n=10)
MultiUpdateMock/32768-12                     7.000 ± 0%      6.000 ± 0%  -14.29% (p=0.000 n=10)
MultiUpdateMock/131072-12                    7.000 ± 0%      6.000 ± 0%  -14.29% (p=0.000 n=10)
geomean                                                 ²                -21.25%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

There are major improvements across the bulker **except** for the Multi operations (due to the bug fix)

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist


- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)