### PR TITLE
Change GOFIPS140=v1.0.0 instead of certified

### DIFF
--- a/.buildkite/scripts/unit_test_fipsonly.sh
+++ b/.buildkite/scripts/unit_test_fipsonly.sh
@@ -9,4 +9,4 @@ with_go
 with_mage
 
 echo "Starting the fips140=only unit tests..."
-GODEBUG=fips140=only,tlsmlkem=0 mage test:unitFIPSOnly test:junitReport
+mage test:unitFIPSOnly test:junitReport

--- a/changelog/fragments/1781550341-Use-gos-FIPS-module-for-fips-artifacts.yaml
+++ b/changelog/fragments/1781550341-Use-gos-FIPS-module-for-fips-artifacts.yaml
@@ -18,9 +18,8 @@ summary: Use go's FIPS module for fips artifacts
 # NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
 description: |
   Use go's FIPS module instead of microsoft/go for creating FIPS artifacts.
-  Mechanically it sets GOFIPS140=certified at compile time which enables
-  FIPS mode but does not force it. The certified value ensures that the
-  latest certified go FIPS module is used when compiling.
+  Mechanically it sets GOFIPS140=v1.0.0 at compile time which enables
+  FIPS mode but does not force it.
 
 # Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
 component: fleet-server

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -80,6 +80,11 @@ func getRunCommand(bi build.Info) func(cmd *cobra.Command, args []string) error 
 				return err
 			}
 
+			if err := validateEnv(); err != nil {
+				log.Error().Err(err).Msg("Failed to validate runtime")
+				return err
+			}
+
 			srv, err := server.NewAgent(cliCfg, os.Stdin, bi, l)
 			if err != nil {
 				return err
@@ -115,6 +120,11 @@ func getRunCommand(bi build.Info) func(cmd *cobra.Command, args []string) error 
 
 			l, err = initLogger(cfg, bi.Version, bi.Commit)
 			if err != nil {
+				return err
+			}
+
+			if err := validateEnv(); err != nil {
+				log.Error().Err(err).Msg("Failed to validate runtime")
 				return err
 			}
 

--- a/cmd/fleet/validateenv.go
+++ b/cmd/fleet/validateenv.go
@@ -1,0 +1,11 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build !requirefips
+
+package fleet
+
+func validateEnv() error {
+	return nil
+}

--- a/cmd/fleet/validateenv_fips.go
+++ b/cmd/fleet/validateenv_fips.go
@@ -15,4 +15,5 @@ func validateEnv() error {
 	if !fips140.Enabled() {
 		return fmt.Errorf("fips disabled")
 	}
+	return nil
 }

--- a/cmd/fleet/validateenv_fips.go
+++ b/cmd/fleet/validateenv_fips.go
@@ -1,0 +1,18 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build requirefips
+
+package fleet
+
+import (
+	"crypto/fips140"
+	"fmt"
+)
+
+func validateEnv() error {
+	if !fips140.Enabled() {
+		return fmt.Errorf("fips disabled")
+	}
+}

--- a/magefile.go
+++ b/magefile.go
@@ -382,7 +382,7 @@ func environMap() map[string]string {
 
 // addFIPSEnvVars mutates the passed env map by adding settings needed to produce a FIPS-capable binary.
 func addFIPSEnvVars(env map[string]string) {
-	env["GOFIPS140"] = "certified" // use the latest certified FIPS module.
+	env["GOFIPS140"] = "v1.0.0" // use a pinned version of the fips provider.
 }
 
 // teeCommand runs the specified command, stdout and stederr will be written to stdout and will be collected and returned.
@@ -1207,7 +1207,7 @@ func (Docker) CustomAgentImage() error {
 // Unit runs unit tests.
 // Produces a unit test output file, and test coverage file in the build directory.
 // SNAPSHOT adds the snapshot build tag.
-// FIPS adds the requirefips build tag.
+// FIPS adds the requirefips build tag and env GOFIPS140 env var.
 // TEST_RUN can be used to pass the value to go test -run.
 func (Test) Unit() error {
 	mg.Deps(mg.F(mkDir, "build"))
@@ -1646,13 +1646,27 @@ func checkFIPSBinary(path string) error {
 		switch setting.Key {
 		case "-tags":
 			foundTags = true
-			if !strings.Contains(setting.Value, "requirefips") {
+			requireFipsTag := false
+			fips140Tag := false
+
+			for _, tag := range strings.Split(setting.Value, ",") {
+				switch tag {
+				case "requirefips":
+					requireFipsTag = true
+				case "fips140v1.0":
+					fips140Tag = true
+				}
+			}
+			if !requireFipsTag {
 				return fmt.Errorf("requirefips tag not found in %s", setting.Value)
+			}
+			if !fips140Tag {
+				return fmt.Errorf("fips140v1.0 tag not found in %s", setting.Value)
 			}
 		case "GOFIPS140":
 			foundFIPS140 = true
 			if setting.Value == "" {
-				return fmt.Errorf("GOFIPS140 is empty in build settings")
+				return fmt.Errorf("GOFIPS140 is empty")
 			}
 		}
 	}
@@ -2163,21 +2177,6 @@ func (Test) E2eDown() error {
 // ConvertCoverage formats coverage data emitted by coverage-enabled binaries in e2e tests.
 func (Test) ConvertCoverage() error {
 	return sh.RunV("go", "tool", "covdata", "textfmt", "-i="+filepath.Join("build", "e2e-cover"), "-o="+filepath.Join("build", "e2e-coverage.out"))
-}
-
-// FipsProviderUnit runs unit tests with GOFIPS140=v1.0.0 set and the requirefips build tag.
-// Produces a unit test output file, and test coverage file in the build directory.
-func (Test) FipsProviderUnit() error {
-	mg.Deps(mg.F(mkDir, "build"))
-	os.Setenv(envFIPS, "true")
-	if !isFIPS() {
-		return fmt.Errorf("FIPS must be set to true.")
-	}
-	env := environMap()
-	addFIPSEnvVars(env)
-	output, err := teeCommand(env, "go", "test", "-tags="+getTagsString(), "-v", "-race", "-coverprofile="+filepath.Join("build", "coverage-fips-provider-"+runtime.GOOS+".out"), "./...")
-	err = errors.Join(err, os.WriteFile(filepath.Join("build", "test-unit-fips-provider-"+runtime.GOOS+".out"), output, 0o644))
-	return err
 }
 
 // CloudE2E provisions a cloud deployment, tests the remote fleet-server instance, then destroys the deployment.


### PR DESCRIPTION
## What is the problem this PR solves?

Use `GOFIPS140=v1.0.0` instead of `GOFIPS140=certified`.
Ensure fips artifacts fail if `GODEBUG=fips140=off` is set.

## How does this PR solve the problem?

Change env var set on build to `GOFIPS140=v1.0.0`.
Add a function that validates the runtime after the logger has been initialized, on non-fips artifacts this function is a `nop`, fips artifacts will check if fips is enabled and error out if it's disabled.
The error is emitted as a error level log, and directly to stderr and the process will exit with a non-zero status code.