### PR TITLE
Use google/go for FIPS, build windows fips artifacts

### DIFF
--- a/.buildkite/pipeline.package.mbp.yml
+++ b/.buildkite/pipeline.package.mbp.yml
@@ -27,7 +27,10 @@ steps:
     # as prereleases are only intended to be used with staging; details in https://github.com/elastic/ingest-dev/issues/4855
     if: "build.env('VERSION_QUALIFIER') == null"
     key: "package-x86-64-snapshot"
-    command: ".buildkite/scripts/package.sh snapshot"
+    command: ".buildkite/scripts/package.sh"
+    env:
+      PLATFORMS: "linux/amd64,darwin/amd64,windows/amd64"
+      SNAPSHOT: "true"
     agents:
       provider: "gcp"
       image: "${IMAGE_UBUNTU_X86_64}"
@@ -41,7 +44,9 @@ steps:
     key: "package-x86-64-staging"
     command: |
       source .buildkite/scripts/version_qualifier.sh
-      .buildkite/scripts/package.sh staging
+      .buildkite/scripts/package.sh
+    env:
+      PLATFORMS: "linux/amd64,darwin/amd64,windows/amd64"
     agents:
       provider: "gcp"
       image: "${IMAGE_UBUNTU_X86_64}"
@@ -55,9 +60,11 @@ steps:
   - label: "Package FIPS x86_64 snapshot"
     if: "build.env('VERSION_QUALIFIER') == null"
     key: "package-fips-x86-64-snapshot"
-    command: ".buildkite/scripts/package.sh snapshot"
+    command: ".buildkite/scripts/package.sh"
     env:
+      SNAPSHOT: "true"
       FIPS: "true"
+      PLATFORMS: "linux/amd64,windows/amd64"
     agents:
       provider: "gcp"
       image: "${IMAGE_UBUNTU_X86_64}"
@@ -72,9 +79,10 @@ steps:
     key: "package-fips-x86-64-staging"
     command: |
       source .buildkite/scripts/version_qualifier.sh
-      .buildkite/scripts/package.sh staging
+      .buildkite/scripts/package.sh
     env:
       FIPS: "true"
+      PLATFORMS: "linux/amd64,windows/amd64"
     agents:
       provider: "gcp"
       image: "${IMAGE_UBUNTU_X86_64}"
@@ -88,7 +96,10 @@ steps:
   - label: "Package aarch64 snapshot"
     if: "build.env('VERSION_QUALIFIER') == null"
     key: "package-arm-snapshot"
-    command: ".buildkite/scripts/package.sh snapshot"
+    command: ".buildkite/scripts/package.sh"
+    env:
+      SNAPSHOT: "true"
+      PLATFORMS: "linux/arm64,darwin/arm64,windows/arm64"
     agents:
       provider: "aws"
       imagePrefix: "${IMAGE_UBUNTU_ARM_64}"
@@ -103,7 +114,9 @@ steps:
     key: "package-arm-staging"
     command: |
       source .buildkite/scripts/version_qualifier.sh
-      .buildkite/scripts/package.sh staging
+      .buildkite/scripts/package.sh
+    env:
+      PLATFORMS: "linux/arm64,darwin/arm64,windows/arm64"
     agents:
       provider: "aws"
       imagePrefix: "${IMAGE_UBUNTU_ARM_64}"
@@ -117,9 +130,11 @@ steps:
   - label: "Package FIPS aarch64 snapshot"
     if: "build.env('VERSION_QUALIFIER') == null"
     key: "package-fips-arm-snapshot"
-    command: ".buildkite/scripts/package.sh snapshot"
+    command: ".buildkite/scripts/package.sh"
     env:
+      SNAPSHOT: "true"
       FIPS: "true"
+      PLATFORMS: "linux/arm64,windows/arm64"
     agents:
       provider: "aws"
       imagePrefix: "${IMAGE_UBUNTU_ARM_64}"
@@ -134,9 +149,10 @@ steps:
     key: "package-fips-arm-staging"
     command: |
       source .buildkite/scripts/version_qualifier.sh
-      .buildkite/scripts/package.sh staging
+      .buildkite/scripts/package.sh
     env:
       FIPS: "true"
+      PLATFORMS: "linux/arm64,windows/arm64"
     agents:
       provider: "aws"
       imagePrefix: "${IMAGE_UBUNTU_ARM_64}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,6 @@ env:
   TERRAFORM_VERSION: "1.6.4"
   IMAGE_UBUNTU_X86_64: "platform-ingest-elastic-agent-ubuntu-2204-1776780011"
   IMAGE_UBUNTU_ARM_64: "platform-ingest-elastic-agent-ubuntu-2204-aarch64-1776780011"
-  IMAGE_UBUNTU_X86_64_FIPS: "platform-ingest-fleet-server-ubuntu-2204-fips"
 
 # This section is used to define the plugins that will be used in the pipeline.
 # See https://buildkite.com/docs/pipelines/integrations/plugins/using#using-yaml-anchors-with-plugins
@@ -67,7 +66,7 @@ steps:
         key: "package-fips-x86-64-pr"
         env:
           FIPS: "true"
-          PLATFORMS: "linux/amd64"
+          PLATFORMS: "linux/amd64,windows/amd64"
         command: ".buildkite/scripts/release_test.sh"
         artifact_paths:
           - build/distributions/**
@@ -98,7 +97,7 @@ steps:
         key: "package-fips-arm64-pr"
         env:
           FIPS: "true"
-          PLATFORMS: "linux/arm64"
+          PLATFORMS: "linux/arm64,windows/arm64"
         command: ".buildkite/scripts/release_test.sh"
         artifact_paths:
           - build/distributions/**
@@ -164,32 +163,27 @@ steps:
           - build/*.xml
           - build/coverage*.out
 
-      - label: ":smartbear-testexecute: Run fips140=on unit tests with FIPS provider and microsoft/go"
-        key: unit-test-fips-tag
+      - label: ":smartbear-testexecute: Run unit tests with FIPS"
+        key: unit-test-fips
         command: ".buildkite/scripts/unit_test.sh"
         env:
           FIPS: "true"
-          GOEXPERIMENT: "systemcrypto"
-          GO_DISTRO: "microsoft"
           GODEBUG: "fips140=on,tlsmlkem=0"
         agents:
-          provider: "aws"
-          imagePrefix: "${IMAGE_UBUNTU_X86_64_FIPS}"
-          instanceType: "m5.xlarge"
+          provider: "gcp"
+          image: "${IMAGE_UBUNTU_X86_64}"
         artifact_paths:
           - build/*.xml
           - build/coverage*.out
 
-      - label: ":smartbear-testexecute: Run fips140=only unit tests with FIPS provider and upstream go"
+      - label: ":smartbear-testexecute: Run fips140=only unit tests"
         key: unit-test-fips140-only
         command: ".buildkite/scripts/unit_test_fipsonly.sh"
         env:
           FIPS: "true"
-          GO_DISTRO: "stdlib"
         agents:
-          provider: "aws"
-          imagePrefix: "${IMAGE_UBUNTU_X86_64_FIPS}"
-          instanceType: "m5.xlarge"
+          provider: "gcp"
+          image: "${IMAGE_UBUNTU_X86_64}"
         artifact_paths:
           - build/*.xml
           - build/coverage*.out

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -51,20 +51,6 @@ with_go() {
     export PATH="${PATH}:$(go env GOPATH):$(go env GOPATH)/bin"
 }
 
-with_msft_go() {
-    echo "Setting up microsoft/go"
-    create_workspace
-    check_platform_architeture
-
-    # Use a temporary folder to house the Go SDK downloaded from Microsoft
-    tempfolder=$(mktemp -d)
-    MSFT_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$(cat .go-version)-1.${platform_type}-${arch_type}.tar.gz
-    retry 5 $(curl -sL -o - $MSFT_DOWNLOAD_URL | tar -xz -f - -C ${tempfolder}/)
-    export PATH="${PATH}:${tempfolder}/go/bin"
-    go version
-    which go
-    export PATH="${PATH}:$(go env GOPATH)/bin"
-}
 
 with_docker_compose() {
     echo "Setting up the Docker-compose environment..."

--- a/.buildkite/scripts/local_build.sh
+++ b/.buildkite/scripts/local_build.sh
@@ -5,11 +5,7 @@ set -euo pipefail
 source .buildkite/scripts/common.sh
 
 add_bin_path
-if [[ "${FIPS:-false}" == "true" ]]; then
-    with_msft_go
-else
-    with_go
-fi
+with_go
 
 with_mage
 

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 
 source .buildkite/scripts/common.sh
 
-PLATFORM_TYPE=$(uname -m)
 TYPE="$1"
 readonly VERSION_QUALIFIER="${VERSION_QUALIFIER:-""}"
 
@@ -13,36 +12,9 @@ if [[ ${BUILDKITE_BRANCH} == "main" && ${TYPE} == "staging" && -z ${VERSION_QUAL
     exit 0
 fi
 
-PLATFORMS=""
-if [[ ${PLATFORM_TYPE} == "arm" || ${PLATFORM_TYPE} == "aarch64" ]]; then
-    PLATFORMS="linux/arm64"
-fi
-
 add_bin_path
-
-if [[ ${FIPS:-false} == "true" ]]; then
-    with_msft_go
-    if [[ ${PLATFORM_TYPE} == "arm" || ${PLATFORM_TYPE} == "aarch64" ]]; then
-        export PLATFORMS="linux/arm64"
-    else
-        export PLATFORMS="linux/amd64"
-    fi
-else
-    with_go
-fi
+with_go
 with_mage
 
-case "${TYPE}" in
-    "snapshot")
-        export SNAPSHOT=true
-        mage docker:release
-        ;;
-    "staging")
-        mage docker:release
-        ;;
-    *)
-    echo "The option is unsupported yet"
-    ;;
-esac
-
+mage docker:release
 upload_mbp_packages_to_gcp_bucket "build/distributions/**/*" "${TYPE}"

--- a/.buildkite/scripts/unit_test.sh
+++ b/.buildkite/scripts/unit_test.sh
@@ -5,13 +5,7 @@ set -euo pipefail
 source .buildkite/scripts/common.sh
 
 add_bin_path
-
-if [[ ${FIPS:-false} == "true" && ${GO_DISTRO:-stdlib} == "microsoft" ]]; then
-    with_msft_go
-else
-  with_go
-fi
-
+with_go
 with_mage
 
 echo "Starting the unit tests..."

--- a/.buildkite/scripts/unit_test_fipsonly.sh
+++ b/.buildkite/scripts/unit_test_fipsonly.sh
@@ -5,14 +5,8 @@ set -euo pipefail
 source .buildkite/scripts/common.sh
 
 add_bin_path
-
-if [[ ${FIPS:-false} == "true" && ${GO_DISTRO:-stdlib} == "microsoft" ]]; then
-    with_msft_go
-else
-  with_go
-fi
-
+with_go
 with_mage
 
 echo "Starting the fips140=only unit tests..."
-mage test:unitFIPSOnly test:junitReport
+GODEBUG=fips140=only,tlsmlkem=0 mage test:unitFIPSOnly test:junitReport

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -1,5 +1,5 @@
 ARG GO_VERSION
-# Suffix should be main-debian11-fips or base-arm-debian11-fips
+# Suffix should be main-debian11 or base-arm-debian11
 ARG SUFFIX
 FROM docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-${SUFFIX} AS base
 
@@ -10,21 +10,22 @@ WORKDIR /fleet-server/
 
 # pre-copy/cache go.mod for pre-downloading dependencies and only redownloading them in subsequent builds if they change
 COPY go.mod go.sum ./
+# GOFIPS140 must be set before go mod download so that the golang.org/fips140 module is cached during image build.
+# Without this, the module would be fetched at build time by the host user who lacks write access to the module cache.
+ENV GOFIPS140=certified
+ENV FIPS=true
 RUN go mod download && go mod verify
 RUN go install github.com/magefile/mage # uses version in go.mod
 
 ENV PATH="$PATH:/go/bin"
-ENV FIPS=true
-ENV CGO_ENABLED=1
 ENV MAGEFILE_CACHE=/fleet-server/build/.magefile
-ENV MS_GOTOOLCHAIN_TELEMETRY_ENABLED=0
 ENTRYPOINT [ "mage" ]
 CMD [ "build:release" ]
 
 # FIPS docker image defined below
 # Does not use base as the lowest layer so we don't have to deal with user/ownership issues when building the image.
 ARG GO_VERSION
-# Suffix should be main-debian11-fips or base-arm-debian11-fips
+# Suffix should be main-debian11 or base-arm-debian11
 ARG SUFFIX
 FROM docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-${SUFFIX} AS builder
 
@@ -42,7 +43,7 @@ ARG DEV=""
 ARG SNAPSHOT=""
 ARG TARGETPLATFORM
 
-RUN MS_GOTOOLCHAIN_TELEMETRY_ENABLED=0 FIPS=true CGO_ENABLED=1 GCFLAGS="${GCFLAGS}" LDFLAGS="${LDFLAGS}" SNAPSHOT="${SNAPSHOT}" DEV="${DEV}" PLATFORMS="${TARGETPLATFORM}" mage build:release
+RUN FIPS=true GCFLAGS="${GCFLAGS}" LDFLAGS="${LDFLAGS}" SNAPSHOT="${SNAPSHOT}" DEV="${DEV}" PLATFORMS="${TARGETPLATFORM}" mage build:release
 
 FROM docker.elastic.co/wolfi/chainguard-base-fips:latest
 ARG VERSION

--- a/changelog/fragments/1781550341-Use-gos-FIPS-module-for-fips-artifacts.yaml
+++ b/changelog/fragments/1781550341-Use-gos-FIPS-module-for-fips-artifacts.yaml
@@ -1,0 +1,36 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Use go's FIPS module for fips artifacts
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+description: |
+  Use go's FIPS module instead of microsoft/go for creating FIPS artifacts.
+  Mechanically it sets GOFIPS140=certified at compile time which enables
+  FIPS mode but does not force it. The certified value ensures that the
+  latest certified go FIPS module is used when compiling.
+
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: fleet-server
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/docs/fips.md
+++ b/docs/fips.md
@@ -2,96 +2,30 @@
 
 **NOTE: FIPS Support is in-progress**
 
-The fleet-server can be built in a FIPS capable mode.
-This forces the use of a FIPS provider to handle any cryptographic calls.
-
-Currently FIPS is provided by compiling with the [microsoft/go](https://github.com/microsoft/go) distribution.
-This toolchain must be present for local compilation.
+The fleet-server can be built in a FIPS capable mode using Go's built-in FIPS 140-3 support via `GOFIPS140=certified`.
+This is pure Go and does not require an external crypto provider or CGO.
 
 ## Build changes
 
-As we are using micrsoft/go as a base we follow their conventions.
+FIPS builds require the `requirefips` build tag and `GOFIPS140=certified` set at compile time.
 
-Our FIPS changes require the `requirefips` build tag.
-When compiling `GOEXPERIMENT=systemcrypto` and `CGO_ENABLED=1` must be set.
-Additionally the `MS_GOTOOLCHAIN_TELEMETRY_ENABLED=0` env var is set to disable telemetry for [microsoft/go](https://github.com/microsoft/go).
-
-The `FIPS=true` env var is used by our magefile as the FIPS toggle.
-This env var applies to all targets, at a minimum the `requirefips` tag will be set.
-For targets that compile binaries, the `GOEXPERIMENT=systemcrypto` and `CGO_ENABLED=1` env vars are set.
-
-For developer conveniance, running `FIPS=true mage multipass` will provision a multipass VM with the Microsoft/go toolchain.
-See [Multipass VM Usage](#multipass-vm-usage) for additional details.
-
-### Multipass VM Usage
-
-A Multipass VM created with `FIPS=true mage multipass` is able to compile FIPS enabled golang programs, but is not able to run them.
-When you try to run one the following error occurs:
-```
-GODEBUG=fips140=on ./bin/fleet-server -c fleet-server.yml
-panic: opensslcrypto: can't enable FIPS mode for OpenSSL 3.0.13 30 Jan 2024: openssl: FIPS mode not supported by any provider
-
-goroutine 1 [running]:
-crypto/internal/backend.init.1()
-	/usr/local/go/src/crypto/internal/backend/openssl_linux.go:85 +0x210
-```
-
-In order to be  able to run a FIPS enabled binary, openssl must have a fips provider.
-Openssl [provides instructions on how to do this](https://github.com/openssl/openssl/blob/master/README-FIPS.md).
-
-A TLDR for our multipass container is:
-
-1. Download and compile the FIPS provider for openssl in the VM by running:
-```
-wget https://github.com/openssl/openssl/releases/download/openssl-3.0.13/openssl-3.0.13.tar.gz
-tar -xzf openssl-3.0.13.tar.gz
-cd openssl-3.0.13
-./Configure enable-fips
-make test
-sudo make install_fips
-sudo openssl fipsinstall -out /usr/local/ssl/fipsmodule.cnf -module /usr/local/lib/ossl-modules/fips.so
-```
-
-2. Copy the `fips.so` module to the system library, in order to find the location run:
-```
-openssl version -m
-```
-
-On my VM I would copy the `fips.so` module with:
-```
-sudo cp /usr/local/lib/ossl-modules/fips.so /usr/lib/aarch64-linux-gnu/ossl-modules/fips.so
-```
-
-3. Create an openssl.cnf for the program to use with the contents:
-```
-config_diagnostics = 1
-openssl_conf = openssl_init
-
-.include /usr/local/ssl/fipsmodule.cnf
-
-[openssl_init]
-providers = provider_sect
-alg_section = algorithm_sect
-
-[provider_sect]
-fips = fips_sect
-base = base_sect
-
-[base_sect]
-activate = 1
-
-[algorithm_sect]
-default_properties = fips=yes
-```
-
-4. Run the program with the `OPENSSL_CONF=openssl.cnf` and `GODEBUG=fips140=on` env vars, i.e.,
-```
-OPENSSL_CONF=./openssl.cnf GODEBUG=fips140=on ./bin/fleet-server -c fleet-server.yml
-23:48:47.871 INF Boot fleet-server args=["-c","fleet-server.yml"] commit=55104f6f ecs.version=1.6.0 exe=./bin/fleet-server pid=65037 ppid=5642 service.name=fleet-server service.type=fleet-server version=9.0.0
-i...
-```
+The `FIPS=true` env var is used by the magefile as the FIPS toggle.
+When set, the magefile automatically applies the `requirefips` tag and sets `GOFIPS140=certified` for all build and test targets.
 
 ## Usage
 
-Binaries produced with the `FIPS=true` env var will panic on startup if they cannot find a FIPS provider.
-The system/image is required to have a FIPS provider available.
+Binaries produced with `FIPS=true` will allow FIPS-approved algorithms at runtime when `GODEBUG=fips140=on` or enfoce them when `GODEBUG=fips140=only` is set.
+
+- `GODEBUG=fips140=on` - enables FIPS mode, falls back to non-FIPS for unsupported operations
+- `GODEBUG=fips140=only` - enforces strict FIPS mode, panics if a non-FIPS operation is attempted
+
+The FIPS docker image sets `GODEBUG=fips140=on` by default.
+
+## Testing
+
+Two unit test targets are available for FIPS testing:
+
+- `FIPS=true mage test:unit` - runs unit tests compiled with `requirefips` and `GOFIPS140=certified`
+- `FIPS=true mage test:unitFIPSOnly` - runs the above with `GODEBUG=fips140=only` enforced at runtime
+
+Note: `test:unitFIPSOnly` also sets `GODEBUG=tlsmlkem=0` to disable X25519MLKEM768, which is not FIPS-approved.

--- a/magefile.go
+++ b/magefile.go
@@ -126,11 +126,6 @@ var (
 		"windows/amd64",
 		"windows/arm64",
 	}
-	// plaformsFIPS is the list of all FIPS-capable platforms.
-	platformsFIPS = []string{
-		"linux/amd64",
-		"linux/arm64",
-	}
 
 	// platformsDocker is the list of all platforms that are supported by docker multiplatform builds.
 	platformsDocker = []string{
@@ -266,15 +261,11 @@ var (
 	// If a user specifies platforms through the env var, getPlatforms will filter out unsupported values.
 	// If as a result of this filtering no valid platforms are detected, the default list will be used.
 	getPlatforms = sync.OnceValue(func() []string {
-		list := platforms
-		if isFIPS() {
-			list = platformsFIPS
-		}
 		// If env var is used ensure values are supported.
 		if pList, ok := os.LookupEnv(envPlatforms); ok {
 			filtered := make([]string, 0)
 			for _, plat := range strings.Split(pList, ",") {
-				if slices.Contains(list, plat) {
+				if slices.Contains(platforms, plat) {
 					filtered = append(filtered, plat)
 				} else {
 					log.Printf("Skipping %q platform is not in the list of allowed platforms.", plat)
@@ -285,7 +276,7 @@ var (
 			}
 			log.Printf("%s env var detected but value %q does not contain valid platforms. Using default list.", envPlatforms, pList)
 		}
-		return list
+		return platforms
 	})
 
 	// getDockerPlatforms returns a list of supported docker multiplatform targets.
@@ -391,9 +382,7 @@ func environMap() map[string]string {
 
 // addFIPSEnvVars mutates the passed env map by adding settings needed to produce a FIPS-capable binary.
 func addFIPSEnvVars(env map[string]string) {
-	env["GOEXPERIMENT"] = "systemcrypto"
-	env["CGO_ENABLED"] = "1"
-	env["MS_GOTOOLCHAIN_TELEMETRY_ENABLED"] = "0"
+	env["GOFIPS140"] = "certified" // use the latest certified FIPS module.
 }
 
 // teeCommand runs the specified command, stdout and stederr will be written to stdout and will be collected and returned.
@@ -417,14 +406,10 @@ func Platforms() {
 }
 
 // Multipass launches a mulitpass instance for development.
-// FIPS may be used  to provision microsoft/go in the VM.
 func Multipass() error {
 	params := map[string]string{
 		"Arch":        runtime.GOARCH,
 		"DownloadURL": fmt.Sprintf("https://go.dev/dl/go%s.linux-%s.tar.gz", getGoVersion(), runtime.GOARCH),
-	}
-	if isFIPS() {
-		params["DownloadURL"] = fmt.Sprintf("https://aka.ms/golang/release/latest/go%s.linux-%s.tar.gz", getGoVersion(), runtime.GOARCH)
 	}
 
 	// write the multipass-cloud-init.yml to launch the instance
@@ -965,7 +950,7 @@ func packageNix(osArg, archArg string) error {
 // Builder creates a docker image used to cross-compile binaries.
 // This image is only built locally and should not be pushed to remote registries.
 // Image produced is tagged as: fleet-server-builder:$GO_VERSION
-// FIPS is used to create ina image that has the microsoft/go tool available so FIPS binaries may be compiled.
+// FIPS is used to create an image that can compile FIPS-capable binaries.
 func (Docker) Builder() error {
 	suffix := dockerSuffix
 	if runtime.GOARCH == "arm64" {
@@ -974,7 +959,7 @@ func (Docker) Builder() error {
 
 	args := []string{"build", "-t", dockerBuilderName + ":" + getGoVersion(), "--build-arg", "GO_VERSION=" + getGoVersion()}
 	if isFIPS() {
-		args = append(args, "-f", dockerBuilderFIPS, "--build-arg", "SUFFIX="+suffix+"-fips", "--target", "base", ".")
+		args = append(args, "-f", dockerBuilderFIPS, "--build-arg", "SUFFIX="+suffix, "--target", "base", ".")
 	} else {
 		args = append(args, "-f", dockerBuilderFile, "--build-arg", "SUFFIX="+suffix, ".")
 	}
@@ -1061,7 +1046,6 @@ func (Docker) Image() error {
 	if isFIPS() {
 		dockerFile = dockerBuilderFIPS
 		image += "-fips"
-		suffix += "-fips"
 	}
 	if v, ok := os.LookupEnv(envDockerImage); ok && v != "" {
 		image = v
@@ -1105,7 +1089,6 @@ func (Docker) Publish() error {
 	if isFIPS() {
 		dockerFile = dockerBuilderFIPS
 		image += "-fips"
-		suffix += "-fips"
 	}
 	if v, ok := os.LookupEnv(envDockerImage); ok && v != "" {
 		image = v
@@ -1228,6 +1211,10 @@ func (Docker) CustomAgentImage() error {
 // TEST_RUN can be used to pass the value to go test -run.
 func (Test) Unit() error {
 	mg.Deps(mg.F(mkDir, "build"))
+	env := environMap()
+	if isFIPS() {
+		addFIPSEnvVars(env)
+	}
 	args := []string{
 		"test",
 		"-tags=" + getTagsString(),
@@ -1239,13 +1226,12 @@ func (Test) Unit() error {
 		args = append(args, "-run", v)
 	}
 	args = append(args, "./...")
-	output, err := teeCommand(environMap(), "go", args...)
+	output, err := teeCommand(env, "go", args...)
 	err = errors.Join(err, os.WriteFile(filepath.Join("build", "test-unit-"+runtime.GOOS+".out"), output, 0o644))
 	return err
 }
 
 // UnitFIPSOnly runs unit tests and injects GODEBUG=fips140=only into the environment.
-// This is done because mage may have issues when running with fips140=only set.
 // Produces a unit test output file, and test coverage file in the build directory.
 // SNAPSHOT adds the snapshot build tag.
 // FIPS adds the requirefips build tag.
@@ -1253,12 +1239,12 @@ func (Test) Unit() error {
 func (Test) UnitFIPSOnly() error {
 	mg.Deps(mg.F(mkDir, "build"))
 
-	// We also set GODEBUG=tlsmlkem=0 to disable the X25519MLKEM768 TLS key
-	// exchange mechanism; without this setting and with the GODEBUG=fips140=only
-	// setting, we get errors in tests like so:
-	// Failed to connect: crypto/ecdh: use of X25519 is not allowed in FIPS 140-only mode
-	// Note that we are only disabling this TLS key exchange mechanism in tests!
+	// GODEBUG=tlsmlkem=0 disables X25519MLKEM768; without it, GODEBUG=fips140=only
+	// causes test failures: crypto/ecdh: use of X25519 is not allowed in FIPS 140-only mode
 	env := environMap()
+	if isFIPS() {
+		addFIPSEnvVars(env)
+	}
 	env["GODEBUG"] = "fips140=only,tlsmlkem=0"
 	args := []string{
 		"test",
@@ -1322,6 +1308,9 @@ func (Test) IntegrationRun(ctx context.Context) error {
 	env["ELASTICSEARCH_SERVICE_TOKEN"] = esToken
 	env["REMOTE_ELASTICSEARCH_SERVICE_TOKEN"] = esRemoteToken
 	env["REMOTE_ELASTICSEARCH_CA_CRT_BASE64"] = remoteCA
+	if isFIPS() {
+		addFIPSEnvVars(env)
+	}
 	args := []string{
 		"test",
 		"-v",
@@ -1651,7 +1640,7 @@ func checkFIPSBinary(path string) error {
 	if err != nil {
 		return fmt.Errorf("unable to read buildinfo: %w", err)
 	}
-	var checkLinks, foundTags, foundExperiment bool
+	var foundTags, foundFIPS140 bool
 
 	for _, setting := range info.Settings {
 		switch setting.Key {
@@ -1660,17 +1649,10 @@ func checkFIPSBinary(path string) error {
 			if !strings.Contains(setting.Value, "requirefips") {
 				return fmt.Errorf("requirefips tag not found in %s", setting.Value)
 			}
-			continue
-		case "GOEXPERIMENT":
-			foundExperiment = true
-			if !strings.Contains(setting.Value, "systemcrypto") {
-				return fmt.Errorf("did not find GOEXPIRIMENT=systemcrypto")
-			}
-			continue
-		case "-ldflags":
-			if !strings.Contains(setting.Value, "-s") {
-				checkLinks = true
-				continue
+		case "GOFIPS140":
+			foundFIPS140 = true
+			if setting.Value == "" {
+				return fmt.Errorf("GOFIPS140 is empty in build settings")
 			}
 		}
 	}
@@ -1678,18 +1660,8 @@ func checkFIPSBinary(path string) error {
 	if !foundTags {
 		return fmt.Errorf("did not find build tags")
 	}
-	if !foundExperiment {
-		return fmt.Errorf("did not find GOEXPERIMENT")
-	}
-	if checkLinks {
-		log.Println("Binary is not stripped, checking symbols table.")
-		output, err := sh.Output("go", "tool", "nm", path)
-		if err != nil {
-			return fmt.Errorf("go tool nm failed: %w", err)
-		}
-		if runtime.GOOS == "linux" && !strings.Contains(output, "OpenSSL_version") { // TODO may need different check for windows/darwin
-			return fmt.Errorf("failed to find OpenSSL symbol links within binary")
-		}
+	if !foundFIPS140 {
+		return fmt.Errorf("did not find GOFIPS140 in build settings")
 	}
 	return nil
 }
@@ -2153,7 +2125,6 @@ func (Test) E2eRun(ctx context.Context) error {
 		"ELASTICSEARCH_SERVICE_TOKEN="+esToken,
 		"AGENT_E2E_IMAGE="+string(p),
 		"STANDALONE_E2E_IMAGE="+image+":"+tag,
-		"CGO_ENABLED=1",
 	)
 
 	var b bytes.Buffer
@@ -2194,8 +2165,7 @@ func (Test) ConvertCoverage() error {
 	return sh.RunV("go", "tool", "covdata", "textfmt", "-i="+filepath.Join("build", "e2e-cover"), "-o="+filepath.Join("build", "e2e-coverage.out"))
 }
 
-// FipsProviderUnit runs unit tests with all FIPS env vars and tags.
-// It requires microsoft/go and a FIPS provider on the system.
+// FipsProviderUnit runs unit tests with GOFIPS140=v1.0.0 set and the requirefips build tag.
 // Produces a unit test output file, and test coverage file in the build directory.
 func (Test) FipsProviderUnit() error {
 	mg.Deps(mg.F(mkDir, "build"))


### PR DESCRIPTION
## What is the problem this PR solves?

Use go's FIPS module when compiling artifacts.

## How does this PR solve the problem?

Replace all uses of microsoft/go which links to a crypto library on the system (such as OpenSSL) that has a FIPS provider to using go's newly certified FIPS provider that is a part of the standard library.

This is set at compile-time with the env var [`GOFIPS140=certified`](https://go.dev/doc/security/fips140#the-gofips140-environment-variable) variable that enables FIPS mode (but does not force GODEBUG=fips140=only).

Additionally this change builds and releases FIPS windows/amd64 and windows/arm64 artifacts.

## How to test this PR locally

`FIPS=true mage docker:release`

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)