### PR TITLE
Revert removal of type arg used by package.sh

### DIFF
--- a/.buildkite/pipeline.package.mbp.yml
+++ b/.buildkite/pipeline.package.mbp.yml
@@ -27,10 +27,9 @@ steps:
     # as prereleases are only intended to be used with staging; details in https://github.com/elastic/ingest-dev/issues/4855
     if: "build.env('VERSION_QUALIFIER') == null"
     key: "package-x86-64-snapshot"
-    command: ".buildkite/scripts/package.sh"
+    command: ".buildkite/scripts/package.sh snapshot"
     env:
       PLATFORMS: "linux/amd64,darwin/amd64,windows/amd64"
-      SNAPSHOT: "true"
     agents:
       provider: "gcp"
       image: "${IMAGE_UBUNTU_X86_64}"
@@ -44,7 +43,7 @@ steps:
     key: "package-x86-64-staging"
     command: |
       source .buildkite/scripts/version_qualifier.sh
-      .buildkite/scripts/package.sh
+      .buildkite/scripts/package.sh staging
     env:
       PLATFORMS: "linux/amd64,darwin/amd64,windows/amd64"
     agents:
@@ -60,9 +59,8 @@ steps:
   - label: "Package FIPS x86_64 snapshot"
     if: "build.env('VERSION_QUALIFIER') == null"
     key: "package-fips-x86-64-snapshot"
-    command: ".buildkite/scripts/package.sh"
+    command: ".buildkite/scripts/package.sh snapshot"
     env:
-      SNAPSHOT: "true"
       FIPS: "true"
       PLATFORMS: "linux/amd64,windows/amd64"
     agents:
@@ -79,7 +77,7 @@ steps:
     key: "package-fips-x86-64-staging"
     command: |
       source .buildkite/scripts/version_qualifier.sh
-      .buildkite/scripts/package.sh
+      .buildkite/scripts/package.sh staging
     env:
       FIPS: "true"
       PLATFORMS: "linux/amd64,windows/amd64"
@@ -96,9 +94,8 @@ steps:
   - label: "Package aarch64 snapshot"
     if: "build.env('VERSION_QUALIFIER') == null"
     key: "package-arm-snapshot"
-    command: ".buildkite/scripts/package.sh"
+    command: ".buildkite/scripts/package.sh snapshot"
     env:
-      SNAPSHOT: "true"
       PLATFORMS: "linux/arm64,darwin/arm64,windows/arm64"
     agents:
       provider: "aws"
@@ -114,7 +111,7 @@ steps:
     key: "package-arm-staging"
     command: |
       source .buildkite/scripts/version_qualifier.sh
-      .buildkite/scripts/package.sh
+      .buildkite/scripts/package.sh staging
     env:
       PLATFORMS: "linux/arm64,darwin/arm64,windows/arm64"
     agents:
@@ -130,9 +127,8 @@ steps:
   - label: "Package FIPS aarch64 snapshot"
     if: "build.env('VERSION_QUALIFIER') == null"
     key: "package-fips-arm-snapshot"
-    command: ".buildkite/scripts/package.sh"
+    command: ".buildkite/scripts/package.sh snapshot"
     env:
-      SNAPSHOT: "true"
       FIPS: "true"
       PLATFORMS: "linux/arm64,windows/arm64"
     agents:
@@ -149,7 +145,7 @@ steps:
     key: "package-fips-arm-staging"
     command: |
       source .buildkite/scripts/version_qualifier.sh
-      .buildkite/scripts/package.sh
+      .buildkite/scripts/package.sh staging
     env:
       FIPS: "true"
       PLATFORMS: "linux/arm64,windows/arm64"

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -118,10 +118,7 @@ get_bucket_uri() {
 
 upload_mbp_packages_to_gcp_bucket() {
     local pattern=${1}
-    local type="staging"
-    if [[ ${SNAPSHOT:-false}  == "true" ]]; then
-        type="snapshot"
-    fi
+    local type=${2}
     get_bucket_uri "${type}"
     gcloud storage cp --recursive --quiet ${pattern} ${bucketUri}
 }

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -4,16 +4,30 @@ set -euo pipefail
 
 source .buildkite/scripts/common.sh
 
+TYPE="$1"
 readonly VERSION_QUALIFIER="${VERSION_QUALIFIER:-""}"
 
-if [[ ${BUILDKITE_BRANCH} == "main" && -z ${VERSION_QUALIFIER} ]]; then
+if [[ ${BUILDKITE_BRANCH} == "main" && ${TYPE} == "staging" && -z ${VERSION_QUALIFIER} ]]; then
     echo "INFO: staging artifacts for the main branch are not required."
     exit 0
 fi
 
 add_bin_path
+
 with_go
 with_mage
 
-mage docker:release
-upload_mbp_packages_to_gcp_bucket "build/distributions/**/*"
+case "${TYPE}" in
+    "snapshot")
+        export SNAPSHOT=true
+        mage docker:release
+        ;;
+    "staging")
+        mage docker:release
+        ;;
+    *)
+    echo "The option is unsupported yet"
+    ;;
+esac
+
+upload_mbp_packages_to_gcp_bucket "build/distributions/**/*" "${TYPE}"


### PR DESCRIPTION
## What is the problem this PR solves?

DRA fails on main

## How does this PR solve the problem?

Reverts changes made in https://github.com/elastic/fleet-server/pull/7202, and attempted fixes in https://github.com/elastic/fleet-server/pull/7263 and https://github.com/elastic/fleet-server/pull/7277 to package.sh which can succeed on branches and PRs but fail on main.

Note that PACKAGES env var used for new FIPS artifacts are kept in the package pipeline declaration instead of being detected (only for FIPS builds) by the script