### PR TITLE
Revert "[9.3](backport #6957) Add support for windows/arm64 builds"

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -82,7 +82,7 @@ steps:
       - label: "Package aarch64"
         key: "package-arm64-pr"
         env:
-          PLATFORMS: "linux/arm64,darwin/arm64,windows/arm64"
+          PLATFORMS: "linux/arm64,darwin/arm64"
         command: ".buildkite/scripts/release_test.sh"
         artifact_paths:
           - build/distributions/**

--- a/magefile.go
+++ b/magefile.go
@@ -124,7 +124,6 @@ var (
 		"linux/amd64",
 		"linux/arm64",
 		"windows/amd64",
-		"windows/arm64",
 	}
 	// plaformsFIPS is the list of all FIPS-capable platforms.
 	platformsFIPS = []string{


### PR DESCRIPTION
Reverts elastic/fleet-server#7312

lets wait for 9.5 instead of backporting arm fleet server build