### PR TITLE
Use copilot-requests: write instead of COPILOT_GITHUB_TOKEN secret

### DIFF
--- a/.github/workflows/trigger-pr-buildkite-detective.yml
+++ b/.github/workflows/trigger-pr-buildkite-detective.yml
@@ -5,6 +5,7 @@ on:
 permissions:
   actions: read
   contents: read
+  copilot-requests: write
   issues: write
   pull-requests: write  # required by gh-aw compiler for add-comment
 
@@ -18,5 +19,4 @@ jobs:
       additional-instructions: |
         If a step fails, check if the failure is reported as a GitHub issue labeled `flaky-test`. Reference the GitHub issue if so. 
     secrets:
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
       BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_LOGS_API_TOKEN }}


### PR DESCRIPTION
As of [2026-06-11](https://github.blog/changelog/2026-06-11-agentic-workflows-no-longer-need-a-personal-access-token/), agentic workflows no longer require a PAT. This removes the `COPILOT_GITHUB_TOKEN` secret and replaces it with the built-in `copilot-requests: write` permission across all 43 caller workflows that use `elastic/ai-github-actions/`.


**Before / After:**
```yaml
# Before
permissions:
  actions: read
  contents: read
  issues: write
...
secrets:
  COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

# After
permissions:
  actions: read
  contents: read
  copilot-requests: write
  issues: write
```