### PR TITLE
Modify CODEOWNERS for release notes and docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,6 @@
 
 /.github/workflows @elastic/observablt-ci
 /.github/workflows/golangci-lint.yml @elastic/elastic-agent-control-plane
-/.github/workflows/release-notes.yml @elastic/ingest-docs @elastic/elastic-agent-control-plane
-/docs/release-notes @elastic/ingest-docs
-/docs/docset.yml @elastic/ingest-docs
+/.github/workflows/release-notes.yml @elastic/ski-docs @elastic/elastic-agent-control-plane
+/docs/release-notes @elastic/ski-docs
+/docs/docset.yml @elastic/ski-docs


### PR DESCRIPTION
The ingest-docs team is too small now. In order to be better at not blocking PRs, we are going to enable the entire team to review via the [elastic/ski-docs](https://github.com/orgs/elastic/teams/ski-docs) handle.