### PR TITLE
File delivery range support

### DIFF
--- a/changelog/fragments/1783099722-file-delivery-support-range.yaml
+++ b/changelog/fragments/1783099722-file-delivery-support-range.yaml
@@ -19,13 +19,13 @@ summary: Support HTTP Range in File Delivery
 #description:
 
 # Affected component; a word indicating the component this changeset affects.
-component: fleet
+component: fleet-server
 
 # PR URL; optional; the PR number that added the changeset.
 # If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
 # NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
 # Please provide it if you are adding a fragment for a different PR.
-#pr: https://github.com/owner/repo/1234
+pr: https://github.com/elastic/fleet-server/pull/7319
 
 # Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
 # If not present is automatically filled by the tooling with the issue linked to the PR number.

--- a/changelog/fragments/1783099722-file-delivery-support-range.yaml
+++ b/changelog/fragments/1783099722-file-delivery-support-range.yaml
@@ -1,0 +1,32 @@
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: enhancement
+
+# Change summary; a 80ish characters long description of the change.
+summary: Support HTTP Range in File Delivery
+
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# NOTE: This field will be rendered only for breaking-change and known-issue kinds at the moment.
+#description:
+
+# Affected component; a word indicating the component this changeset affects.
+component: fleet
+
+# PR URL; optional; the PR number that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+#pr: https://github.com/owner/repo/1234
+
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+#issue: https://github.com/owner/repo/1234

--- a/internal/pkg/api/error.go
+++ b/internal/pkg/api/error.go
@@ -516,6 +516,15 @@ func NewHTTPErrResp(err error) HTTPErrResp {
 			},
 		},
 		{
+			ErrMultiRangeNotSupported,
+			HTTPErrResp{
+				http.StatusRequestedRangeNotSatisfiable,
+				"ErrRangeNotSatisfiable",
+				"Multipart ranges not satisfiable",
+				zerolog.InfoLevel,
+			},
+		},
+		{
 			file.ErrInvalidID,
 			HTTPErrResp{
 				http.StatusBadRequest,

--- a/internal/pkg/api/error.go
+++ b/internal/pkg/api/error.go
@@ -507,6 +507,15 @@ func NewHTTPErrResp(err error) HTTPErrResp {
 			},
 		},
 		{
+			ErrBadRange,
+			HTTPErrResp{
+				http.StatusRequestedRangeNotSatisfiable,
+				"ErrRangeNotSatisfiable",
+				"range not satisfiable",
+				zerolog.InfoLevel,
+			},
+		},
+		{
 			file.ErrInvalidID,
 			HTTPErrResp{
 				http.StatusBadRequest,

--- a/internal/pkg/api/handleFileDelivery.go
+++ b/internal/pkg/api/handleFileDelivery.go
@@ -169,8 +169,8 @@ func (ft *FileDeliveryT) sendFileAsRanges(zlog zerolog.Logger, w http.ResponseWr
 
 	w.WriteHeader(http.StatusPartialContent)
 
-	startOffset := uint64(ra.start % info.File.ChunkSize)
-	endOffset := uint64(((ra.start + ra.length - 1) % info.File.ChunkSize) + 1)
+	startOffset := ra.start % info.File.ChunkSize
+	endOffset := ((ra.start + ra.length - 1) % info.File.ChunkSize) + 1
 	return ft.deliverer.SendChunks(r.Context(), zlog, w, chunks, fileID, &startOffset, &endOffset)
 }
 

--- a/internal/pkg/api/handleFileDelivery.go
+++ b/internal/pkg/api/handleFileDelivery.go
@@ -170,6 +170,9 @@ func (ft *FileDeliveryT) sendFileAsRanges(zlog zerolog.Logger, w http.ResponseWr
 	}
 	w.Header().Set("Content-Range", ra.contentRange(info.File.Size))
 	w.Header().Set("Content-Length", strconv.FormatInt(ra.length, 10))
+	if info.File.Hash != nil && info.File.Hash.SHA2 != "" {
+		w.Header().Set("X-File-SHA2", info.File.Hash.SHA2)
+	}
 
 	startOffset := ra.start % info.File.ChunkSize
 	endOffset := ((ra.start + ra.length - 1) % info.File.ChunkSize) + 1

--- a/internal/pkg/api/handleFileDelivery.go
+++ b/internal/pkg/api/handleFileDelivery.go
@@ -228,7 +228,7 @@ func parseRange(s string, size int64) ([]httpRange, error) {
 				return nil, errors.New("invalid range")
 			}
 			i, err := strconv.ParseInt(end, 10, 64)
-			if i < 0 || err != nil {
+			if i <= 0 || err != nil {
 				return nil, errors.New("invalid range")
 			}
 			if i > size {

--- a/internal/pkg/api/handleFileDelivery.go
+++ b/internal/pkg/api/handleFileDelivery.go
@@ -8,7 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/textproto"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -24,6 +26,7 @@ import (
 )
 
 var (
+	ErrBadRange                = errors.New("range not satisfiable")
 	ErrClientFileForbidden     = errors.New("agent not authorized for library")
 	ErrFileForDeliveryNotFound = errors.New("unable to retrieve file")
 	ErrLibraryFileNotFound     = fmt.Errorf("%w from library", ErrFileForDeliveryNotFound)
@@ -94,7 +97,27 @@ func (ft *FileDeliveryT) handleSendFile(zlog zerolog.Logger, w http.ResponseWrit
 	if err != nil {
 		return err
 	}
+	w.Header().Set("Accept-Ranges", "bytes")
 
+	// Send partial content if Range is requested
+	ranges, err := parseRange(r.Header.Get("Range"), info.File.Size)
+	if err != nil {
+		w.Header().Set("Content-Range", "bytes */"+strconv.FormatInt(info.File.Size, 10))
+		return fmt.Errorf("%w: %w", ErrBadRange, err)
+	}
+	if sumRangesSize(ranges) > info.File.Size {
+		// ignore bad-math or bad-acting client range requests, serve as normal
+		ranges = nil
+	}
+
+	if len(ranges) > 0 {
+		return ft.sendFileAsRanges(zlog, w, r, fileID, info, chunks, ranges)
+	}
+	// no ranges requested, send 200 response with all content
+	return ft.sendFullFile(zlog, w, r, fileID, info, chunks)
+}
+
+func (ft *FileDeliveryT) sendFullFile(zlog zerolog.Logger, w http.ResponseWriter, r *http.Request, fileID string, info file.MetaDoc, chunks []file.ChunkInfo) error {
 	// set headers before writing any chunks!
 
 	// if mime_type was provided, set as Content-Type, otherwise fall back to octet-stream
@@ -112,10 +135,145 @@ func (ft *FileDeliveryT) handleSendFile(zlog zerolog.Logger, w http.ResponseWrit
 	}
 
 	// stream the chunks out
-	return ft.deliverer.SendFile(r.Context(), zlog, w, chunks, fileID)
+	return ft.deliverer.SendChunks(r.Context(), zlog, w, chunks, fileID, nil, nil)
 }
 
 func sanitizedIndexInput(s string) string {
 	r := regexp.MustCompile(`[*?"<>\\/,|#]`) // bad characters
 	return r.ReplaceAllString(strings.ToLower(strings.TrimSpace(s)), "")
+}
+
+func (ft *FileDeliveryT) sendFileAsRanges(zlog zerolog.Logger, w http.ResponseWriter, r *http.Request, fileID string, info file.MetaDoc, chunks []file.ChunkInfo, ranges []httpRange) error {
+	if len(ranges) > 1 {
+		return errors.New("multipart ranges not supported")
+	}
+	ra := ranges[0]
+
+	sort.SliceStable(chunks, func(i, j int) bool {
+		return chunks[i].Pos < chunks[j].Pos
+	})
+
+	// reduce to fetch only required chunks.
+	// Int64 Floor division used intentionally for index math
+	chunkIdxStart := ra.start / info.File.ChunkSize
+	chunkIdxStop := (ra.start + ra.length - 1) / info.File.ChunkSize
+	chunks = chunks[chunkIdxStart : chunkIdxStop+1]
+
+	// if supporting multiple ranges, this becomes multipart/byteranges !
+	w.Header().Set("Content-Type", "application/octet-stream")
+	if info.File.MimeType != "" {
+		w.Header().Set("Content-Type", info.File.MimeType)
+	}
+	w.Header().Set("Content-Range", ra.contentRange(info.File.Size))
+	w.Header().Set("Content-Length", strconv.FormatInt(ra.length, 10))
+
+	w.WriteHeader(http.StatusPartialContent)
+
+	startOffset := uint64(ra.start % info.File.ChunkSize)
+	endOffset := uint64(((ra.start + ra.length - 1) % info.File.ChunkSize) + 1)
+	return ft.deliverer.SendChunks(r.Context(), zlog, w, chunks, fileID, &startOffset, &endOffset)
+}
+
+/*
+ * HTTP Range parsing
+ *
+ * modified from Go source http/fs.go
+ * see NOTICE.txt for license
+ */
+
+// errNoOverlap is returned by serveContent's parseRange if first-byte-pos of
+// all of the byte-range-spec values is greater than the content size.
+var errNoOverlap = errors.New("invalid range: failed to overlap")
+
+// httpRange specifies the byte range to be sent to the client.
+type httpRange struct {
+	start, length int64
+}
+
+func (r httpRange) contentRange(size int64) string {
+	return fmt.Sprintf("bytes %d-%d/%d", r.start, r.start+r.length-1, size)
+}
+
+// parseRange parses a Range header string as per RFC 7233.
+// errNoOverlap is returned if none of the ranges overlap.
+func parseRange(s string, size int64) ([]httpRange, error) {
+	if s == "" {
+		return nil, nil // header not present
+	}
+	const b = "bytes="
+	if !strings.HasPrefix(s, b) {
+		return nil, errors.New("invalid range")
+	}
+	var ranges []httpRange
+	noOverlap := false
+	for ra := range strings.SplitSeq(s[len(b):], ",") {
+		ra = textproto.TrimString(ra)
+		if ra == "" {
+			continue
+		}
+		start, end, ok := strings.Cut(ra, "-")
+		if !ok {
+			return nil, errors.New("invalid range")
+		}
+		start, end = textproto.TrimString(start), textproto.TrimString(end)
+		var r httpRange
+		if start == "" {
+			// If no start is specified, end specifies the
+			// range start relative to the end of the file,
+			// and we are dealing with <suffix-length>
+			// which has to be a non-negative integer as per
+			// RFC 7233 Section 2.1 "Byte-Ranges".
+			if end == "" || end[0] == '-' {
+				return nil, errors.New("invalid range")
+			}
+			i, err := strconv.ParseInt(end, 10, 64)
+			if i < 0 || err != nil {
+				return nil, errors.New("invalid range")
+			}
+			if i > size {
+				i = size
+			}
+			r.start = size - i
+			r.length = size - r.start
+		} else {
+			i, err := strconv.ParseInt(start, 10, 64)
+			if err != nil || i < 0 {
+				return nil, errors.New("invalid range")
+			}
+			if i >= size {
+				// If the range begins after the size of the content,
+				// then it does not overlap.
+				noOverlap = true
+				continue
+			}
+			r.start = i
+			if end == "" {
+				// If no end is specified, range extends to end of the file.
+				r.length = size - r.start
+			} else {
+				i, err := strconv.ParseInt(end, 10, 64)
+				if err != nil || r.start > i {
+					return nil, errors.New("invalid range")
+				}
+				if i >= size {
+					i = size - 1
+				}
+				r.length = i - r.start + 1
+			}
+		}
+		ranges = append(ranges, r)
+	}
+	if noOverlap && len(ranges) == 0 {
+		// The specified ranges did not overlap with the content.
+		return nil, errNoOverlap
+	}
+	return ranges, nil
+}
+
+func sumRangesSize(ranges []httpRange) int64 {
+	var size int64 = 0
+	for _, ra := range ranges {
+		size += ra.length
+	}
+	return size
 }

--- a/internal/pkg/api/handleFileDelivery.go
+++ b/internal/pkg/api/handleFileDelivery.go
@@ -27,6 +27,7 @@ import (
 
 var (
 	ErrBadRange                = errors.New("range not satisfiable")
+	ErrMultiRangeNotSupported  = errors.New("multipart ranges not supported")
 	ErrClientFileForbidden     = errors.New("agent not authorized for library")
 	ErrFileForDeliveryNotFound = errors.New("unable to retrieve file")
 	ErrLibraryFileNotFound     = fmt.Errorf("%w from library", ErrFileForDeliveryNotFound)
@@ -145,7 +146,7 @@ func sanitizedIndexInput(s string) string {
 
 func (ft *FileDeliveryT) sendFileAsRanges(zlog zerolog.Logger, w http.ResponseWriter, r *http.Request, fileID string, info file.MetaDoc, chunks []file.ChunkInfo, ranges []httpRange) error {
 	if len(ranges) > 1 {
-		return errors.New("multipart ranges not supported")
+		return ErrMultiRangeNotSupported
 	}
 	ra := ranges[0]
 

--- a/internal/pkg/api/handleFileDelivery.go
+++ b/internal/pkg/api/handleFileDelivery.go
@@ -158,6 +158,9 @@ func (ft *FileDeliveryT) sendFileAsRanges(zlog zerolog.Logger, w http.ResponseWr
 	// Int64 Floor division used intentionally for index math
 	chunkIdxStart := ra.start / info.File.ChunkSize
 	chunkIdxStop := (ra.start + ra.length - 1) / info.File.ChunkSize
+	if chunkIdxStart >= int64(len(chunks)) || chunkIdxStart > chunkIdxStop || chunkIdxStop >= int64(len(chunks)) {
+		return ErrBadRange
+	}
 	chunks = chunks[chunkIdxStart : chunkIdxStop+1]
 
 	// if supporting multiple ranges, this becomes multipart/byteranges !
@@ -168,11 +171,17 @@ func (ft *FileDeliveryT) sendFileAsRanges(zlog zerolog.Logger, w http.ResponseWr
 	w.Header().Set("Content-Range", ra.contentRange(info.File.Size))
 	w.Header().Set("Content-Length", strconv.FormatInt(ra.length, 10))
 
-	w.WriteHeader(http.StatusPartialContent)
-
 	startOffset := ra.start % info.File.ChunkSize
 	endOffset := ((ra.start + ra.length - 1) % info.File.ChunkSize) + 1
-	return ft.deliverer.SendChunks(r.Context(), zlog, w, chunks, fileID, &startOffset, &endOffset)
+
+	// Status code must be written before any calls to w.Write. But we cannot return any HTTP errors after this.
+	// So errors are logged, but not returned from this point forward
+	w.WriteHeader(http.StatusPartialContent)
+	if err := ft.deliverer.SendChunks(r.Context(), zlog, w, chunks, fileID, &startOffset, &endOffset); err != nil {
+		zlog.Error().Err(err).Msg("error streaming file range after response began")
+		// intentionally do not return the error
+	}
+	return nil
 }
 
 /*

--- a/internal/pkg/api/handleFileDelivery_test.go
+++ b/internal/pkg/api/handleFileDelivery_test.go
@@ -489,6 +489,7 @@ func TestFileDeliveryInvalidRangeReq(t *testing.T) {
 	}{
 		{"900-1200", http.StatusRequestedRangeNotSatisfiable},
 		{"100-20", http.StatusRequestedRangeNotSatisfiable},
+		{"0-50, 100-150", http.StatusRequestedRangeNotSatisfiable}, // multipart range should give 416
 	}
 
 	for _, tc := range cases {

--- a/internal/pkg/api/handleFileDelivery_test.go
+++ b/internal/pkg/api/handleFileDelivery_test.go
@@ -7,11 +7,14 @@
 package api
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -320,6 +323,7 @@ func TestFileDeliverySetsHeaders(t *testing.T) {
 	assert.Equal(t, "text/csv", rec.Header().Get("Content-Type"))
 	assert.Equal(t, "4", rec.Header().Get("Content-Length"))
 	assert.Empty(t, rec.Header().Get("X-File-SHA2"))
+	assert.Equal(t, "bytes", rec.Header().Get("Accept-Ranges"))
 }
 
 func TestFileDeliverySetsHashWhenPresent(t *testing.T) {
@@ -379,6 +383,106 @@ func TestFileDeliverySetsHashWhenPresent(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "deadbeef", rec.Header().Get("X-File-SHA2"))
+}
+
+func TestRangeParsing(t *testing.T) {
+
+	cases := []struct {
+		header            string
+		expectedStartByte int64
+		expectedLength    int64
+		fileSize          int64
+	}{
+		{"bytes=0-209", 0, 210, 600},
+		{"bytes=50-499", 50, 450, 600},
+		{"bytes=-100", 500, 100, 600},
+		{"bytes=400-", 400, 200, 600},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.header, func(t *testing.T) {
+			ranges, err := parseRange(tc.header, tc.fileSize)
+			require.NoError(t, err)
+			assert.Equal(t, 1, len(ranges))
+			assert.Equal(t, httpRange{tc.expectedStartByte, tc.expectedLength}, ranges[0])
+		})
+	}
+
+}
+
+func TestFileDeliveryRangeSupport(t *testing.T) {
+	hr, _, tx, bulk := prepareFileDeliveryMock(t)
+
+	mockChunkSize := 100
+	mockFileSize := 600
+
+	mockBodyBytes := mockChunkedFile(tx, bulk, int64(mockChunkSize), int64(mockFileSize), "X")
+
+	// Testing behaviors described in https://datatracker.ietf.org/doc/html/rfc9110#section-14.1.2
+	cases := []struct {
+		rangeReq      string // byte string as requested
+		expectedStart int
+		expectedEnd   int
+	}{
+		{"10-209", 10, 209},
+		{"103-443", 103, 443},
+		{"0-306", 0, 306},
+		{"7-30", 7, 30},                                // range within a single chunk
+		{"405-", 405, mockFileSize - 1},                // open-ended, goes to EOF
+		{"-150", mockFileSize - 150, mockFileSize - 1}, // last N bytes format
+		{"400-900", 400, mockFileSize - 1},             // if larger than end, server corrects it to be the file-end
+		{"-900", 0, mockFileSize - 1},                  // suffix spec greater than file size self-corrects and gives the whole file
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.rangeReq, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/fleet/file/X", nil)
+			req.Header.Set("Range", "bytes="+tc.rangeReq)
+
+			hr.ServeHTTP(rec, req)
+			require.Equal(t, http.StatusPartialContent, rec.Code)
+			assert.Equal(t, fmt.Sprintf("bytes %d-%d/%d", tc.expectedStart, tc.expectedEnd, mockFileSize), rec.Header().Get("Content-Range"))
+			assert.Equal(t, strconv.Itoa(tc.expectedEnd-tc.expectedStart+1), rec.Header().Get("Content-Length"))
+			assert.Equal(t, tc.expectedEnd-tc.expectedStart+1, rec.Body.Len())
+			assert.Equal(t, mockBodyBytes[tc.expectedStart:tc.expectedEnd+1], rec.Body.Bytes())
+
+		})
+	}
+
+}
+
+func TestFileDeliveryInvalidRangeReq(t *testing.T) {
+	hr, _, tx, bulk := prepareFileDeliveryMock(t)
+
+	mockChunkSize := 64
+	mockFileSize := 450
+
+	mockBodyBytes := mockChunkedFile(tx, bulk, int64(mockChunkSize), int64(mockFileSize), "X")
+	_ = mockBodyBytes
+
+	// invalid ranges
+	cases := []struct {
+		rangeReq         string // byte string as requested
+		expectedHTTPCode int
+	}{
+		{"900-1200", http.StatusRequestedRangeNotSatisfiable},
+		{"100-20", http.StatusRequestedRangeNotSatisfiable},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.rangeReq, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/fleet/file/X", nil)
+			req.Header.Set("Range", "bytes="+tc.rangeReq)
+
+			hr.ServeHTTP(rec, req)
+			require.Equal(t, tc.expectedHTTPCode, rec.Code)
+
+		})
+	}
 }
 
 func TestFileLibraryDeliveryStopsEmptyClients(t *testing.T) {
@@ -540,10 +644,101 @@ func prepareFileDeliveryMock(t *testing.T) (http.Handler, apiServer, *MockTransp
 	return Handler(&si), si, tx, fakebulk
 }
 
+func mockChunkedFile(tx *MockTransport, bulk *itesting.MockBulk, mockChunkSize int64, mockFileSize int64, fileID string) []byte {
+	mockBodyBytes := make([]byte, mockFileSize)
+	j := 0
+	for i := range mockFileSize {
+		mockBodyBytes[i] = byte(j)
+		j += 1
+		if j > 255 {
+			j = 0
+		}
+	}
+	chunkHits := make([]es.HitT, int(math.Ceil(float64(mockFileSize)/float64(mockChunkSize))))
+	for i := range chunkHits {
+		chunkHits[i] = es.HitT{
+			ID:      fmt.Sprintf("%s.%d", fileID, i),
+			SeqNo:   1,
+			Version: 1,
+			Index:   fmt.Sprintf(delivery.FileDataIndexPattern, "endpoint"),
+			Fields: map[string]any{
+				file.FieldBaseID: []any{fileID},
+			},
+		}
+		if i == len(chunkHits)-1 {
+			chunkHits[i].Fields[file.FieldLast] = []any{true}
+		}
+	}
+
+	bulk.On("Search", mock.Anything, isFileMetaSearch, mock.Anything, mock.Anything, mock.Anything).Return(
+		&es.ResultT{
+			HitsT: es.HitsT{
+				Hits: []es.HitT{{
+					ID:      fileID,
+					SeqNo:   1,
+					Version: 1,
+					Index:   fmt.Sprintf(delivery.FileHeaderIndexPattern, "endpoint"),
+					Source: fmt.Appendf(nil, `{
+						"file": {
+							"created": "2023-06-05T15:23:37.499Z",
+							"Status": "READY",
+							"Updated": "2023-06-05T15:23:37.499Z",
+							"name": "somefile",
+							"mime_type": "application/octet-stream",
+							"Meta": {
+								"target_agents": ["someagent"],
+								"action_id": ""
+							},
+							"size": %d,
+							"ChunkSize": %d
+						}
+					}`, mockFileSize, mockChunkSize),
+				}},
+			},
+		}, nil,
+	)
+	bulk.On("Search", mock.Anything, isFileChunkSearch, mock.Anything, mock.Anything, mock.Anything).Return(
+		&es.ResultT{
+			HitsT: es.HitsT{
+				Hits: chunkHits,
+			},
+		}, nil,
+	)
+
+	mockChunks := make([][]byte, len(chunkHits))
+	for i := range chunkHits {
+		sliceTo := int64(math.Min(float64((int64(i)+1)*mockChunkSize), float64(mockFileSize)))
+		mockChunks[i] = mockChunkCBOR(fmt.Sprintf("%s.%d", fileID, i), mockBodyBytes[int64(i)*mockChunkSize:sliceTo])
+	}
+
+	tx.RoundTripFn = func(req *http.Request) (*http.Response, error) {
+		// Parse out the chunk number requested
+		parts := strings.Split(req.URL.Path, "/") // ["", ".fleet-filedelivery-data-endpoint-0001", "_doc", "xyz.1"]
+		docIdx := strings.TrimPrefix(parts[3], fileID+".")
+		docnum, err := strconv.Atoi(docIdx)
+		if err != nil {
+			return nil, err
+		}
+
+		if docnum < 0 || docnum > len(mockChunks)-1 {
+			return nil, errors.New("invalid chunk")
+		}
+		return sendBodyBytes(mockChunks[docnum]), nil
+	}
+
+	return mockBodyBytes
+}
+
 func hexDecode(s string) []byte {
 	data, err := hex.DecodeString(s)
 	if err != nil {
 		panic(err)
 	}
 	return data
+}
+
+func mockChunkCBOR(docid string, data []byte) []byte {
+	dlen := make([]byte, 4)
+	binary.BigEndian.PutUint32(dlen, uint32(len(data)))
+	return hexDecode(fmt.Sprintf("A7665F696E64657878212E666C6565742D66696C6564656C69766572792D646174612D656E64706F696E74635F6964%02X%02X685F76657273696F6E01675F7365715F6E6F016D5F7072696D6172795F7465726D0165666F756E64F5666669656C6473A16464617461815A%02X%02X", len(docid)+0x60, docid, dlen, data))
 }

--- a/internal/pkg/api/handleFileDelivery_test.go
+++ b/internal/pkg/api/handleFileDelivery_test.go
@@ -420,6 +420,8 @@ func TestRangeParsingErrs(t *testing.T) {
 		"bytes=--400",
 		"bytes=-100-400",
 		"bytes=20--100",
+		"bytes=-0",
+		"bytes=0",
 	}
 
 	for _, tc := range cases {
@@ -428,6 +430,22 @@ func TestRangeParsingErrs(t *testing.T) {
 			assert.Error(t, err)
 		})
 	}
+}
+
+// empty range requests that should not produce any ranges
+func TestIgnoredRangeRequests(t *testing.T) {
+	cases := []string{
+		"",
+		"bytes=",
+	}
+	for _, tc := range cases {
+		t.Run(tc, func(t *testing.T) {
+			ranges, err := parseRange(tc, 1024)
+			assert.NoError(t, err)
+			assert.Nil(t, ranges)
+		})
+	}
+
 }
 
 func TestFileDeliveryRangeSupport(t *testing.T) {

--- a/internal/pkg/api/handleFileDelivery_test.go
+++ b/internal/pkg/api/handleFileDelivery_test.go
@@ -407,7 +407,27 @@ func TestRangeParsing(t *testing.T) {
 			assert.Equal(t, httpRange{tc.expectedStartByte, tc.expectedLength}, ranges[0])
 		})
 	}
+}
 
+func TestRangeParsingErrs(t *testing.T) {
+
+	cases := []string{
+		"bytes=100-40",
+		"bytes=40",
+		"bytes 9-99",
+		"400-500",
+		"bytes=start-end",
+		"bytes=--400",
+		"bytes=-100-400",
+		"bytes=20--100",
+	}
+
+	for _, tc := range cases {
+		t.Run(tc, func(t *testing.T) {
+			_, err := parseRange(tc, 1024)
+			assert.Error(t, err)
+		})
+	}
 }
 
 func TestFileDeliveryRangeSupport(t *testing.T) {

--- a/internal/pkg/file/delivery/delivery.go
+++ b/internal/pkg/file/delivery/delivery.go
@@ -95,13 +95,13 @@ func (d *Deliverer) LocateChunks(ctx context.Context, zlog zerolog.Logger, fileI
 	return infos, nil
 }
 
-func (d *Deliverer) SendFile(ctx context.Context, zlog zerolog.Logger, w io.Writer, chunks []file.ChunkInfo, fileID string) error {
+func (d *Deliverer) SendChunks(ctx context.Context, zlog zerolog.Logger, w io.Writer, chunks []file.ChunkInfo, fileID string, startOffset *uint64, endOffset *uint64) error {
 	span, ctx := apm.StartSpan(ctx, "response", "write")
 	defer span.End()
 	sort.SliceStable(chunks, func(i, j int) bool {
 		return chunks[i].Pos < chunks[j].Pos
 	})
-	for _, chunkInfo := range chunks {
+	for i, chunkInfo := range chunks {
 		body, err := readChunkStream(ctx, d.client, chunkInfo.Index, chunkInfo.ID)
 		if err != nil {
 			zlog.Error().Err(err).Str("fileID", fileID).Str("chunkID", chunkInfo.ID).Msg("error reading chunk stream")
@@ -115,7 +115,12 @@ func (d *Deliverer) SendFile(ctx context.Context, zlog zerolog.Logger, w io.Writ
 			zlog.Error().Err(err).Str("fileID", fileID).Str("chunkID", chunkInfo.ID).Msg("error decoding chunk")
 			return err
 		}
-
+		if i == len(chunks)-1 && endOffset != nil {
+			chunk = chunk[:*endOffset]
+		}
+		if i == 0 && startOffset != nil {
+			chunk = chunk[*startOffset:]
+		}
 		n, err := w.Write(chunk)
 		if err != nil {
 			zlog.Error().Err(err).Str("fileID", fileID).Str("chunkID", chunkInfo.ID).Msg("error writing chunk to output")

--- a/internal/pkg/file/delivery/delivery.go
+++ b/internal/pkg/file/delivery/delivery.go
@@ -95,7 +95,10 @@ func (d *Deliverer) LocateChunks(ctx context.Context, zlog zerolog.Logger, fileI
 	return infos, nil
 }
 
-func (d *Deliverer) SendChunks(ctx context.Context, zlog zerolog.Logger, w io.Writer, chunks []file.ChunkInfo, fileID string, startOffset *uint64, endOffset *uint64) error {
+func (d *Deliverer) SendChunks(ctx context.Context, zlog zerolog.Logger, w io.Writer, chunks []file.ChunkInfo, fileID string, startOffset *int64, endOffset *int64) error {
+	if (startOffset != nil && *startOffset < 0) || (endOffset != nil && *endOffset < 0) {
+		return errors.New("invalid range offset")
+	}
 	span, ctx := apm.StartSpan(ctx, "response", "write")
 	defer span.End()
 	sort.SliceStable(chunks, func(i, j int) bool {

--- a/internal/pkg/file/delivery/delivery_test.go
+++ b/internal/pkg/file/delivery/delivery_test.go
@@ -7,6 +7,7 @@ package delivery
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -173,7 +174,7 @@ func TestSendFile(t *testing.T) {
 	// Chunk data from a tiny PNG, as a full CBOR document
 	esMock.Response = sendBodyBytes(hexDecode("bf665f696e64657878212e666c6565742d66696c6564656c69766572792d646174612d656e64706f696e74635f6964654142432e30685f76657273696f6e02675f7365715f6e6f016d5f7072696d6172795f7465726d0165666f756e64f5666669656c6473bf64646174619f586789504e470d0a1a0a0000000d494844520000010000000100010300000066bc3a2500000003504c5445b5d0d0630416ea0000001f494441546881edc1010d000000c2a0f74f6d0e37a00000000000000000be0d210000019a60e1d50000000049454e44ae426082ffffff")) //nolint:bodyclose // nopcloser is used, linter does not see it
 	d := New(esClient, fakeBulk, nil)
-	err := d.SendFile(context.Background(), zerolog.Logger{}, buf, chunks, fileID)
+	err := d.SendChunks(context.Background(), zerolog.Logger{}, buf, chunks, fileID, nil, nil)
 	require.NoError(t, err)
 
 	// the byte string is the bare PNG file data
@@ -209,7 +210,7 @@ func TestSendFileMultipleChunks(t *testing.T) {
 	}
 
 	d := New(esClient, fakeBulk, nil)
-	err := d.SendFile(context.Background(), zerolog.Logger{}, buf, chunks, fileID)
+	err := d.SendChunks(context.Background(), zerolog.Logger{}, buf, chunks, fileID, nil, nil)
 	require.NoError(t, err)
 
 	// the collective bytes sent (0xabcd in first chunk, 0xef01 in second)
@@ -250,7 +251,7 @@ func TestSendFileMultipleChunksUsesBackingIndex(t *testing.T) {
 	}
 
 	d := New(esClient, fakeBulk, nil)
-	err := d.SendFile(context.Background(), zerolog.Logger{}, buf, chunks, fileID)
+	err := d.SendChunks(context.Background(), zerolog.Logger{}, buf, chunks, fileID, nil, nil)
 	require.NoError(t, err)
 }
 
@@ -308,8 +309,65 @@ func TestSendFileHandlesDisorderedChunks(t *testing.T) {
 	}
 
 	d := New(esClient, fakeBulk, nil)
-	err := d.SendFile(context.Background(), zerolog.Logger{}, buf, chunks, fileID)
+	err := d.SendChunks(context.Background(), zerolog.Logger{}, buf, chunks, fileID, nil, nil)
 	require.NoError(t, err)
+}
+
+func TestSendChunkRanges(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+
+	fakeBulk := itesting.NewMockBulk()
+	esClient, esMock := mockESClient(t)
+
+	const fileID = "xyz"
+	idx := fmt.Sprintf(FileDataIndexPattern, "endpoint") + "-0001"
+
+	chunkLength := 200
+
+	chunkBody := make([]byte, chunkLength)
+	for i := range chunkBody {
+		chunkBody[i] = byte(i)
+	}
+
+	chunks := []file.ChunkInfo{
+		{Index: idx, ID: fileID + ".5", Pos: 5}, // lowest position, given a subset of file's chunks
+		{Index: idx, ID: fileID + ".6", Pos: 6},
+		{Index: idx, ID: fileID + ".7", Pos: 7},
+		{Index: idx, ID: fileID + ".8", Pos: 8},
+		{Index: idx, ID: fileID + ".9", Pos: 9},
+		{Index: idx, ID: fileID + ".10", Pos: 10},
+	}
+
+	expectedIdx := 5
+	esMock.RoundTripFn = func(req *http.Request) (*http.Response, error) {
+		// Parse out the chunk number requested
+		parts := strings.Split(req.URL.Path, "/") // ["", ".fleet-filedelivery-data-endpoint-0001", "_doc", "xyz.1"]
+		docIdx := strings.TrimPrefix(parts[3], fileID+".")
+		docnum, err := strconv.Atoi(docIdx)
+		require.NoError(t, err)
+
+		// should be our expected increasing counter
+		assert.Equal(t, expectedIdx, docnum)
+		expectedIdx += 1
+		return sendBodyBytes(mockChunkCBOR(parts[3], chunkBody)), nil
+	}
+
+	startOffset := uint64(100)
+	endOffset := uint64(50)
+
+	d := New(esClient, fakeBulk, nil)
+	err := d.SendChunks(t.Context(), zerolog.Logger{}, buf, chunks, fileID, &startOffset, &endOffset)
+	require.NoError(t, err)
+
+	expectedLength := (chunkLength - int(startOffset)) + // first chunk [startOffset:]
+		(len(chunks)-2)*chunkLength + // middle chunks, excluding first and last
+		int(endOffset) // last chunk:  [:endOffset]
+	assert.Equal(t, expectedLength, buf.Len())
+
+	output := buf.Bytes()
+
+	assert.Equal(t, chunkBody[startOffset:], output[:chunkLength-int(startOffset)])
+	assert.Equal(t, chunkBody, output[chunkLength-int(startOffset):chunkLength+int(startOffset)])
 }
 
 /*
@@ -359,4 +417,10 @@ func hexDecode(s string) []byte {
 		panic(err)
 	}
 	return data
+}
+
+func mockChunkCBOR(docid string, data []byte) []byte {
+	dlen := make([]byte, 4)
+	binary.BigEndian.PutUint32(dlen, uint32(len(data)))
+	return hexDecode(fmt.Sprintf("A7665F696E64657878212E666C6565742D66696C6564656C69766572792D646174612D656E64706F696E74635F6964%02X%02X685F76657273696F6E01675F7365715F6E6F016D5F7072696D6172795F7465726D0165666F756E64F5666669656C6473A16464617461815A%02X%02X", len(docid)+0x60, docid, dlen, data))
 }

--- a/internal/pkg/file/delivery/delivery_test.go
+++ b/internal/pkg/file/delivery/delivery_test.go
@@ -352,8 +352,8 @@ func TestSendChunkRanges(t *testing.T) {
 		return sendBodyBytes(mockChunkCBOR(parts[3], chunkBody)), nil
 	}
 
-	startOffset := uint64(100)
-	endOffset := uint64(50)
+	startOffset := int64(100)
+	endOffset := int64(50)
 
 	d := New(esClient, fakeBulk, nil)
 	err := d.SendChunks(t.Context(), zerolog.Logger{}, buf, chunks, fileID, &startOffset, &endOffset)
@@ -421,6 +421,6 @@ func hexDecode(s string) []byte {
 
 func mockChunkCBOR(docid string, data []byte) []byte {
 	dlen := make([]byte, 4)
-	binary.BigEndian.PutUint32(dlen, uint32(len(data)))
+	binary.BigEndian.PutUint32(dlen, uint32(len(data))) //nolint:gosec // disable G115, lengths cannot be negative
 	return hexDecode(fmt.Sprintf("A7665F696E64657878212E666C6565742D66696C6564656C69766572792D646174612D656E64706F696E74635F6964%02X%02X685F76657273696F6E01675F7365715F6E6F016D5F7072696D6172795F7465726D0165666F756E64F5666669656C6473A16464617461815A%02X%02X", len(docid)+0x60, docid, dlen, data))
 }

--- a/model/openapi.yml
+++ b/model/openapi.yml
@@ -1984,6 +1984,19 @@ paths:
               schema:
                 type: string
                 format: binary
+        "206":
+          description: Partial File Contents
+          headers:
+            Content-Range:
+              description: Byte range of returned file section
+              schema:
+                type: string
+                examples:
+                  - "500-4096/250000"
+            Elastic-Api-Version:
+              $ref: "#/components/headers/apiVersion"
+            X-Request-Id:
+              $ref: "#/components/headers/requestID"
         "400":
           $ref: "#/components/responses/badRequest"
         "401":
@@ -2008,6 +2021,13 @@ paths:
                     message: Client is not authorized
         "404":
           description: bad path, file not found
+          headers:
+            Elastic-Api-Version:
+              $ref: "#/components/headers/apiVersion"
+            X-Request-Id:
+              $ref: "#/components/headers/requestID"
+        "416":
+          description: Range Not Satisfiable
           headers:
             Elastic-Api-Version:
               $ref: "#/components/headers/apiVersion"


### PR DESCRIPTION

## What is the problem this PR solves?

Enables clients (e.g. endpoint) to gracefully resume downloads of (large) files via the HTTP Range header.

This allows for completing large file transfers under unstable or periodic network conditions, as opposed to starting the file download over.

**N.B.**: 
- This only supports single ranges (e.g. `bytes=100-400`) and not multipart range requests (e.g. `bytes=0-500, 1024-2048, -600`).  
- Also HTTP Spec allows for graceful degradation here. For unclear range headers (or for any reason if the server chooses not to fulfill a particular range), either a `416 Range Unsatisfiable` error OR `HTTP 200` with full file contents are both acceptable responses.  This implementation mostly generates 416s for clients to handle malformed byte strings, but in narrow cases where intent is unclear (e.g. the header is present without a value: `Range: `) then we do fall back to HTTP 200 with file contents, as spec defines.

## How does this PR solve the problem?

Only fetch chunks that fall inside the requested range




## Design Checklist

<!-- Mandatory
This checklist is a reminder about high level design problems that should be considered for any change made to fleet server.
-->

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [x] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

<!-- Mandatory
This checklist is to help creators of PRs to find parts which might not be directly related to code change but still need to be addressed. Anything that does not apply to the PR should be removed from the checklist.
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
