### PR TITLE
fix: propagate namespaces from enrollment key to OpAMP agent on enroll

### DIFF
--- a/internal/pkg/api/handleOpAMP.go
+++ b/internal/pkg/api/handleOpAMP.go
@@ -386,6 +386,7 @@ func (oa *OpAMPT) enrollAgent(ctx context.Context, zlog zerolog.Logger, uid uuid
 		Active:     true,
 		EnrolledAt: now.UTC().Format(time.RFC3339),
 		PolicyID:   rec.PolicyID,
+		Namespaces: rec.Namespaces,
 		Agent: &model.AgentMetadata{
 			ID:      instanceUID,
 			Version: meta.Elastic.Agent.Version,

--- a/internal/pkg/api/handleOpAMP_test.go
+++ b/internal/pkg/api/handleOpAMP_test.go
@@ -244,9 +244,10 @@ func TestEnrollAgentWithAgentToServerMessage(t *testing.T) {
 	bulker := ftesting.NewMockBulk()
 
 	enrollKey := model.EnrollmentAPIKey{ //nolint:gosec // fake api key used in test
-		APIKeyID: "enroll-key-id",
-		PolicyID: "policy-123",
-		Active:   true,
+		APIKeyID:   "enroll-key-id",
+		PolicyID:   "policy-123",
+		Namespaces: []string{"my-space"},
+		Active:     true,
 	}
 	enrollKeyBytes, err := json.Marshal(enrollKey) //nolint:gosec // fake api key used in test
 	require.NoError(t, err)
@@ -321,6 +322,8 @@ func TestEnrollAgentWithAgentToServerMessage(t *testing.T) {
 
 	require.Equal(t, agent.Id, createdAgent.Agent.ID)
 	require.Equal(t, agent.PolicyID, createdAgent.PolicyID)
+	require.Equal(t, []string{"my-space"}, agent.Namespaces)
+	require.Equal(t, []string{"my-space"}, createdAgent.Namespaces)
 	bulker.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug where OTel (OpAMP) collectors enrolled from a non-default Kibana space always appeared in the **Default** space.

### Root cause

`enrollAgent` in `handleOpAMP.go` fetches the enrollment API key record (`rec`) and correctly sets `PolicyID: rec.PolicyID` on the new agent document — but never set `Namespaces`. The standard enrollment handler (`handleEnroll.go`) passes `enrollAPI.Namespaces` through to `_enroll`, which stamps the agent's `namespaces` field and allows Kibana's space-awareness filtering to work correctly.

### Fix

One line: add `Namespaces: rec.Namespaces` to the `model.Agent` struct in `enrollAgent`, mirroring the standard enroll path.

### Test

Updated `TestEnrollAgentWithAgentToServerMessage` to include `Namespaces: []string{"my-space"}` in the mock enrollment key and assert that both the returned agent and the written ES document have `Namespaces: ["my-space"]`.

Companion Kibana fix: elastic/kibana#275602
Closes: https://github.com/elastic/kibana/issues/275528