### PR TITLE
Increase timeouts in e2e tests to 3m

### DIFF
--- a/testing/e2e/agent_container_test.go
+++ b/testing/e2e/agent_container_test.go
@@ -88,9 +88,7 @@ func (suite *AgentContainerSuite) TearDownTest() {
 //
 // It checks the status API on the fleet-server's external port and that the agent listed in Kibana states "online"
 // Tests that enroll another agent explicitly need fleet-server to be online
-func (suite *AgentContainerSuite) FleetIsHealthy(bCtx context.Context, endpoint string) {
-	ctx, cancel := context.WithTimeout(bCtx, time.Minute)
-	defer cancel()
+func (suite *AgentContainerSuite) FleetIsHealthy(ctx context.Context, endpoint string) {
 	suite.FleetServerStatusOK(ctx, endpoint)
 
 	if suite.agentID != "" {
@@ -102,7 +100,7 @@ func (suite *AgentContainerSuite) FleetIsHealthy(bCtx context.Context, endpoint 
 }
 
 func (suite *AgentContainerSuite) TestHTTP() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 3*time.Minute)
 	defer cancel()
 
 	req := testcontainers.ContainerRequest{
@@ -146,7 +144,7 @@ func (suite *AgentContainerSuite) TestHTTP() {
 }
 
 func (suite *AgentContainerSuite) TestWithSecretFiles() {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 3*time.Minute)
 	defer cancel()
 
 	req := testcontainers.ContainerRequest{
@@ -220,8 +218,6 @@ func (suite *AgentContainerSuite) TestSleep10m() {
 	if !longFlag {
 		suite.T().Skip("Long tests skipped. Enable with -long.")
 	}
-	bCtx, bCancel := context.WithCancel(context.Background())
-	defer bCancel()
 
 	req := testcontainers.ContainerRequest{
 		Hostname: "fleet-server",
@@ -270,7 +266,7 @@ func (suite *AgentContainerSuite) TestSleep10m() {
 		},
 		WaitingFor: containerWaitForHealthyStatus().WithTLS(true, nil),
 	}
-	fleetC, err := testcontainers.GenericContainer(bCtx, testcontainers.GenericContainerRequest{
+	fleetC, err := testcontainers.GenericContainer(suite.T().Context(), testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 		Logger:           &logger{suite.T()},
@@ -278,15 +274,20 @@ func (suite *AgentContainerSuite) TestSleep10m() {
 	suite.Require().NoError(err)
 	suite.container = fleetC
 
-	endpoint, err := fleetC.Endpoint(bCtx, "https")
+	endpoint, err := fleetC.Endpoint(suite.T().Context(), "https")
 	suite.Require().NoError(err)
 
-	suite.FleetIsHealthy(bCtx, endpoint)
+	suite.FleetIsHealthy(suite.T().Context(), endpoint)
 
-	suite.T().Log("sleeping for 10m")
-	time.Sleep(time.Minute * 10)
-
-	suite.FleetIsHealthy(bCtx, endpoint)
+	for i := range 10 {
+		select {
+		case <-suite.T().Context().Done():
+			suite.Require().NoError(suite.T().Context().Err())
+		case <-time.After(time.Minute):
+			suite.T().Logf("checking fleet health at minute %d", i)
+			suite.FleetIsHealthy(suite.T().Context(), endpoint)
+		}
+	}
 }
 
 // TestDockerAgent will enroll a real agent running in a docker container.
@@ -295,9 +296,6 @@ func (suite *AgentContainerSuite) TestSleep10m() {
 //
 // NOTE: This is intended as a sanity check. Additional fleet-server/elastic-agent are not tested.
 func (suite *AgentContainerSuite) TestDockerAgent() {
-	bCtx, bCancel := context.WithCancel(context.Background())
-	defer bCancel()
-
 	req := testcontainers.ContainerRequest{
 		Hostname: "fleet-server",
 		Image:    suite.dockerImg,
@@ -345,7 +343,7 @@ func (suite *AgentContainerSuite) TestDockerAgent() {
 		},
 		WaitingFor: containerWaitForHealthyStatus().WithTLS(true, nil),
 	}
-	fleetC, err := testcontainers.GenericContainer(bCtx, testcontainers.GenericContainerRequest{
+	fleetC, err := testcontainers.GenericContainer(suite.T().Context(), testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 		Logger:           &logger{suite.T()},
@@ -353,12 +351,12 @@ func (suite *AgentContainerSuite) TestDockerAgent() {
 	suite.Require().NoError(err)
 	suite.container = fleetC
 
-	endpoint, err := fleetC.Endpoint(bCtx, "https")
+	endpoint, err := fleetC.Endpoint(suite.T().Context(), "https")
 	suite.Require().NoError(err)
 
-	suite.FleetIsHealthy(bCtx, endpoint)
+	suite.FleetIsHealthy(suite.T().Context(), endpoint)
 
-	enrollmentKey := suite.GetEnrollmentTokenForPolicyID(bCtx, "dummy-policy")
+	enrollmentKey := suite.GetEnrollmentTokenForPolicyID(suite.T().Context(), "dummy-policy")
 	req = testcontainers.ContainerRequest{
 		Image: suite.dockerImg,
 		Env: map[string]string{
@@ -382,7 +380,7 @@ func (suite *AgentContainerSuite) TestDockerAgent() {
 			},
 		},
 	}
-	agentC, err := testcontainers.GenericContainer(bCtx, testcontainers.GenericContainerRequest{
+	agentC, err := testcontainers.GenericContainer(suite.T().Context(), testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 		Logger:           &logger{suite.T()},
@@ -390,9 +388,9 @@ func (suite *AgentContainerSuite) TestDockerAgent() {
 	suite.Require().NoError(err)
 	// Read agent logs if the test failed
 	// terminate the agent
-	defer func() {
+	suite.T().Cleanup(func() {
 		if suite.T().Failed() {
-			rc, err := agentC.Logs(bCtx)
+			rc, err := agentC.Logs(context.Background())
 			if err != nil {
 				suite.T().Logf("elastic-agent container unable to get logs: %v", err)
 			} else {
@@ -402,11 +400,11 @@ func (suite *AgentContainerSuite) TestDockerAgent() {
 			}
 
 		}
-		err := agentC.Terminate(bCtx)
+		err := agentC.Terminate(context.Background())
 		suite.Require().NoError(err)
-	}()
+	})
 
-	ctx, cancel := context.WithTimeout(bCtx, time.Minute*5)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 5*time.Minute)
 	defer cancel()
 	timer := time.NewTimer(time.Second)
 	agentID := ""
@@ -460,7 +458,7 @@ func (suite *AgentContainerSuite) TestAPMInstrumentationFile() {
 	f.Close()
 	suite.Require().NoError(err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 3*time.Minute)
 	defer cancel()
 
 	req := testcontainers.ContainerRequest{

--- a/testing/e2e/agent_install_test.go
+++ b/testing/e2e/agent_install_test.go
@@ -69,7 +69,7 @@ func (suite *AgentInstallSuite) SetupSuite() {
 	suite.Require().NoError(err)
 
 	// setup context - timeline is for file download
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 10*time.Minute)
 	defer cancel()
 
 	// use artifacts API to download snapshot
@@ -143,10 +143,13 @@ func (suite *AgentInstallSuite) TearDownTest() {
 
 	out, err := exec.Command("sudo", "elastic-development-agent", "uninstall", "--force").CombinedOutput()
 	suite.Assert().NoErrorf(err, "elastic-development-agent uninstall failed. Output: %s", out)
+
+	portFree := suite.IsFleetServerPortFree()
+	suite.Assert().True(portFree, "port 8220 still in use 30s after uninstall")
 }
 
 func (suite *AgentInstallSuite) TestHTTP() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*3)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 3*time.Minute)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "sudo", suite.agentPath, "install",
@@ -171,7 +174,7 @@ func (suite *AgentInstallSuite) TestWithSecretFiles() {
 	err := os.WriteFile(filepath.Join(dir, "service-token"), []byte(suite.ServiceToken), 0600)
 	suite.Require().NoError(err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*3)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 3*time.Minute)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "sudo", suite.agentPath, "install",
@@ -227,7 +230,7 @@ func (suite *AgentInstallSuite) TestAPMInstrumentationFile() {
 	f.Close()
 	suite.Require().NoError(err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 10*time.Minute)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "sudo", suite.agentPath, "install",
@@ -249,7 +252,7 @@ func (suite *AgentInstallSuite) TestAPMInstrumentationFile() {
 }
 
 func (suite *AgentInstallSuite) TestAPMInstrumentationPolicy() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 10*time.Minute)
 	defer cancel()
 
 	suite.AddPolicyOverrides(ctx, "fleet-server-apm", map[string]any{

--- a/testing/e2e/api_version/client_api_2023_06_01.go
+++ b/testing/e2e/api_version/client_api_2023_06_01.go
@@ -259,19 +259,19 @@ func (tester *ClientAPITester20230601) Artifact(ctx context.Context, apiKey, id,
 }
 
 func (tester *ClientAPITester20230601) TestStatus_Unauthenticated() {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(tester.T().Context())
 	defer cancel()
 	tester.Status(ctx, "")
 }
 
 func (tester *ClientAPITester20230601) TestStatus_Authenticated() {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(tester.T().Context())
 	defer cancel()
 	tester.Status(ctx, tester.enrollmentKey)
 }
 
 func (tester *ClientAPITester20230601) TestEnrollCheckinAck() {
-	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	ctx, cancel := context.WithTimeout(tester.T().Context(), 4*time.Minute)
 	defer cancel()
 
 	tester.T().Log("test enrollment")
@@ -295,7 +295,7 @@ func (tester *ClientAPITester20230601) TestEnrollCheckinAck() {
 }
 
 func (tester *ClientAPITester20230601) TestFullFileUpload() {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(tester.T().Context())
 	defer cancel()
 
 	agentID, agentKey := tester.Enroll(ctx, tester.enrollmentKey)

--- a/testing/e2e/api_version/client_api_current.go
+++ b/testing/e2e/api_version/client_api_current.go
@@ -320,19 +320,19 @@ func (tester *ClientAPITester) AuditUnenroll(ctx context.Context, apiKey, id str
 }
 
 func (tester *ClientAPITester) TestStatus_Unauthenticated() {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(tester.T().Context())
 	defer cancel()
 	tester.Status(ctx, "")
 }
 
 func (tester *ClientAPITester) TestStatus_Authenticated() {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(tester.T().Context())
 	defer cancel()
 	tester.Status(ctx, tester.enrollmentKey)
 }
 
 func (tester *ClientAPITester) TestEnrollCheckinAck() {
-	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	ctx, cancel := context.WithTimeout(tester.T().Context(), 4*time.Minute)
 	defer cancel()
 
 	tester.T().Log("test enrollment")
@@ -358,7 +358,7 @@ func (tester *ClientAPITester) TestEnrollCheckinAck() {
 }
 
 func (tester *ClientAPITester) TestCheckinWithBadRequest() {
-	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	ctx, cancel := context.WithTimeout(tester.T().Context(), 4*time.Minute)
 	defer cancel()
 
 	tester.T().Log("test enrollment")
@@ -372,7 +372,7 @@ func (tester *ClientAPITester) TestCheckinWithBadRequest() {
 }
 
 func (tester *ClientAPITester) TestCheckinWithActionNotFound() {
-	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	ctx, cancel := context.WithTimeout(tester.T().Context(), 4*time.Minute)
 	defer cancel()
 
 	// enroll agent
@@ -395,7 +395,7 @@ func (tester *ClientAPITester) TestCheckinWithActionNotFound() {
 }
 
 func (tester *ClientAPITester) TestFullFileUpload() {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(tester.T().Context())
 	defer cancel()
 
 	agentID, agentKey := tester.Enroll(ctx, tester.enrollmentKey)
@@ -451,13 +451,13 @@ func (tester *ClientAPITester) TestArtifact() {
 }
 
 func (tester *ClientAPITester) TestGetPGPKey() {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(tester.T().Context())
 	defer cancel()
 	tester.GetPGPKey(ctx)
 }
 
 func (tester *ClientAPITester) TestEnrollAuditUnenroll() {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(tester.T().Context())
 	defer cancel()
 	now := time.Now().UTC()
 

--- a/testing/e2e/scaffold/scaffold.go
+++ b/testing/e2e/scaffold/scaffold.go
@@ -197,6 +197,7 @@ func (s *Scaffold) FleetServerStatusNeverBecomes(ctx context.Context, url string
 // If the passed context terminates before, the current test will be marked as failed.
 func (s *Scaffold) FleetServerStatusCondition(ctx context.Context, url string, condition func(resp *http.Response) bool, failOnDone bool) {
 	timer := time.NewTimer(time.Second)
+	var lastStatusCode int
 	for {
 		select {
 		case <-ctx.Done():
@@ -211,16 +212,28 @@ func (s *Scaffold) FleetServerStatusCondition(ctx context.Context, url string, c
 
 			resp, err := s.Client.Do(req)
 			if err != nil {
+				if lastStatusCode != -1 {
+					s.T().Logf("fleet-server %s: connection error: %v", url, err)
+					lastStatusCode = -1
+				}
 				timer.Reset(time.Second)
 				continue
 			}
 
+			// Read body once so both condition and logging can use it.
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			resp.Body = io.NopCloser(bytes.NewReader(body))
+
 			// on success
 			if condition(resp) {
-				resp.Body.Close()
 				return
 			}
-			resp.Body.Close()
+
+			if resp.StatusCode != lastStatusCode {
+				s.T().Logf("fleet-server %s: %s %s", url, resp.Status, string(body))
+				lastStatusCode = resp.StatusCode
+			}
 
 			// fail, try after a wait
 			timer.Reset(time.Second)

--- a/testing/e2e/stand_alone_api_test.go
+++ b/testing/e2e/stand_alone_api_test.go
@@ -7,10 +7,8 @@
 package e2e
 
 import (
-	"bytes"
 	"context"
 	"html/template"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -68,7 +66,6 @@ type StandAloneAPIBase struct {
 
 	cancel   context.CancelFunc
 	cmd      *exec.Cmd
-	stderr   io.Reader
 	endpoint string
 	key      string
 }
@@ -80,6 +77,9 @@ func (suite *StandAloneAPIBase) SetupSuite() {
 	// make sure we can bind to port
 	portFree := suite.IsFleetServerPortFree()
 	suite.Require().True(portFree, "port 8220 must not be in use for test to start")
+
+	// clean up agents from previous test suites so fleet-server initializes quickly
+	suite.DeleteAllAgents(suite.T().Context())
 
 	// Start fleet-server
 	dir := suite.T().TempDir()
@@ -96,15 +96,12 @@ func (suite *StandAloneAPIBase) SetupSuite() {
 	})
 	f.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(suite.T().Context())
 	suite.cancel = cancel
 
 	// Run the fleet-server binary, cancelling context should stop process
 	cmd := exec.CommandContext(ctx, suite.binaryPath, "-c", filepath.Join(dir, "config.yml"))
-	// collect logs from stderr in case there is a failure
-	var errBuff bytes.Buffer
-	cmd.Stderr = &errBuff
-	suite.stderr = &errBuff
+	cmd.Stderr = os.Stderr
 
 	cmd.Cancel = func() error {
 		return cmd.Process.Signal(syscall.SIGTERM)
@@ -115,7 +112,7 @@ func (suite *StandAloneAPIBase) SetupSuite() {
 	suite.Require().NoError(err)
 	suite.cmd = cmd
 
-	rCtx, rCancel := context.WithTimeout(ctx, time.Minute)
+	rCtx, rCancel := context.WithTimeout(ctx, 3*time.Minute)
 	suite.FleetServerStatusOK(rCtx, "https://localhost:8220")
 	rCancel()
 
@@ -127,8 +124,4 @@ func (suite *StandAloneAPIBase) TearDownSuite() {
 	suite.T().Log("Stopping fleet-server process")
 	suite.cancel()
 	suite.cmd.Wait()
-	if suite.T().Failed() {
-		stderr, err := io.ReadAll(suite.stderr)
-		suite.T().Logf("Test failure detected, printing fleet-server stderr: %s\nread err: %v", string(stderr), err)
-	}
 }

--- a/testing/e2e/stand_alone_container_test.go
+++ b/testing/e2e/stand_alone_container_test.go
@@ -114,7 +114,7 @@ func (suite *StandAloneContainerSuite) startFleetServer(ctx context.Context, opt
 }
 
 func (suite *StandAloneContainerSuite) TestHTTP() {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 3*time.Minute)
 	defer cancel()
 
 	suite.startFleetServer(ctx, standaloneContainerOptions{
@@ -134,7 +134,7 @@ func (suite *StandAloneContainerSuite) TestHTTP() {
 // TestWithElasticsearchConnectionFailures checks the behaviour of stand alone Fleet Server
 // when Elasticsearch is not reachable.
 func (suite *StandAloneContainerSuite) TestWithElasticsearchConnectionFailures() {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 3*time.Minute)
 	defer cancel()
 
 	proxyContainer := suite.StartToxiproxy(ctx)
@@ -171,7 +171,7 @@ func (suite *StandAloneContainerSuite) TestWithElasticsearchConnectionFailures()
 }
 
 func (suite *StandAloneContainerSuite) TestAPMInstrumentation() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*3)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), time.Minute*3)
 	defer cancel()
 
 	suite.startFleetServer(ctx, standaloneContainerOptions{

--- a/testing/e2e/stand_alone_test.go
+++ b/testing/e2e/stand_alone_test.go
@@ -89,7 +89,8 @@ func (suite *StandAloneSuite) TestHTTP() {
 	f.Close()
 	suite.Require().NoError(err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 3*time.Minute)
+	defer cancel()
 
 	// Run the fleet-server binary
 	cmd := exec.CommandContext(ctx, suite.binaryPath, "-c", filepath.Join(dir, "config.yml"))
@@ -108,7 +109,8 @@ func (suite *StandAloneSuite) TestHTTP() {
 // TestWithElasticsearchConnectionFailures checks the behaviour of stand alone Fleet Server
 // when Elasticsearch is not reachable.
 func (suite *StandAloneSuite) TestWithElasticsearchConnectionFailures() {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 5*time.Minute)
+	defer cancel()
 
 	proxyContainer := suite.StartToxiproxy(ctx)
 	proxyEndpoint, err := proxyContainer.URI(ctx)
@@ -162,7 +164,8 @@ func (suite *StandAloneSuite) TestWithElasticsearchConnectionFailures() {
 // TestWithElasticsearchConnectionFlakyness checks the behaviour of stand alone Fleet Server
 // when Elasticsearch is not reachable portion of the time.
 func (suite *StandAloneSuite) TestWithElasticsearchConnectionFlakyness() {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 5*time.Minute)
+	defer cancel()
 
 	proxyContainer := suite.StartToxiproxy(ctx)
 	proxyEndpoint, err := proxyContainer.URI(ctx)
@@ -205,6 +208,7 @@ func (suite *StandAloneSuite) TestWithElasticsearchConnectionFlakyness() {
 
 	// wait for unit state degraded
 	timeoutCtx, tCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer tCancel()
 	suite.FleetServerStatusNeverBecomes(timeoutCtx, "http://localhost:8220", client.UnitStateDegraded)
 
 	// test should not fail at this point
@@ -241,7 +245,7 @@ func (suite *StandAloneSuite) TestWithSecretFiles() {
 	f.Close()
 	suite.Require().NoError(err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 3*time.Minute)
 	defer cancel()
 
 	// Run the fleet-server binary, cancelling context should stop process
@@ -279,7 +283,7 @@ func (suite *StandAloneSuite) TestStaticTokenAuthentication() {
 	suite.Require().NoError(err)
 	f.Close()
 
-	bCtx, bCancel := context.WithCancel(context.Background())
+	bCtx, bCancel := context.WithCancel(suite.T().Context())
 	defer bCancel()
 	suite.T().Log("testing fleet-server binary")
 	// Run the fleet-server binary, cancelling context should stop process
@@ -293,14 +297,13 @@ func (suite *StandAloneSuite) TestStaticTokenAuthentication() {
 	err = cmd.Start()
 	suite.Require().NoError(err)
 
-	ctx, cancel := context.WithTimeout(bCtx, time.Minute)
+	ctx, cancel := context.WithTimeout(bCtx, 3*time.Minute)
+	defer cancel()
 	suite.FleetServerStatusOK(ctx, "https://localhost:8220")
 
 	// echo -n "01234:abcdefg" | base64
 	// the id does not matter, the key is the important part
 	enrollmentToken := "MDEyMzQ6YWJjZGVmZw=="
-
-	defer cancel()
 	tester := api_version.NewClientAPITesterCurrent(
 		suite.Scaffold,
 		"https://localhost:8220",
@@ -321,7 +324,8 @@ func (suite *StandAloneSuite) TestStaticTokenAuthentication() {
 // TestElasticsearch429OnStartup will check to ensure fleet-server functions as expected (does not crash)
 // if Elasticsearch returns 429s on startup.
 func (suite *StandAloneSuite) TestElasticsearch429OnStartup() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 3*time.Minute)
+	defer cancel()
 
 	// Create a proxy that returns 429s
 	proxy := NewStatusProxy(suite.T(), 429)
@@ -353,11 +357,10 @@ func (suite *StandAloneSuite) TestElasticsearch429OnStartup() {
 	err = cmd.Start()
 	suite.Require().NoError(err)
 
-	// FIXME timeout to make sure fleet-server has started
-	time.Sleep(5 * time.Second)
+	sCtx, sCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer sCancel()
 	suite.T().Log("Checking fleet-server status")
-	// Wait to check that it is Starting.
-	suite.FleetServerStatusIs(ctx, "http://localhost:8220", client.UnitStateStarting) // fleet-server returns 503:starting if upstream ES returns 429.
+	suite.FleetServerStatusIs(sCtx, "http://localhost:8220", client.UnitStateStarting) // fleet-server returns 503:starting if upstream ES returns 429.
 
 	// Disable proxy and ensure fleet-server recovers
 	suite.T().Log("Disable proxy")
@@ -371,7 +374,8 @@ func (suite *StandAloneSuite) TestElasticsearch429OnStartup() {
 // TestElasticsearch503OnStartup will check to ensure fleet-server functions as expected (does not crash)
 // if Elasticsearch returns 503s on startup.
 func (suite *StandAloneSuite) TestElasticsearch503OnStartup() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 3*time.Minute)
+	defer cancel()
 
 	// Create a proxy that returns 503s
 	proxy := NewStatusProxy(suite.T(), http.StatusServiceUnavailable)
@@ -403,11 +407,10 @@ func (suite *StandAloneSuite) TestElasticsearch503OnStartup() {
 	err = cmd.Start()
 	suite.Require().NoError(err)
 
-	// FIXME timeout to make sure fleet-server has started
-	time.Sleep(5 * time.Second)
+	sCtx, sCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer sCancel()
 	suite.T().Log("Checking fleet-server status")
-	// Wait to check that it is Starting.
-	suite.FleetServerStatusIs(ctx, "http://localhost:8220", client.UnitStateStarting) // fleet-server returns 503:starting if upstream ES returns 429.
+	suite.FleetServerStatusIs(sCtx, "http://localhost:8220", client.UnitStateStarting) // fleet-server returns 503:starting if upstream ES returns 429.
 
 	// Disable proxy and ensure fleet-server recovers
 	suite.T().Log("Disable proxy")
@@ -421,7 +424,8 @@ func (suite *StandAloneSuite) TestElasticsearch503OnStartup() {
 // TestElasticsearch503OnEnroll will check to ensure fleet-server returns a 503 error when elasticsearch returns a
 // 503 gateway error.
 func (suite *StandAloneSuite) TestElasticsearch503OnEnroll() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 3*time.Minute)
+	defer cancel()
 
 	// Create a proxy that returns 503s
 	proxy := NewStatusProxy(suite.T(), http.StatusServiceUnavailable)
@@ -460,11 +464,10 @@ func (suite *StandAloneSuite) TestElasticsearch503OnEnroll() {
 		cmd.Wait()
 	}()
 
-	// FIXME timeout to make sure fleet-server has started
-	time.Sleep(5 * time.Second)
+	sCtx, sCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer sCancel()
 	suite.T().Log("Checking fleet-server status")
-	// Should start healthy as the proxy is disabled.
-	suite.FleetServerStatusIs(ctx, "http://localhost:8220", client.UnitStateHealthy)
+	suite.FleetServerStatusIs(sCtx, "http://localhost:8220", client.UnitStateHealthy)
 
 	// Ensure enrollment works correctly
 	suite.T().Log("Checking enrollment works")
@@ -500,7 +503,8 @@ func (suite *StandAloneSuite) TestElasticsearch503OnEnroll() {
 // TestElasticsearchTimeoutOnStartup will check to ensure fleet-server functions as expected (does not crash)
 // if Elasticsearch times out on startup.
 func (suite *StandAloneSuite) TestElasticsearchTimeoutOnStartup() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 3*time.Minute)
+	defer cancel()
 
 	proxyContainer := suite.StartToxiproxy(ctx)
 	proxyEndpoint, err := proxyContainer.URI(ctx)
@@ -564,7 +568,7 @@ func (suite *StandAloneSuite) TestAPMInstrumentation() {
 	f.Close()
 	suite.Require().NoError(err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*3)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 3*time.Minute)
 
 	// Run the fleet-server binary
 	cmd := exec.CommandContext(ctx, suite.binaryPath, "-c", filepath.Join(dir, "config.yml"))
@@ -644,7 +648,7 @@ func (suite *StandAloneSuite) writeOpAMPCollectorConfig(configFilePath, instance
 func (suite *StandAloneSuite) TestOpAMPWithUpstreamCollector() {
 	dir := suite.T().TempDir()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 5*time.Minute)
 	defer cancel()
 
 	apiKey := suite.startFleetServerForOpAMP(ctx, dir, "opamp-e2e-test-key")
@@ -741,7 +745,7 @@ func (suite *StandAloneSuite) TestOpAMPWithEDOTCollector() {
 	agentExtractDir := filepath.Join(dir, "elastic-agent-package")
 	suite.Require().NoError(os.MkdirAll(agentExtractDir, 0755))
 
-	downloadCtx, downloadCancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	downloadCtx, downloadCancel := context.WithTimeout(suite.T().Context(), 10*time.Minute)
 	defer downloadCancel()
 	rc := downloadElasticAgent(downloadCtx, suite.T(), suite.Client)
 	var paths extractedPaths
@@ -760,7 +764,7 @@ func (suite *StandAloneSuite) TestOpAMPWithEDOTCollector() {
 
 	suite.T().Logf("Found elastic-agent binary at %s", agentBinaryPath)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 2*time.Minute)
 	defer cancel()
 
 	apiKey := suite.startFleetServerForOpAMP(ctx, dir, "edot-opamp-e2e-test-key")


### PR DESCRIPTION
## What is the problem this PR solves?

Increase timeouts in e2e tests to 3m and use t.Context() as the root context in test cases. Timeout is increased from 1m to improve reliability in the buildkite test environment.
Add FreePort(8220) check to test tear down in AgentInstallTestSuite to ensure that the test that has not released the port is flagged instead of the next test
Increase timeouts of APM related tests to 10m to improve performance under load.

## How to test this PR locally

`mage test:e2e`