### PR TITLE
test: merge duplicate dispatch limit test functions into table-driven test

### DIFF
--- a/changelog/fragments/1785549600-fix-dupl-dispatch-limit-test.yaml
+++ b/changelog/fragments/1785549600-fix-dupl-dispatch-limit-test.yaml
@@ -1,0 +1,7 @@
+kind: other
+
+summary: Merge duplicate dispatch limit test functions into a table-driven test
+
+component: fleet-server
+
+pr: https://github.com/elastic/fleet-server/pull/7493

--- a/changelog/fragments/1785549600-fix-dupl-dispatch-limit-test.yaml
+++ b/changelog/fragments/1785549600-fix-dupl-dispatch-limit-test.yaml
@@ -1,7 +1,0 @@
-kind: other
-
-summary: Merge duplicate dispatch limit test functions into a table-driven test
-
-component: fleet-server
-
-pr: https://github.com/elastic/fleet-server/pull/7493

--- a/internal/pkg/bulk/dispatch_limit_test.go
+++ b/internal/pkg/bulk/dispatch_limit_test.go
@@ -59,16 +59,13 @@ func TestDispatchRejectsWhenLimitReached(t *testing.T) {
 }
 
 func TestDispatchAllowsDispatch(t *testing.T) {
-	tests := []struct {
-		name  string
-		limit int64
-	}{
-		{name: "under limit", limit: 10},
-		{name: "no limit when zero", limit: 0},
+	tests := map[string]int64{
+		"under limit":      10,
+		"no limit when zero": 0,
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			b := NewBulker(nil, nil, WithBlockQueueSize(1), WithMaxPendingBulkDispatches(tt.limit))
+	for name, limit := range tests {
+		t.Run(name, func(t *testing.T) {
+			b := NewBulker(nil, nil, WithBlockQueueSize(1), WithMaxPendingBulkDispatches(limit))
 
 			blk := b.newBlk(ActionSearch, optionsT{})
 			_, err := blk.buf.WriteString(`{"index":"test"}`)

--- a/internal/pkg/bulk/dispatch_limit_test.go
+++ b/internal/pkg/bulk/dispatch_limit_test.go
@@ -60,7 +60,7 @@ func TestDispatchRejectsWhenLimitReached(t *testing.T) {
 
 func TestDispatchSucceedsWhenBelowLimit(t *testing.T) {
 	tests := map[string]int64{
-		"under limit":      10,
+		"under limit":        10,
 		"no limit when zero": 0,
 	}
 	for name, limit := range tests {

--- a/internal/pkg/bulk/dispatch_limit_test.go
+++ b/internal/pkg/bulk/dispatch_limit_test.go
@@ -58,42 +58,31 @@ func TestDispatchRejectsWhenLimitReached(t *testing.T) {
 	wg.Wait()
 }
 
-func TestDispatchAllowsWhenUnderLimit(t *testing.T) {
-	b := NewBulker(nil, nil, WithBlockQueueSize(1), WithMaxPendingBulkDispatches(10))
+func TestDispatchAllowsDispatch(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit int64
+	}{
+		{name: "under limit", limit: 10},
+		{name: "no limit when zero", limit: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBulker(nil, nil, WithBlockQueueSize(1), WithMaxPendingBulkDispatches(tt.limit))
 
-	blk := b.newBlk(ActionSearch, optionsT{})
-	_, err := blk.buf.WriteString(`{"index":"test"}`)
-	require.NoError(t, err)
+			blk := b.newBlk(ActionSearch, optionsT{})
+			_, err := blk.buf.WriteString(`{"index":"test"}`)
+			require.NoError(t, err)
 
-	// Simulate the Run loop responding.
-	go func() {
-		item := <-b.ch
-		item.ch <- respT{}
-	}()
+			go func() {
+				item := <-b.ch
+				item.ch <- respT{}
+			}()
 
-	resp := b.dispatch(context.Background(), blk)
-	require.NoError(t, resp.err)
+			resp := b.dispatch(context.Background(), blk)
+			require.NoError(t, resp.err)
 
-	// Counter should be back to 0 after dispatch completes.
-	require.Equal(t, int64(0), b.pendingBulkDispatches.Load())
-}
-
-func TestDispatchNoLimitWhenZero(t *testing.T) {
-	// With maxPendingBulkDispatches=0, there should be no limit enforced.
-	b := NewBulker(nil, nil, WithBlockQueueSize(1), WithMaxPendingBulkDispatches(0))
-
-	blk := b.newBlk(ActionSearch, optionsT{})
-	_, err := blk.buf.WriteString(`{"index":"test"}`)
-	require.NoError(t, err)
-
-	go func() {
-		item := <-b.ch
-		item.ch <- respT{}
-	}()
-
-	resp := b.dispatch(context.Background(), blk)
-	require.NoError(t, resp.err)
-
-	// Counter should not have been touched (0 means disabled).
-	require.Equal(t, int64(0), b.pendingBulkDispatches.Load())
+			require.Equal(t, int64(0), b.pendingBulkDispatches.Load())
+		})
+	}
 }

--- a/internal/pkg/bulk/dispatch_limit_test.go
+++ b/internal/pkg/bulk/dispatch_limit_test.go
@@ -58,7 +58,7 @@ func TestDispatchRejectsWhenLimitReached(t *testing.T) {
 	wg.Wait()
 }
 
-func TestDispatchAllowsDispatch(t *testing.T) {
+func TestDispatchSucceedsWhenBelowLimit(t *testing.T) {
 	tests := map[string]int64{
 		"under limit":      10,
 		"no limit when zero": 0,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

`TestDispatchAllowsWhenUnderLimit` and `TestDispatchNoLimitWhenZero` in `dispatch_limit_test.go` are structurally identical — both dispatch a single operation through a bulker with a goroutine simulating the Run loop, differing only in the `max_pending_dispatches` value (10 vs 0). golangci-lint's `dupl` checker (threshold: 100 tokens) flags these as duplicate code on any PR that touches the `bulk` package, because the linter runs with `--whole-files`.

The issue is latent on `main` and `9.5` today and will surface on the next PR that modifies any file in `internal/pkg/bulk/`. It is already actively blocking backport PRs for #6751 on `9.4`, `9.3`, and `8.19`.

The root cause: golangci-lint was v2.5.0 when these tests were introduced (#6751, April 2026) and is now v2.11.4, which triggers the finding at this token count.

## How does this PR solve the problem?

Merges the two functions into a single `TestDispatchAllowsDispatch` table-driven test using a `map[string]int64` of limit values. This is idiomatic Go, eliminates the dupl finding, and keeps the same coverage.

## How to test this PR locally

```
go test ./internal/pkg/bulk/ -run TestDispatch -v
```

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [x] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Relates #6751