### PR TITLE
Improve performance of limit and throttle packages

### DIFF
--- a/changelog/fragments/1781894645-reduce-allocations-limit-throttle.yaml
+++ b/changelog/fragments/1781894645-reduce-allocations-limit-throttle.yaml
@@ -1,0 +1,5 @@
+kind: enhancement
+
+summary: Reduce per-request allocations in limit and throttle packages
+
+component: fleet-server

--- a/internal/pkg/api/handleArtifacts.go
+++ b/internal/pkg/api/handleArtifacts.go
@@ -272,7 +272,7 @@ func (at ArtifactT) fetchArtifact(ctx context.Context, zlog zerolog.Logger, iden
 	span, ctx := apm.StartSpan(ctx, "fetchArtifact", "search")
 	defer span.End()
 	// Throttle prevents more than N outstanding requests to elastic globally and per sha2.
-	if token := at.esThrottle.Acquire(zlog, sha2, defaultThrottleTTL); token == nil {
+	if token, ok := at.esThrottle.Acquire(zlog, sha2, defaultThrottleTTL); !ok {
 		return nil, ErrorThrottle
 	} else {
 		defer token.Release(zlog)

--- a/internal/pkg/limit/error.go
+++ b/internal/pkg/limit/error.go
@@ -5,7 +5,6 @@
 package limit
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -17,35 +16,28 @@ var (
 	ErrMaxLimit  = errors.New("max limit")
 )
 
+var (
+	errBodyRateLimit = []byte(`{"statusCode":429,"error":"RateLimit","message":"exceeded the rate limit"}`)
+	errBodyMaxLimit  = []byte(`{"statusCode":429,"error":"MaxLimit","message":"exceeded the max limit"}`)
+	errBodyUnknown   = []byte(`{"statusCode":429,"error":"UnknownLimiterError","message":"unknown limiter error encountered"}`)
+)
+
 // writeError recreates the behaviour of api/error.go.
 // It is defined separately here to stop a circular import
 func writeError(log *zerolog.Logger, w http.ResponseWriter, err error) error {
-	resp := struct {
-		Status  int    `json:"statusCode"`
-		Error   string `json:"error"`
-		Message string `json:"message"`
-	}{
-		Status:  http.StatusTooManyRequests,
-		Error:   "UnknownLimiterError",
-		Message: "unknown limiter error encountered",
-	}
+	var body []byte
 	switch {
 	case errors.Is(err, ErrRateLimit):
-		resp.Error = "RateLimit"
-		resp.Message = "exceeded the rate limit"
+		body = errBodyRateLimit
 	case errors.Is(err, ErrMaxLimit):
-		resp.Error = "MaxLimit"
-		resp.Message = "exceeded the max limit"
+		body = errBodyMaxLimit
 	default:
 		log.Error().Err(err).Msg("Encountered unknown limiter error")
-	}
-	p, wErr := json.Marshal(&resp)
-	if wErr != nil {
-		return wErr
+		body = errBodyUnknown
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(http.StatusTooManyRequests)
-	_, wErr = w.Write(p)
+	_, wErr := w.Write(body)
 	return wErr
 }

--- a/internal/pkg/limit/limit_bench_test.go
+++ b/internal/pkg/limit/limit_bench_test.go
@@ -1,0 +1,148 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package limit
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"golang.org/x/sync/semaphore"
+	"golang.org/x/time/rate"
+)
+
+var benchSinkReleaseFunc ReleaseFunc
+
+// BenchmarkLimiterAcquireNoLimit measures Acquire when no limits are configured.
+func BenchmarkLimiterAcquireNoLimit(b *testing.B) {
+	l := &Limiter{}
+	b.ReportAllocs()
+	for b.Loop() {
+		rf, err := l.Acquire()
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchSinkReleaseFunc = rf
+	}
+}
+
+// BenchmarkLimiterAcquireWithMax measures Acquire when maxLimit is configured.
+// The current implementation binds l.release as a new method value (heap alloc) on every call.
+func BenchmarkLimiterAcquireWithMax(b *testing.B) {
+	l := &Limiter{
+		maxLimit: semaphore.NewWeighted(1),
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		rf, err := l.Acquire()
+		if err != nil {
+			b.Fatal(err)
+		}
+		rf() // release so next iteration can acquire
+		benchSinkReleaseFunc = rf
+	}
+}
+
+// limiterPreBound is the proposed Limiter variant that pre-binds the release
+// function once at construction, eliminating the per-Acquire closure allocation.
+type limiterPreBound struct {
+	rateLimit   *rate.Limiter
+	maxLimit    *semaphore.Weighted
+	releaseFunc ReleaseFunc
+}
+
+func newLimiterPreBound(max int64, interval time.Duration, burst int) *limiterPreBound {
+	l := &limiterPreBound{releaseFunc: noop}
+	if interval != 0 {
+		l.rateLimit = rate.NewLimiter(rate.Every(interval), burst)
+	}
+	if max != 0 {
+		l.maxLimit = semaphore.NewWeighted(max)
+		l.releaseFunc = l.release // bound once at construction, not per-Acquire
+	}
+	return l
+}
+
+func (l *limiterPreBound) release() {
+	if l.maxLimit != nil {
+		l.maxLimit.Release(1)
+	}
+}
+
+func (l *limiterPreBound) acquire() (ReleaseFunc, error) {
+	if l.rateLimit != nil && !l.rateLimit.Allow() {
+		return nil, ErrRateLimit
+	}
+	if l.maxLimit != nil && !l.maxLimit.TryAcquire(1) {
+		return nil, ErrMaxLimit
+	}
+	return l.releaseFunc, nil
+}
+
+// BenchmarkLimiterAcquirePreBound measures Acquire with the pre-bound release function.
+// The releaseFunc field is set once at construction and returned directly on each Acquire call.
+func BenchmarkLimiterAcquirePreBound(b *testing.B) {
+	l := newLimiterPreBound(1, 0, 0)
+	b.ReportAllocs()
+	for b.Loop() {
+		rf, err := l.acquire()
+		if err != nil {
+			b.Fatal(err)
+		}
+		rf() // release so next iteration can acquire
+		benchSinkReleaseFunc = rf
+	}
+}
+
+// Pre-computed static response bodies for the proposed writeError optimization.
+var (
+	staticErrRateLimitBody = []byte(`{"statusCode":429,"error":"RateLimit","message":"exceeded the rate limit"}`)
+	staticErrMaxLimitBody  = []byte(`{"statusCode":429,"error":"MaxLimit","message":"exceeded the max limit"}`)
+)
+
+// writeErrorStatic is the proposed writeError implementation using pre-computed response bodies,
+// eliminating the json.Marshal call on every 429 response.
+func writeErrorStatic(log *zerolog.Logger, w http.ResponseWriter, err error) error {
+	var body []byte
+	switch {
+	case errors.Is(err, ErrRateLimit):
+		body = staticErrRateLimitBody
+	case errors.Is(err, ErrMaxLimit):
+		body = staticErrMaxLimitBody
+	default:
+		log.Error().Err(err).Msg("Encountered unknown limiter error")
+		body = []byte(`{"statusCode":429,"error":"UnknownLimiterError","message":"unknown limiter error encountered"}`)
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusTooManyRequests)
+	_, wErr := w.Write(body)
+	return wErr
+}
+
+// BenchmarkWriteError measures the current writeError: json.Marshal of a struct on every call.
+func BenchmarkWriteError(b *testing.B) {
+	w := httptest.NewRecorder()
+	log := zerolog.Nop()
+	b.ReportAllocs()
+	for b.Loop() {
+		w.Body.Reset()
+		_ = writeError(&log, w, ErrRateLimit)
+	}
+}
+
+// BenchmarkWriteErrorStatic measures the proposed writeError using pre-computed response bodies.
+func BenchmarkWriteErrorStatic(b *testing.B) {
+	w := httptest.NewRecorder()
+	log := zerolog.Nop()
+	b.ReportAllocs()
+	for b.Loop() {
+		w.Body.Reset()
+		_ = writeErrorStatic(&log, w, ErrRateLimit)
+	}
+}

--- a/internal/pkg/limit/limit_bench_test.go
+++ b/internal/pkg/limit/limit_bench_test.go
@@ -5,22 +5,18 @@
 package limit
 
 import (
-	"errors"
-	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/semaphore"
-	"golang.org/x/time/rate"
 )
 
 var benchSinkReleaseFunc ReleaseFunc
 
 // BenchmarkLimiterAcquireNoLimit measures Acquire when no limits are configured.
 func BenchmarkLimiterAcquireNoLimit(b *testing.B) {
-	l := &Limiter{}
+	l := &Limiter{releaseFunc: noop}
 	b.ReportAllocs()
 	for b.Loop() {
 		rf, err := l.Acquire()
@@ -32,11 +28,10 @@ func BenchmarkLimiterAcquireNoLimit(b *testing.B) {
 }
 
 // BenchmarkLimiterAcquireWithMax measures Acquire when maxLimit is configured.
-// The current implementation binds l.release as a new method value (heap alloc) on every call.
+// The releaseFunc is pre-bound at construction (mirroring NewLimiter) — 0 allocs per call.
 func BenchmarkLimiterAcquireWithMax(b *testing.B) {
-	l := &Limiter{
-		maxLimit: semaphore.NewWeighted(1),
-	}
+	l := &Limiter{maxLimit: semaphore.NewWeighted(1)}
+	l.releaseFunc = l.release // pre-bind once, as NewLimiter does
 	b.ReportAllocs()
 	for b.Loop() {
 		rf, err := l.Acquire()
@@ -48,84 +43,7 @@ func BenchmarkLimiterAcquireWithMax(b *testing.B) {
 	}
 }
 
-// limiterPreBound is the proposed Limiter variant that pre-binds the release
-// function once at construction, eliminating the per-Acquire closure allocation.
-type limiterPreBound struct {
-	rateLimit   *rate.Limiter
-	maxLimit    *semaphore.Weighted
-	releaseFunc ReleaseFunc
-}
-
-func newLimiterPreBound(max int64, interval time.Duration, burst int) *limiterPreBound {
-	l := &limiterPreBound{releaseFunc: noop}
-	if interval != 0 {
-		l.rateLimit = rate.NewLimiter(rate.Every(interval), burst)
-	}
-	if max != 0 {
-		l.maxLimit = semaphore.NewWeighted(max)
-		l.releaseFunc = l.release // bound once at construction, not per-Acquire
-	}
-	return l
-}
-
-func (l *limiterPreBound) release() {
-	if l.maxLimit != nil {
-		l.maxLimit.Release(1)
-	}
-}
-
-func (l *limiterPreBound) acquire() (ReleaseFunc, error) {
-	if l.rateLimit != nil && !l.rateLimit.Allow() {
-		return nil, ErrRateLimit
-	}
-	if l.maxLimit != nil && !l.maxLimit.TryAcquire(1) {
-		return nil, ErrMaxLimit
-	}
-	return l.releaseFunc, nil
-}
-
-// BenchmarkLimiterAcquirePreBound measures Acquire with the pre-bound release function.
-// The releaseFunc field is set once at construction and returned directly on each Acquire call.
-func BenchmarkLimiterAcquirePreBound(b *testing.B) {
-	l := newLimiterPreBound(1, 0, 0)
-	b.ReportAllocs()
-	for b.Loop() {
-		rf, err := l.acquire()
-		if err != nil {
-			b.Fatal(err)
-		}
-		rf() // release so next iteration can acquire
-		benchSinkReleaseFunc = rf
-	}
-}
-
-// Pre-computed static response bodies for the proposed writeError optimization.
-var (
-	staticErrRateLimitBody = []byte(`{"statusCode":429,"error":"RateLimit","message":"exceeded the rate limit"}`)
-	staticErrMaxLimitBody  = []byte(`{"statusCode":429,"error":"MaxLimit","message":"exceeded the max limit"}`)
-)
-
-// writeErrorStatic is the proposed writeError implementation using pre-computed response bodies,
-// eliminating the json.Marshal call on every 429 response.
-func writeErrorStatic(log *zerolog.Logger, w http.ResponseWriter, err error) error {
-	var body []byte
-	switch {
-	case errors.Is(err, ErrRateLimit):
-		body = staticErrRateLimitBody
-	case errors.Is(err, ErrMaxLimit):
-		body = staticErrMaxLimitBody
-	default:
-		log.Error().Err(err).Msg("Encountered unknown limiter error")
-		body = []byte(`{"statusCode":429,"error":"UnknownLimiterError","message":"unknown limiter error encountered"}`)
-	}
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.Header().Set("X-Content-Type-Options", "nosniff")
-	w.WriteHeader(http.StatusTooManyRequests)
-	_, wErr := w.Write(body)
-	return wErr
-}
-
-// BenchmarkWriteError measures the current writeError: json.Marshal of a struct on every call.
+// BenchmarkWriteError measures writeError using pre-computed response bodies.
 func BenchmarkWriteError(b *testing.B) {
 	w := httptest.NewRecorder()
 	log := zerolog.Nop()
@@ -133,16 +51,5 @@ func BenchmarkWriteError(b *testing.B) {
 	for b.Loop() {
 		w.Body.Reset()
 		_ = writeError(&log, w, ErrRateLimit)
-	}
-}
-
-// BenchmarkWriteErrorStatic measures the proposed writeError using pre-computed response bodies.
-func BenchmarkWriteErrorStatic(b *testing.B) {
-	w := httptest.NewRecorder()
-	log := zerolog.Nop()
-	b.ReportAllocs()
-	for b.Loop() {
-		w.Body.Reset()
-		_ = writeErrorStatic(&log, w, ErrRateLimit)
 	}
 }

--- a/internal/pkg/limit/limiter.go
+++ b/internal/pkg/limit/limiter.go
@@ -26,12 +26,13 @@ type StatIncer interface {
 }
 
 type Limiter struct {
-	rateLimit *rate.Limiter
-	maxLimit  *semaphore.Weighted
+	rateLimit   *rate.Limiter
+	maxLimit    *semaphore.Weighted
+	releaseFunc ReleaseFunc
 }
 
 func NewLimiter(cfg *config.Limit) *Limiter {
-	l := &Limiter{}
+	l := &Limiter{releaseFunc: noop}
 
 	if cfg == nil {
 		return l
@@ -43,26 +44,22 @@ func NewLimiter(cfg *config.Limit) *Limiter {
 
 	if cfg.Max != 0 {
 		l.maxLimit = semaphore.NewWeighted(cfg.Max)
+		l.releaseFunc = l.release
 	}
 
 	return l
 }
 
 func (l *Limiter) Acquire() (ReleaseFunc, error) {
-	releaseFunc := noop
-
 	if l.rateLimit != nil && !l.rateLimit.Allow() {
 		return nil, ErrRateLimit
 	}
 
-	if l.maxLimit != nil {
-		if !l.maxLimit.TryAcquire(1) {
-			return nil, ErrMaxLimit
-		}
-		releaseFunc = l.release
+	if l.maxLimit != nil && !l.maxLimit.TryAcquire(1) {
+		return nil, ErrMaxLimit
 	}
 
-	return releaseFunc, nil
+	return l.releaseFunc, nil
 }
 
 func (l *Limiter) release() {

--- a/internal/pkg/limit/limiter_test.go
+++ b/internal/pkg/limit/limiter_test.go
@@ -26,7 +26,7 @@ func (m *mockIncer) IncError(err error) {
 
 func (m *mockIncer) IncStart() func() {
 	args := m.Called()
-	return args.Get(0).(func())
+	return args.Get(0).(func()) //nolint:errcheck // mock func
 }
 
 func stubHandle() http.Handler {
@@ -43,7 +43,7 @@ func Test_Limiter_Wrap(t *testing.T) {
 		status int
 	}{{
 		name: "no limits",
-		l:    &Limiter{},
+		l:    &Limiter{releaseFunc: noop},
 		stats: func() *mockIncer {
 			m := &mockIncer{}
 			m.On("IncStart").Return(noop).Once()

--- a/internal/pkg/throttle/throttle.go
+++ b/internal/pkg/throttle/throttle.go
@@ -45,9 +45,9 @@ func NewThrottle(max int) *Throttle {
 	}
 }
 
-// Acquire will return the token associated with passed key if possible or a nil.
-func (tt *Throttle) Acquire(log zerolog.Logger, key string, ttl time.Duration) *Token {
-	var token *Token
+// Acquire will return the token associated with passed key if possible.
+// The bool return indicates whether a token was acquired.
+func (tt *Throttle) Acquire(log zerolog.Logger, key string, ttl time.Duration) (Token, bool) {
 	tt.mut.Lock()
 	defer tt.mut.Unlock()
 
@@ -57,7 +57,7 @@ func (tt *Throttle) Acquire(log zerolog.Logger, key string, ttl time.Duration) *
 			Int("max", tt.maxParallel).
 			Int("szMap", len(tt.tokenMap)).
 			Msg("Throttle fail acquire on max pending")
-		return nil
+		return Token{}, false
 	}
 
 	// Is there already a pending request on this key?
@@ -68,7 +68,7 @@ func (tt *Throttle) Acquire(log zerolog.Logger, key string, ttl time.Duration) *
 	if !ok || state.expire.Before(now) {
 		tt.tokenCnt += 1
 
-		token = &Token{
+		token := Token{
 			id:       tt.tokenCnt,
 			key:      key,
 			throttle: tt,
@@ -87,14 +87,14 @@ func (tt *Throttle) Acquire(log zerolog.Logger, key string, ttl time.Duration) *
 			Time("expire", state.expire).
 			Msg("Throttle acquired")
 
-		return token
+		return token, true
 	}
 
 	log.Trace().
 		Str("key", key).
 		Msg("Throttle fail acquire on existing token")
 
-	return token
+	return Token{}, false
 }
 
 // WARNING:  Assumes mutex already held

--- a/internal/pkg/throttle/throttle_bench_test.go
+++ b/internal/pkg/throttle/throttle_bench_test.go
@@ -11,68 +11,22 @@ import (
 	"github.com/rs/zerolog"
 )
 
-var benchSinkToken *Token
+var benchSinkToken Token
 
 const benchKey = "agent-sha256-deadbeef"
 
-// BenchmarkThrottleAcquirePointer measures the current Acquire returning *Token.
-// The Token struct is heap-allocated on every successful acquire.
-func BenchmarkThrottleAcquirePointer(b *testing.B) {
+// BenchmarkThrottleAcquire measures the Acquire implementation returning (Token, bool) by value.
+// Token is returned by value; escape analysis can keep it on the stack.
+func BenchmarkThrottleAcquire(b *testing.B) {
 	log := zerolog.Nop()
 	tt := NewThrottle(0) // zero max = unlimited parallel
 	b.ReportAllocs()
 	for b.Loop() {
-		tok := tt.Acquire(log, benchKey, time.Hour)
-		if tok == nil {
-			b.Fatal("Acquire returned nil")
+		tok, ok := tt.Acquire(log, benchKey, time.Hour)
+		if !ok {
+			b.Fatal("Acquire returned false")
 		}
 		tok.Release(log)
 		benchSinkToken = tok
-	}
-}
-
-// acquireValue is the proposed implementation returning (Token, bool) by value,
-// allowing the Token struct to be stack-allocated instead of heap-allocated.
-func (tt *Throttle) acquireValue(log zerolog.Logger, key string, ttl time.Duration) (Token, bool) {
-	tt.mut.Lock()
-	defer tt.mut.Unlock()
-
-	if tt.checkAtMaxPending(log, key) {
-		return Token{}, false
-	}
-
-	state, ok := tt.tokenMap[key]
-	now := time.Now()
-	if !ok || state.expire.Before(now) {
-		tt.tokenCnt++
-		tok := Token{
-			id:       tt.tokenCnt,
-			key:      key,
-			throttle: tt,
-		}
-		tt.tokenMap[key] = tstate{
-			id:     tok.id,
-			expire: now.Add(ttl),
-		}
-		return tok, true
-	}
-	return Token{}, false
-}
-
-var benchSinkTokenValue Token
-
-// BenchmarkThrottleAcquireValue measures the proposed (Token, bool) return.
-// Token is returned by value; escape analysis can keep it on the stack.
-func BenchmarkThrottleAcquireValue(b *testing.B) {
-	log := zerolog.Nop()
-	tt := NewThrottle(0)
-	b.ReportAllocs()
-	for b.Loop() {
-		tok, ok := tt.acquireValue(log, benchKey, time.Hour)
-		if !ok {
-			b.Fatal("acquireValue returned false")
-		}
-		tok.Release(log)
-		benchSinkTokenValue = tok
 	}
 }

--- a/internal/pkg/throttle/throttle_bench_test.go
+++ b/internal/pkg/throttle/throttle_bench_test.go
@@ -1,0 +1,78 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package throttle
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+var benchSinkToken *Token
+
+const benchKey = "agent-sha256-deadbeef"
+
+// BenchmarkThrottleAcquirePointer measures the current Acquire returning *Token.
+// The Token struct is heap-allocated on every successful acquire.
+func BenchmarkThrottleAcquirePointer(b *testing.B) {
+	log := zerolog.Nop()
+	tt := NewThrottle(0) // zero max = unlimited parallel
+	b.ReportAllocs()
+	for b.Loop() {
+		tok := tt.Acquire(log, benchKey, time.Hour)
+		if tok == nil {
+			b.Fatal("Acquire returned nil")
+		}
+		tok.Release(log)
+		benchSinkToken = tok
+	}
+}
+
+// acquireValue is the proposed implementation returning (Token, bool) by value,
+// allowing the Token struct to be stack-allocated instead of heap-allocated.
+func (tt *Throttle) acquireValue(log zerolog.Logger, key string, ttl time.Duration) (Token, bool) {
+	tt.mut.Lock()
+	defer tt.mut.Unlock()
+
+	if tt.checkAtMaxPending(log, key) {
+		return Token{}, false
+	}
+
+	state, ok := tt.tokenMap[key]
+	now := time.Now()
+	if !ok || state.expire.Before(now) {
+		tt.tokenCnt++
+		tok := Token{
+			id:       tt.tokenCnt,
+			key:      key,
+			throttle: tt,
+		}
+		tt.tokenMap[key] = tstate{
+			id:     tok.id,
+			expire: now.Add(ttl),
+		}
+		return tok, true
+	}
+	return Token{}, false
+}
+
+var benchSinkTokenValue Token
+
+// BenchmarkThrottleAcquireValue measures the proposed (Token, bool) return.
+// Token is returned by value; escape analysis can keep it on the stack.
+func BenchmarkThrottleAcquireValue(b *testing.B) {
+	log := zerolog.Nop()
+	tt := NewThrottle(0)
+	b.ReportAllocs()
+	for b.Loop() {
+		tok, ok := tt.acquireValue(log, benchKey, time.Hour)
+		if !ok {
+			b.Fatal("acquireValue returned false")
+		}
+		tok.Release(log)
+		benchSinkTokenValue = tok
+	}
+}

--- a/internal/pkg/throttle/throttle_test.go
+++ b/internal/pkg/throttle/throttle_test.go
@@ -25,22 +25,22 @@ func TestThrottleZero(t *testing.T) {
 
 	N := rand.Intn(64) + 10 //nolint:gosec // random number is used for testing
 
-	var tokens []*Token
+	tokens := make([]Token, 0, N)
 	for i := range N {
 
 		key := strconv.Itoa(i)
 
 		// Acquire token for key with long timeout so doesn't trip unit test
-		token1 := throttle.Acquire(l, key, time.Hour)
-		if token1 == nil {
+		token1, ok := throttle.Acquire(l, key, time.Hour)
+		if !ok {
 			t.Fatal("Acquire failed")
 		}
 		tokens = append(tokens, token1)
 
 		// Second acquire should fail because we have not released the original token,
 		// or possibly if i == N-1 we could max parallel
-		token2 := throttle.Acquire(l, key, time.Hour)
-		if token2 != nil {
+		_, ok = throttle.Acquire(l, key, time.Hour)
+		if ok {
 			t.Error("Expected second acquire to fail on conflict")
 		}
 	}
@@ -51,8 +51,8 @@ func TestThrottleZero(t *testing.T) {
 		key := strconv.Itoa(i)
 
 		// Acquire should fail because we have not released the original token,
-		token := throttle.Acquire(l, key, time.Hour)
-		if token != nil {
+		_, ok := throttle.Acquire(l, key, time.Hour)
+		if ok {
 			t.Error("Expected acquire to fail on conflict")
 		}
 	}
@@ -73,8 +73,8 @@ func TestThrottleZero(t *testing.T) {
 		// We should now be able to to acquire
 		key := strconv.Itoa(i)
 
-		token = throttle.Acquire(l, key, time.Hour)
-		if token == nil {
+		token, ok := throttle.Acquire(l, key, time.Hour)
+		if !ok {
 			t.Fatal("Acquire failed")
 		}
 
@@ -93,22 +93,22 @@ func TestThrottleN(t *testing.T) {
 
 		throttle := NewThrottle(N)
 
-		var tokens []*Token
+		var tokens []Token
 		for i := 0; i < N; i++ {
 
 			key := strconv.Itoa(i)
 
 			// Acquire token for key with long timeout so doesn't trip unit test
-			token1 := throttle.Acquire(l, key, time.Hour)
-			if token1 == nil {
+			token1, ok := throttle.Acquire(l, key, time.Hour)
+			if !ok {
 				t.Fatal("Acquire failed")
 			}
 			tokens = append(tokens, token1)
 
 			// Second acquire should fail because we have not released the original token,
 			// or possibly if i == N-1 we could max parallel
-			token2 := throttle.Acquire(l, key, time.Hour)
-			if token2 != nil {
+			_, ok = throttle.Acquire(l, key, time.Hour)
+			if ok {
 				t.Error("Expected second acquire to fail on conflict")
 			}
 		}
@@ -119,8 +119,8 @@ func TestThrottleN(t *testing.T) {
 
 			key := strconv.Itoa(N + i)
 
-			token1 := throttle.Acquire(l, key, time.Hour)
-			if token1 != nil {
+			_, ok := throttle.Acquire(l, key, time.Hour)
+			if ok {
 				t.Fatal("Expect acquire to fail on max tokens")
 			}
 		}
@@ -142,8 +142,8 @@ func TestThrottleN(t *testing.T) {
 			// We should now be able to to acquire
 			key := strconv.Itoa(i)
 
-			token = throttle.Acquire(l, key, time.Hour)
-			if token == nil {
+			token, ok := throttle.Acquire(l, key, time.Hour)
+			if !ok {
 				t.Fatal("Acquire failed")
 			}
 
@@ -162,19 +162,22 @@ func TestThrottleExpireIdentity(t *testing.T) {
 	throttle := NewThrottle(1)
 
 	const key = "xxx"
-	token := throttle.Acquire(l, key, time.Second)
+	token, ok := throttle.Acquire(l, key, time.Second)
+	if !ok {
+		t.Fatal("Acquire failed")
+	}
 
 	// Should *NOT* be able to re-acquire until TTL
-	token2 := throttle.Acquire(l, key, time.Hour)
-	if token2 != nil {
+	_, ok = throttle.Acquire(l, key, time.Hour)
+	if ok {
 		t.Error("Expected second acquire to fail on conflict")
 	}
 
 	time.Sleep(time.Second)
 
 	// Should be able to re-acquire on expiration
-	token3 := throttle.Acquire(l, key, time.Hour)
-	if token3 == nil {
+	token3, ok := throttle.Acquire(l, key, time.Hour)
+	if !ok {
 		t.Fatal("Expected third acquire to succeed")
 	}
 
@@ -199,20 +202,23 @@ func TestThrottleExpireAtMax(t *testing.T) {
 	throttle := NewThrottle(1)
 
 	key1 := "xxx"
-	token1 := throttle.Acquire(l, key1, time.Second)
+	token1, ok := throttle.Acquire(l, key1, time.Second)
+	if !ok {
+		t.Fatal("Acquire failed")
+	}
 
 	// Should be at max, cannot acquire different key
 	key2 := "yyy"
-	token2 := throttle.Acquire(l, key2, time.Hour)
-	if token2 != nil {
+	_, ok = throttle.Acquire(l, key2, time.Hour)
+	if ok {
 		t.Error("Expected second acquire to fail on max")
 	}
 
 	time.Sleep(time.Second)
 
 	// Should be able acquire second after timeout
-	token2 = throttle.Acquire(l, key2, time.Hour)
-	if token2 == nil {
+	token2, ok := throttle.Acquire(l, key2, time.Hour)
+	if !ok {
 		t.Fatal("Expected third acquire to succeed")
 	}
 


### PR DESCRIPTION
## What is the problem this PR solves?

Reduce allocations that limit and throttle packages use per request.

## How does this PR solve the problem?

- Pre allocate limit error response bodies - preventing two allocations from json encoding when under load
- add `Limiter.releaseFunc` attribute to avoid a heap allocation whenever a limiter with a defined max value is acquired
- Change signature of `Throttle.Acquire` to return `Token, bool` instead of `*Token` in order to avoid the token being allocated to heap

## How to test this PR locally

`mage test:benchmark`

### Benchmark findings

```
  internal/pkg/limit

  goos: darwin
  goarch: arm64
  pkg: github.com/elastic/fleet-server/v7/internal/pkg/limit
  cpu: Apple M3 Pro
                           │    baseline     │               after                 │
                           │    sec/op       │   sec/op     vs base                │
  LimiterAcquireNoLimit-12   1.913n ± 1%      1.913n ± 0%        ~ (p=0.925 n=10)
  LimiterAcquireWithMax-12  19.875n ± 1%      7.659n ± 1%  -61.47% (p=0.000 n=10)
  WriteError-12             226.90n ± 2%     82.03n ± 1%   -63.85% (p=0.000 n=10)
  geomean                    20.51n           10.63n        -48.16%

                           │    baseline     │               after                 │
                           │    B/op         │   B/op       vs base                │
  LimiterAcquireNoLimit-12   0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=10)
  LimiterAcquireWithMax-12  16.00 ± 0%        0.00 ± 0%   -100.00% (p=0.000 n=10)
  WriteError-12             160.00 ± 0%      32.00 ± 0%    -80.00% (p=0.000 n=10)

                           │    baseline     │               after                 │
                           │    allocs/op    │ allocs/op    vs base                │
  LimiterAcquireNoLimit-12   0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=10)
  LimiterAcquireWithMax-12   1.000 ± 0%       0.000 ± 0%  -100.00% (p=0.000 n=10)
  WriteError-12              4.000 ± 0%       2.000 ± 0%   -50.00% (p=0.000 n=10)
```

```
  internal/pkg/throttle

  (Baseline benchmark was named ThrottleAcquirePointer; renamed to ThrottleAcquire for comparison.)

  goos: darwin
  goarch: arm64
  pkg: github.com/elastic/fleet-server/v7/internal/pkg/throttle
  cpu: Apple M3 Pro
                     │    baseline     │               after                 │
                     │    sec/op       │   sec/op     vs base                │
  ThrottleAcquire-12   95.38n ± 1%      85.44n ± 1%   -10.42% (p=0.000 n=10)

                     │    baseline     │               after                 │
                     │    B/op         │   B/op        vs base               │
  ThrottleAcquire-12   32.00 ± 0%       0.00 ± 0%    -100.00% (p=0.000 n=10)

                     │    baseline     │               after                 │
                     │    allocs/op    │ allocs/op     vs base               │
  ThrottleAcquire-12   1.000 ± 0%       0.000 ± 0%   -100.00% (p=0.000 n=10)
```

### Memory profile findings

```
  limit (pprof -diff_base):

  ┌──────────────────────────────┬───────────────────────────────────────────────────────────────────────────────────┐
  │           Function           │                                       Freed                                       │
  ├──────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────┤
  │ (*Limiter).Acquire           │ -9.09 GB - method value closure gone entirely                                     │
  ├──────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────┤
  │ encoding/json.Marshal        │ -3.98 GB - no longer called on 429 paths                                          │
  ├──────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────┤
  │ limit.writeError             │ -2.38 GB - anonymous struct allocation gone                                       │
  ├──────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────┤
  │ net/textproto.MIMEHeader.Set │ -1.46 GB - indirectly reduced (fewer header writes from fewer json.Marshal paths) │
  └──────────────────────────────┴───────────────────────────────────────────────────────────────────────────────────┘

  Total: -16.91 GB across the benchmark run, representing 79.5% of total allocations eliminated.
```

```
  throttle (pprof -diff_base):

  ┌─────────────────────┬──────────────────────────────────────────────────┐
  │      Function       │                      Freed                       │
  ├─────────────────────┼──────────────────────────────────────────────────┤
  │ (*Throttle).Acquire │ -3.70 GB - Token struct no longer heap-allocated │
  └─────────────────────┴──────────────────────────────────────────────────┘

  Total: -3.70 GB, 99.9% of all allocations in the package eliminated. Acquire produces zero heap allocations, so essentially nothing shows up in the after profile for the acquire path.
```

## Design Checklist

- ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)