### PR TITLE
Add checkin capacity-rejection rate metric to /stats

### DIFF
--- a/changelog/fragments/1783459187-checkin-capacity-rejection-rate-metric.yaml
+++ b/changelog/fragments/1783459187-checkin-capacity-rejection-rate-metric.yaml
@@ -1,0 +1,17 @@
+kind: enhancement
+
+summary: Expose a checkin capacity-rejection rate metric for use as an autoscaling signal
+
+description: |
+  Adds a new http_server.routes.checkin.limit_max_rate gauge to the internal
+  /stats endpoint. It is a rolling, server-computed rate (rejections/sec) of the
+  existing http_server.routes.checkin.limit_max counter, which tracks checkins
+  rejected because Fleet Server was at capacity (the per-route concurrency limit
+  was reached).
+
+  Unlike checkin volume, this counter can only be incremented by Fleet Server
+  itself, so it can't be inflated by a client checking in unusually often. This
+  makes the rate a safer signal than raw checkin throughput for driving
+  autoscaling decisions elsewhere (e.g. fleet-controller's EPA configuration).
+
+component: fleet-server

--- a/internal/pkg/api/metrics.go
+++ b/internal/pkg/api/metrics.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -149,6 +150,14 @@ func (g *statsGauge) Dec() {
 	g.gauge.Dec()
 }
 
+// Set overwrites the gauge's current value. Used for values that are computed
+// out-of-band (e.g. a rate sampled on an interval) rather than incremented in
+// the request path.
+func (g *statsGauge) Set(v uint64) {
+	g.metric.Set(v)
+	g.gauge.Set(float64(v))
+}
+
 // statsCounter wraps counters for internal libbeat and prometheus
 type statsCounter struct {
 	metric  *monitoring.Uint
@@ -177,16 +186,28 @@ func (g *statsCounter) Inc() {
 	g.counter.Inc()
 }
 
+// Get returns the counter's current value. Used by out-of-band samplers (e.g.
+// a rate computation) that need to read a counter without incrementing it.
+func (g *statsCounter) Get() uint64 {
+	return g.metric.Get()
+}
+
 // routeStats is the generic collection metrics that we collect per API route.
 type routeStats struct {
 	active    *statsGauge
 	total     *statsCounter
 	rateLimit *statsCounter
 	maxLimit  *statsCounter
-	failure   *statsCounter
-	drop      *statsCounter
-	bodyIn    *statsCounter
-	bodyOut   *statsCounter
+	// maxLimitRate is a rolling per-interval rate (rejections/sec) derived from
+	// maxLimit. Unlike maxLimit (a monotonically increasing counter), this is a
+	// point-in-time gauge suitable for use as an autoscaling trigger: it reflects
+	// current saturation rather than lifetime totals. Populated out-of-band by a
+	// sampler (see RunCheckinRejectionRateSampler); zero until sampled.
+	maxLimitRate *statsGauge
+	failure      *statsCounter
+	drop         *statsCounter
+	bodyIn       *statsCounter
+	bodyOut      *statsCounter
 }
 
 func (rt *routeStats) Register(registry *metricsRegistry) {
@@ -194,6 +215,7 @@ func (rt *routeStats) Register(registry *metricsRegistry) {
 	rt.total = newCounter(registry, "total")
 	rt.rateLimit = newCounter(registry, "limit_rate")
 	rt.maxLimit = newCounter(registry, "limit_max")
+	rt.maxLimitRate = newGauge(registry, "limit_max_rate")
 	rt.failure = newCounter(registry, "fail")
 	rt.drop = newCounter(registry, "drop")
 	rt.bodyIn = newCounter(registry, "body_in")
@@ -302,4 +324,48 @@ func attachPrometheusEndpoint(router metricsRouter, reg *prometheus.Registry, bi
 
 	h := promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
 	router.AddRoute("/metrics", promhttp.InstrumentMetricHandler(reg, h).ServeHTTP)
+}
+
+// CheckinRateSampleInterval is how often RunCheckinRejectionRateSampler recomputes
+// the checkin capacity-rejection rate.
+const CheckinRateSampleInterval = 10 * time.Second
+
+// computeRate returns the non-negative per-second rate of change between prev and
+// cur over the elapsed duration dt, rounded to the nearest integer. It returns 0
+// if dt is non-positive or if cur < prev (e.g. a process restart reset the
+// underlying counter to zero), since a rejection rate can never be negative.
+func computeRate(prev, cur uint64, dt time.Duration) uint64 {
+	if dt <= 0 || cur < prev {
+		return 0
+	}
+	return uint64(float64(cur-prev)/dt.Seconds() + 0.5)
+}
+
+// RunCheckinRejectionRateSampler periodically samples the checkin route's
+// limit_max counter (checkins rejected because Fleet Server was at capacity) and
+// publishes the resulting rate as the limit_max_rate gauge.
+//
+// Unlike checkin volume (which a client can inflate), limit_max only increments
+// when Fleet Server itself rejects a checkin due to the per-route concurrency
+// limit, so the resulting rate is a server-side signal of saturation suitable for
+// use as an autoscaling trigger. It complements http_server.tcp_active, which can
+// understate demand when connections are being turned away rather than accepted.
+//
+// Run blocks until ctx is canceled, following the same lifecycle contract as the
+// other subsystems started in Fleet.runSubsystems.
+func RunCheckinRejectionRateSampler(ctx context.Context, interval time.Duration) error {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	prev, prevT := cntCheckin.maxLimit.Get(), time.Now()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case now := <-ticker.C:
+			cur := cntCheckin.maxLimit.Get()
+			cntCheckin.maxLimitRate.Set(computeRate(prev, cur, now.Sub(prevT)))
+			prev, prevT = cur, now
+		}
+	}
 }

--- a/internal/pkg/api/metrics.go
+++ b/internal/pkg/api/metrics.go
@@ -330,10 +330,21 @@ func attachPrometheusEndpoint(router metricsRouter, reg *prometheus.Registry, bi
 // the checkin capacity-rejection rate.
 const CheckinRateSampleInterval = 10 * time.Second
 
-// computeRate returns the non-negative per-second rate of change between prev and
-// cur over the elapsed duration dt, rounded to the nearest integer. It returns 0
-// if dt is non-positive or if cur < prev (e.g. a process restart reset the
-// underlying counter to zero), since a rejection rate can never be negative.
+// computeRate returns the count of rejections (cur-prev) divided by an elapsed
+// time (dt), rounded to the nearest integer. It returns 0 if dt is non-positive
+// or if cur < prev: a count of rejections can only increase, so a computed
+// decrease means the counter was reset or wrapped around rather than a genuine
+// negative rate, which wouldn't be meaningful for a count of events.
+//
+// The raw rate (cur-prev)/dt.Seconds() is usually fractional (e.g. 2.5
+// rejections/sec), but converting a float64 to uint64 in Go truncates toward
+// zero rather than rounding, which would silently bias every result down (2.5
+// would become 2, and a real but small rate like 0.6 would floor to 0 and look
+// like no rejections at all). Adding 0.5 before truncating is the standard
+// "round half up" trick: floor(x+0.5) lands on the nearest integer instead of
+// always the one below it (e.g. 2.5+0.5=3.0 truncates to 3; 0.6+0.5=1.1
+// truncates to 1). This only rounds correctly for non-negative x, which the
+// dt<=0 || cur<prev guard above guarantees.
 func computeRate(prev, cur uint64, dt time.Duration) uint64 {
 	if dt <= 0 || cur < prev {
 		return 0

--- a/internal/pkg/api/metrics_integration_test.go
+++ b/internal/pkg/api/metrics_integration_test.go
@@ -7,6 +7,7 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -43,8 +44,27 @@ func TestMetricsEndpoints(t *testing.T) {
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
-			resp.Body.Close()
+			defer resp.Body.Close()
 			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			if path == "/stats" {
+				var stats map[string]any
+				require.NoError(t, json.NewDecoder(resp.Body).Decode(&stats))
+
+				httpServer, ok := stats["http_server"].(map[string]any)
+				require.True(t, ok, "expected http_server object in /stats response, got: %v", stats)
+				routes, ok := httpServer["routes"].(map[string]any)
+				require.True(t, ok, "expected http_server.routes object, got: %v", httpServer)
+				checkin, ok := routes["checkin"].(map[string]any)
+				require.True(t, ok, "expected http_server.routes.checkin object, got: %v", routes)
+
+				// limit_max_rate is the checkin capacity-rejection rate gauge used as
+				// an autoscaling trigger; it must always be present (even if 0, since
+				// no checkins have been rejected in this test) so that consumers like
+				// fleet-controller's EPA config can rely on it being scraped.
+				require.Contains(t, checkin, "limit_max_rate")
+				require.InDelta(t, 0, checkin["limit_max_rate"], 0, "expected limit_max_rate to be 0 with no rejected checkins")
+			}
 		})
 	}
 }

--- a/internal/pkg/api/metrics_test.go
+++ b/internal/pkg/api/metrics_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -73,7 +72,7 @@ func TestComputeRate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, computeRate(tt.prev, tt.cur, tt.dt))
+			require.Equal(t, tt.want, computeRate(tt.prev, tt.cur, tt.dt))
 		})
 	}
 }
@@ -94,7 +93,6 @@ func TestRunCheckinRejectionRateSampler(t *testing.T) {
 	cntCheckin.Register(registry.newRegistry(fmt.Sprintf("test_checkin_rejection_rate_sampler_%d", testRegistrySeq.Add(1))))
 
 	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 
 	const interval = 10 * time.Millisecond
 	done := make(chan error, 1)
@@ -124,25 +122,20 @@ func TestRunCheckinRejectionRateSampler(t *testing.T) {
 		}
 	}()
 
-	var sawPositiveRate atomic.Bool
-	deadline := time.After(20 * interval)
-poll:
-	for {
-		select {
-		case <-deadline:
-			break poll
-		default:
-			if cntCheckin.maxLimitRate.metric.Get() > 0 {
-				sawPositiveRate.Store(true)
-				break poll
-			}
-			time.Sleep(interval / 4)
-		}
-	}
+	// Stop both goroutines and wait for them to actually exit before this test
+	// returns -- registered as Cleanup, like the cntCheckin restoration above, so
+	// it still runs if require.Eventually below fails (which unwinds via
+	// runtime.Goexit, skipping any code after it). Cleanup funcs run in LIFO
+	// order, so this (registered second) runs before the cntCheckin restoration
+	// (registered first) -- otherwise that restoration could race with either
+	// goroutine still running and mutating the shared cntCheckin global.
+	t.Cleanup(func() {
+		cancel()
+		require.NoError(t, <-done)
+		<-injectorDone
+	})
 
-	cancel()
-	require.NoError(t, <-done)
-	<-injectorDone
-
-	assert.True(t, sawPositiveRate.Load(), "expected the rejection rate gauge to become positive while rejections were ongoing")
+	require.Eventually(t, func() bool {
+		return cntCheckin.maxLimitRate.metric.Get() > 0
+	}, 20*interval, interval/4, "expected the rejection rate gauge to become positive while rejections were ongoing")
 }

--- a/internal/pkg/api/metrics_test.go
+++ b/internal/pkg/api/metrics_test.go
@@ -1,0 +1,148 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testRegistrySeq disambiguates the throwaway metrics registry name used by
+// TestRunCheckinRejectionRateSampler across repeated runs in the same process.
+var testRegistrySeq atomic.Int64
+
+func TestComputeRate(t *testing.T) {
+	tests := []struct {
+		name string
+		prev uint64
+		cur  uint64
+		dt   time.Duration
+		want uint64
+	}{
+		{
+			name: "normal delta over one second",
+			prev: 100,
+			cur:  150,
+			dt:   time.Second,
+			want: 50,
+		},
+		{
+			name: "normal delta over multiple seconds, rounds to nearest",
+			prev: 100,
+			cur:  125,
+			dt:   10 * time.Second,
+			want: 3, // 2.5 rounds to 3
+		},
+		{
+			name: "no delta",
+			prev: 100,
+			cur:  100,
+			dt:   time.Second,
+			want: 0,
+		},
+		{
+			name: "zero elapsed time",
+			prev: 100,
+			cur:  200,
+			dt:   0,
+			want: 0,
+		},
+		{
+			name: "negative elapsed time",
+			prev: 100,
+			cur:  200,
+			dt:   -time.Second,
+			want: 0,
+		},
+		{
+			name: "counter reset (process restart)",
+			prev: 1000,
+			cur:  5,
+			dt:   time.Second,
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, computeRate(tt.prev, tt.cur, tt.dt))
+		})
+	}
+}
+
+func TestRunCheckinRejectionRateSampler(t *testing.T) {
+	// cntCheckin is a package-level global shared with the checkin route handler
+	// and other tests in this package. Swap in a throwaway routeStats registered
+	// under a private namespace for the duration of this test, then restore the
+	// original so other tests/handlers keep using the real, shared metrics.
+	orig := cntCheckin
+	t.Cleanup(func() { cntCheckin = orig })
+
+	// newGauge/newCounter register into the package-global prometheus registry,
+	// which panics on a duplicate name. Suffix with a per-call counter so this
+	// test can safely run more than once in the same process (e.g. `go test
+	// -count=N`, or a test-retry mechanism).
+	cntCheckin = routeStats{}
+	cntCheckin.Register(registry.newRegistry(fmt.Sprintf("test_checkin_rejection_rate_sampler_%d", testRegistrySeq.Add(1))))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	const interval = 10 * time.Millisecond
+	done := make(chan error, 1)
+	go func() {
+		done <- RunCheckinRejectionRateSampler(ctx, interval)
+	}()
+
+	// The rate gauge is a point-in-time reading: it goes back to 0 on any sample
+	// tick with no new rejections since the previous one, by design (it reflects
+	// current saturation, not a lifetime total). So rather than injecting a single
+	// burst and checking the gauge at an arbitrary later time -- which races
+	// against it decaying back to 0 on the next empty tick -- keep simulating
+	// rejections for the duration of the test and poll for the gauge having been
+	// positive at least once.
+	injectorDone := make(chan struct{})
+	go func() {
+		defer close(injectorDone)
+		t := time.NewTicker(interval / 2)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				cntCheckin.maxLimit.Add(1)
+			}
+		}
+	}()
+
+	var sawPositiveRate atomic.Bool
+	deadline := time.After(20 * interval)
+poll:
+	for {
+		select {
+		case <-deadline:
+			break poll
+		default:
+			if cntCheckin.maxLimitRate.metric.Get() > 0 {
+				sawPositiveRate.Store(true)
+				break poll
+			}
+			time.Sleep(interval / 4)
+		}
+	}
+
+	cancel()
+	require.NoError(t, <-done)
+	<-injectorDone
+
+	assert.True(t, sawPositiveRate.Load(), "expected the rejection rate gauge to become positive while rejections were ongoing")
+}

--- a/internal/pkg/server/fleet.go
+++ b/internal/pkg/server/fleet.go
@@ -524,6 +524,12 @@ func (f *Fleet) runSubsystems(ctx context.Context, cfg *config.Config, g *errgro
 	bc := checkin.NewBulk(bulker)
 	g.Go(loggedRunFunc(ctx, "Bulk checkin", bc.Run))
 
+	// Samples the checkin capacity-rejection counter into a rate gauge, exposed via
+	// /stats for use as an autoscaling signal. See api.RunCheckinRejectionRateSampler.
+	g.Go(loggedRunFunc(ctx, "Checkin rejection rate sampler", func(ctx context.Context) error {
+		return api.RunCheckinRejectionRateSampler(ctx, api.CheckinRateSampleInterval)
+	}))
+
 	ct, err := api.NewCheckinT(f.verCon, &cfg.Inputs[0].Server, f.cache, bc, pm, am, ad, bulker)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!-- Type of change: Enhancement -->

## What is the problem this PR solves?

The EPA autoscaler for Fleet Server (configured in fleet-controller) currently scales on `http_server.tcp_active` (active TCP connections). This has repeatedly failed to scale up pods fast enough under load in Serverless scale tests — including the 20k → 30k drone check-in test tracked in [elastic/ingest-dev#7719](https://github.com/elastic/ingest-dev/issues/7719), and other runs such as a recent 5k test where the autoscaler did not add pods when it should have.

The root cause: when a pod is saturated, agents being turned away don't count as "active" connections, so `tcp_active` understates real demand and the autoscaler under-reacts.

In [this comment](https://github.com/elastic/ingest-dev/issues/7719#issuecomment-4810371846), @cmacknz suggested scaling on the rate of check-ins rejected because Fleet Server was at capacity instead — a server-side saturation signal that (unlike checkin volume) can't be inflated by a valid-but-misbehaving or malicious client.

Fleet Server already counts these rejections (`http_server.routes.checkin.limit_max`), but it's a monotonically increasing counter, not a rate — not directly usable as an autoscaler trigger (the EPA reads metric values as levels, not deltas).

## How does this PR solve the problem?

Adds a new gauge, `http_server.routes.checkin.limit_max_rate`, to the internal `/stats` endpoint. A new background subsystem (`api.RunCheckinRejectionRateSampler`, wired into `Fleet.runSubsystems` alongside the other subsystems) samples the existing `limit_max` counter every 10s and publishes the delta as a rejections/sec rate.

This is intentionally computed **inside Fleet Server**, not left to the consumer (e.g. an autoscaler) to derive from the raw counter, so the rate is available directly via `/stats` in a form ready to use as a metric target.

This PR only adds the metric; it does not change any existing behavior or defaults. A follow-up draft PR to fleet-controller (elastic/fleet-controller#623) wires the EPA to this new metric as an additional (not replacing) autoscaling trigger.

**⚠️ Deployment sequencing note:** the companion fleet-controller change must not be enabled until this change has been rolled out to **all** Fleet Server pods. The EPA has no fallback for a metric that's missing from a pod's `/stats` response — a missing metric aborts that reconcile cycle entirely (including evaluation of the existing `tcp_active` trigger), rather than degrading gracefully. See the fleet-controller PR for how this is gated (metric is opt-in via config, defaulted off).

## How to test this PR locally

1. Run fleet-server with the internal HTTP server enabled (`http.enabled: true`, default port `5066`).
2. `curl localhost:5066/stats | jq .http_server.routes.checkin.limit_max_rate` — should read `0` at idle.
3. Drive check-ins past `checkin_limit.max` (e.g. via a load test) and confirm the value rises, then falls back to `0` once rejections stop.
4. Or run `go test ./internal/pkg/api/... -run TestComputeRate` and `-run TestRunCheckinRejectionRateSampler` for the unit-level behavior, and `go test -tags integration ./internal/pkg/api/... -run TestMetricsEndpoints` for the `/stats` JSON shape.

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer. (Per-pod gauge, sampled from per-pod in-memory counters only — no shared state.)
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected. (Intended as part of the ingest-dev#7719 scale test follow-up; not yet run at 100K+.)
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc. (Purely observational — a read-only sampler goroutine on a 10s ticker; adds no load to the request path.)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (none needed — no new config)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the changelog tool

## Related issues

- Relates elastic/ingest-dev#7719

