### PR TITLE
Modify Time function to return error on parsing failure

### DIFF
--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -6,6 +6,7 @@
 package build
 
 import (
+	"errors"
 	"fmt"
 	"time"
 )
@@ -22,11 +23,11 @@ func (i Info) FullVersion() string {
 	return fmt.Sprintf("%s [%s built %s] (FIPS-distribution: %v)", i.Version, i.Commit, i.BuildTime, FIPSDistribution)
 }
 
-// Time parses the given string using RFC3339, or returns an empty time.Time.
-func Time(stime string) time.Time {
+// Time parses the given string using RFC3339, or returns an error if parsing fails.
+func Time(stime string) (time.Time, error) {
 	t, err := time.Parse(time.RFC3339, stime)
 	if err != nil {
-		return time.Time{}
+		return time.Time{}, err
 	}
-	return t
+	return t, nil
 }

--- a/internal/pkg/build/build.go
+++ b/internal/pkg/build/build.go
@@ -6,7 +6,6 @@
 package build
 
 import (
-	"errors"
 	"fmt"
 	"time"
 )

--- a/main.go
+++ b/main.go
@@ -29,10 +29,16 @@ var (
 )
 
 func main() {
+	buildTime, err := build.Time(BuildTime)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid build time %q: %v\n", BuildTime, err)
+		os.Exit(1)
+	}
+
 	cmd := fleet.NewCommand(build.Info{
 		Version:   Version,
 		Commit:    Commit,
-		BuildTime: build.Time(BuildTime),
+		BuildTime: buildTime,
 	})
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
This PR addresses a critical issue in the Time function, which fails to properly handle parsing errors. When the input fails to parse, the function currently returns an empty time.Time, leading to potential bugs and data corruption downstream. The root cause is a lack of error handling in the parsing logic. I've modified the Time function to return an error instead of an empty time.Time when parsing fails, improving error handling and robustness. To verify the fix, I ran the existing test suite and manually tested the function with various input scenarios, confirming that it correctly returns an error on parsing failures.