### PR TITLE
feat: add http_server.tcp_rejected_rate metric for connection-cap saturation

### DIFF
--- a/changelog/fragments/1785309171-tcp-rejected-rate-metric.yaml
+++ b/changelog/fragments/1785309171-tcp-rejected-rate-metric.yaml
@@ -1,0 +1,5 @@
+kind: enhancement
+
+summary: Add http_server.tcp_rejected_rate metric for connection-cap saturation signalling
+
+component: fleet-server

--- a/internal/pkg/api/metrics.go
+++ b/internal/pkg/api/metrics.go
@@ -332,13 +332,9 @@ func attachPrometheusEndpoint(router metricsRouter, reg *prometheus.Registry, bi
 	router.AddRoute("/metrics", promhttp.InstrumentMetricHandler(reg, h).ServeHTTP)
 }
 
-// CheckinRateSampleInterval is how often RunCheckinRejectionRateSampler recomputes
-// the checkin capacity-rejection rate.
-const CheckinRateSampleInterval = 10 * time.Second
-
-// ConnRejectionRateSampleInterval is how often RunConnRejectionRateSampler recomputes
-// the connection-cap rejection rate.
-const ConnRejectionRateSampleInterval = CheckinRateSampleInterval
+// RejectionRateSampleInterval is how often the rejection-rate samplers recompute
+// the checkin and connection-cap rejection rates.
+const RejectionRateSampleInterval = 10 * time.Second
 
 // computeRate returns the count of rejections (cur-prev) divided by an elapsed
 // time (dt), rounded to the nearest integer. It returns 0 if dt is non-positive

--- a/internal/pkg/api/metrics.go
+++ b/internal/pkg/api/metrics.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -36,8 +37,10 @@ var (
 	cntHTTPNew          *statsCounter
 	cntHTTPClose        *statsCounter
 	cntHTTPActive       *statsGauge
-	cntHTTPRejected     *statsCounter
 	cntHTTPRejectedRate *statsGauge
+	// cntHTTPRejected is an internal-only accumulator; only the derived rate is
+	// exposed in /stats. Not registered with the metrics registry.
+	cntHTTPRejected atomic.Uint64
 
 	cntCheckin       routeStats
 	cntEnroll        routeStats
@@ -63,7 +66,6 @@ func init() {
 	cntHTTPNew = newCounter(registry, "tcp_open")
 	cntHTTPClose = newCounter(registry, "tcp_close")
 	cntHTTPActive = newGauge(registry, "tcp_active")
-	cntHTTPRejected = newCounter(registry, "tcp_rejected")
 	cntHTTPRejectedRate = newGauge(registry, "tcp_rejected_rate")
 
 	routesRegistry := registry.newRegistry("routes")
@@ -386,13 +388,13 @@ func RunConnRejectionRateSampler(ctx context.Context, interval time.Duration) er
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
-	prev, prevT := cntHTTPRejected.Get(), time.Now()
+	prev, prevT := cntHTTPRejected.Load(), time.Now()
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		case now := <-ticker.C:
-			cur := cntHTTPRejected.Get()
+			cur := cntHTTPRejected.Load()
 			cntHTTPRejectedRate.Set(computeRate(prev, cur, now.Sub(prevT)))
 			prev, prevT = cur, now
 		}

--- a/internal/pkg/api/metrics.go
+++ b/internal/pkg/api/metrics.go
@@ -33,9 +33,11 @@ import (
 var (
 	registry *metricsRegistry
 
-	cntHTTPNew    *statsCounter
-	cntHTTPClose  *statsCounter
-	cntHTTPActive *statsGauge
+	cntHTTPNew          *statsCounter
+	cntHTTPClose        *statsCounter
+	cntHTTPActive       *statsGauge
+	cntHTTPRejected     *statsCounter
+	cntHTTPRejectedRate *statsGauge
 
 	cntCheckin       routeStats
 	cntEnroll        routeStats
@@ -61,6 +63,8 @@ func init() {
 	cntHTTPNew = newCounter(registry, "tcp_open")
 	cntHTTPClose = newCounter(registry, "tcp_close")
 	cntHTTPActive = newGauge(registry, "tcp_active")
+	cntHTTPRejected = newCounter(registry, "tcp_rejected")
+	cntHTTPRejectedRate = newGauge(registry, "tcp_rejected_rate")
 
 	routesRegistry := registry.newRegistry("routes")
 
@@ -330,6 +334,10 @@ func attachPrometheusEndpoint(router metricsRouter, reg *prometheus.Registry, bi
 // the checkin capacity-rejection rate.
 const CheckinRateSampleInterval = 10 * time.Second
 
+// ConnRejectionRateSampleInterval is how often RunConnRejectionRateSampler recomputes
+// the connection-cap rejection rate.
+const ConnRejectionRateSampleInterval = CheckinRateSampleInterval
+
 // computeRate returns the count of rejections (cur-prev) divided by an elapsed
 // time (dt), rounded to the nearest integer. It returns 0 if dt is non-positive
 // or if cur < prev: a count of rejections can only increase, so a computed
@@ -350,6 +358,45 @@ func computeRate(prev, cur uint64, dt time.Duration) uint64 {
 		return 0
 	}
 	return uint64(float64(cur-prev)/dt.Seconds() + 0.5)
+}
+
+// RunConnRejectionRateSampler periodically samples the connection-cap rejection
+// counter (http_server.tcp_rejected) and publishes the resulting rate as the
+// tcp_rejected_rate gauge.
+//
+// tcp_rejected_rate is a saturation signal that complements tcp_active:
+//   - tcp_active is a utilization signal — EPA uses it to maintain headroom by
+//     scaling before pods fill up. It works well at steady state but understates
+//     demand when connections are short-lived (e.g. an enrollment burst), because
+//     the metric lags behind a burst that arrives and clears between sample points.
+//   - tcp_rejected_rate fires only when the pod is already at its connection
+//     ceiling and actively turning clients away (HTTP 429 from the chi Throttle
+//     middleware). It catches bursts that tcp_active misses, triggering an
+//     immediate scale-up rather than waiting for the next utilization sample.
+//
+// Together, EPA can scale both proactively (tcp_active: maintain headroom during
+// steady-state load) and reactively (tcp_rejected_rate: act the moment a burst
+// overwhelms a pod). EPA takes the maximum desired replica count across all
+// configured metrics, so tcp_rejected_rate can only make scale-up more aggressive,
+// never suppress it.
+//
+// Run blocks until ctx is canceled, following the same lifecycle contract as the
+// other subsystems started in Fleet.runSubsystems.
+func RunConnRejectionRateSampler(ctx context.Context, interval time.Duration) error {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	prev, prevT := cntHTTPRejected.Get(), time.Now()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case now := <-ticker.C:
+			cur := cntHTTPRejected.Get()
+			cntHTTPRejectedRate.Set(computeRate(prev, cur, now.Sub(prevT)))
+			prev, prevT = cur, now
+		}
+	}
 }
 
 // RunCheckinRejectionRateSampler periodically samples the checkin route's

--- a/internal/pkg/api/metrics_test.go
+++ b/internal/pkg/api/metrics_test.go
@@ -95,6 +95,7 @@ func TestRunConnRejectionRateSampler(t *testing.T) {
 		done <- RunConnRejectionRateSampler(ctx, interval)
 	}()
 
+	injectorCtx, stopInjector := context.WithCancel(ctx)
 	injectorDone := make(chan struct{})
 	go func() {
 		defer close(injectorDone)
@@ -102,7 +103,7 @@ func TestRunConnRejectionRateSampler(t *testing.T) {
 		defer ticker.Stop()
 		for {
 			select {
-			case <-ctx.Done():
+			case <-injectorCtx.Done():
 				return
 			case <-ticker.C:
 				cntHTTPRejected.Add(1)
@@ -112,6 +113,7 @@ func TestRunConnRejectionRateSampler(t *testing.T) {
 
 	t.Cleanup(func() {
 		cancel()
+		stopInjector()
 		require.NoError(t, <-done)
 		<-injectorDone
 	})
@@ -119,6 +121,12 @@ func TestRunConnRejectionRateSampler(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return cntHTTPRejectedRate.metric.Get() > 0
 	}, 20*interval, interval/4, "expected the connection rejection rate gauge to become positive while rejections were ongoing")
+
+	stopInjector()
+	<-injectorDone
+	require.Eventually(t, func() bool {
+		return cntHTTPRejectedRate.metric.Get() == 0
+	}, 20*interval, interval/4, "expected the connection rejection rate gauge to return to zero after rejections stopped")
 }
 
 func TestRunCheckinRejectionRateSampler(t *testing.T) {

--- a/internal/pkg/api/metrics_test.go
+++ b/internal/pkg/api/metrics_test.go
@@ -77,6 +77,50 @@ func TestComputeRate(t *testing.T) {
 	}
 }
 
+func TestRunConnRejectionRateSampler(t *testing.T) {
+	// Swap in a fresh gauge registered under a private namespace to avoid
+	// duplicate-name panics in the Prometheus registry across repeated runs.
+	origRate := cntHTTPRejectedRate
+	t.Cleanup(func() { cntHTTPRejectedRate = origRate })
+	cntHTTPRejectedRate = newGauge(
+		registry.newRegistry(fmt.Sprintf("test_conn_rejection_rate_sampler_%d", testRegistrySeq.Add(1))),
+		"tcp_rejected_rate",
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	const interval = 10 * time.Millisecond
+	done := make(chan error, 1)
+	go func() {
+		done <- RunConnRejectionRateSampler(ctx, interval)
+	}()
+
+	injectorDone := make(chan struct{})
+	go func() {
+		defer close(injectorDone)
+		ticker := time.NewTicker(interval / 2)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				cntHTTPRejected.Add(1)
+			}
+		}
+	}()
+
+	t.Cleanup(func() {
+		cancel()
+		require.NoError(t, <-done)
+		<-injectorDone
+	})
+
+	require.Eventually(t, func() bool {
+		return cntHTTPRejectedRate.metric.Get() > 0
+	}, 20*interval, interval/4, "expected the connection rejection rate gauge to become positive while rejections were ongoing")
+}
+
 func TestRunCheckinRejectionRateSampler(t *testing.T) {
 	// cntCheckin is a package-level global shared with the checkin route handler
 	// and other tests in this package. Swap in a throwaway routeStats registered

--- a/internal/pkg/api/router.go
+++ b/internal/pkg/api/router.go
@@ -85,7 +85,7 @@ func throttleWithCount(limit int) func(http.Handler) http.Handler {
 			rw := &statusRecorder{ResponseWriter: w}
 			throttled.ServeHTTP(rw, r)
 			if rw.status == http.StatusTooManyRequests {
-				cntHTTPRejected.Inc()
+				cntHTTPRejected.Add(1)
 			}
 		})
 	}

--- a/internal/pkg/api/router.go
+++ b/internal/pkg/api/router.go
@@ -97,9 +97,22 @@ type statusRecorder struct {
 	status int
 }
 
+func (s *statusRecorder) Write(buf []byte) (int, error) {
+	if s.status == 0 {
+		s.WriteHeader(http.StatusOK)
+	}
+	return s.ResponseWriter.Write(buf)
+}
+
 func (s *statusRecorder) WriteHeader(code int) {
-	s.status = code
+	if s.status == 0 {
+		s.status = code
+	}
 	s.ResponseWriter.WriteHeader(code)
+}
+
+func (s *statusRecorder) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter
 }
 
 var pgpReg = regexp.MustCompile(`\/api\/agents\/upgrades\/[0-9]+\.[0-9]+\.[0-9]+\/pgp-public-key`)

--- a/internal/pkg/api/router.go
+++ b/internal/pkg/api/router.go
@@ -28,7 +28,7 @@ func newRouter(cfg *config.ServerLimits, si ServerInterface, tracer *apm.Tracer)
 	r.Use(logger.Middleware) // Attach middlewares to router directly so the occur before any request parsing/validation
 	r.Use(middleware.Recoverer)
 	if cfg.MaxConnections > 0 {
-		r.Use(middleware.Throttle(cfg.MaxConnections))
+		r.Use(throttleWithCount(cfg.MaxConnections))
 	}
 	r.Use(Limiter(cfg).middleware)
 	return HandlerWithOptions(si, ChiServerOptions{
@@ -72,6 +72,34 @@ func Limiter(cfg *config.ServerLimits) *limiter {
 		getPGPKey:      limit.NewLimiter(&cfg.GetPGPKey),
 		auditUnenroll:  limit.NewLimiter(&cfg.AuditUnenrollLimit),
 	}
+}
+
+// throttleWithCount wraps chi's Throttle middleware and increments
+// cntHTTPRejected whenever a request is rejected with HTTP 429 due to the
+// per-pod connection cap. The count is rate-sampled by RunConnRejectionRateSampler
+// and exposed as http_server.tcp_rejected_rate for use as an EPA scaling trigger.
+func throttleWithCount(limit int) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		throttled := middleware.Throttle(limit)(next)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			rw := &statusRecorder{ResponseWriter: w}
+			throttled.ServeHTTP(rw, r)
+			if rw.status == http.StatusTooManyRequests {
+				cntHTTPRejected.Inc()
+			}
+		})
+	}
+}
+
+// statusRecorder captures the HTTP status code written by a downstream handler.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (s *statusRecorder) WriteHeader(code int) {
+	s.status = code
+	s.ResponseWriter.WriteHeader(code)
 }
 
 var pgpReg = regexp.MustCompile(`\/api\/agents\/upgrades\/[0-9]+\.[0-9]+\.[0-9]+\/pgp-public-key`)

--- a/internal/pkg/api/router_test.go
+++ b/internal/pkg/api/router_test.go
@@ -5,6 +5,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -97,7 +98,7 @@ func TestLimiter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := testStatusServer(t, tt.cfg)
 			w := httptest.NewRecorder()
-			r := httptest.NewRequest("GET", "/api/status", nil)
+			r := httptest.NewRequestWithContext(t.Context(), "GET", "/api/status", nil)
 
 			h.ServeHTTP(w, r)
 			resp := w.Result()
@@ -122,7 +123,7 @@ func TestThrottleWithCount(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		}))
 		w := httptest.NewRecorder()
-		h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+		h.ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil))
 		require.Equal(t, http.StatusOK, w.Code)
 		require.Equal(t, before, cntHTTPRejected.Load())
 	})
@@ -136,11 +137,11 @@ func TestThrottleWithCount(t *testing.T) {
 			time.Sleep(100 * time.Millisecond)
 		}))
 
-		go h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+		go h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
 		<-started // first request has acquired the connection slot
 
 		w := httptest.NewRecorder()
-		h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+		h.ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil))
 		require.Equal(t, http.StatusTooManyRequests, w.Code)
 		require.Equal(t, before+1, cntHTTPRejected.Load())
 	})

--- a/internal/pkg/api/router_test.go
+++ b/internal/pkg/api/router_test.go
@@ -109,11 +109,23 @@ func TestLimiter(t *testing.T) {
 }
 
 func TestStatusRecorder(t *testing.T) {
-	rw := httptest.NewRecorder()
-	rec := &statusRecorder{ResponseWriter: rw}
-	rec.WriteHeader(http.StatusTeapot)
-	require.Equal(t, http.StatusTeapot, rec.status)
-	require.Equal(t, http.StatusTeapot, rw.Code)
+	t.Run("captures explicit status", func(t *testing.T) {
+		rw := httptest.NewRecorder()
+		rec := &statusRecorder{ResponseWriter: rw}
+		rec.WriteHeader(http.StatusTeapot)
+		require.Equal(t, http.StatusTeapot, rec.status)
+		require.Equal(t, http.StatusTeapot, rw.Code)
+	})
+
+	t.Run("captures implicit success status", func(t *testing.T) {
+		rw := httptest.NewRecorder()
+		rec := &statusRecorder{ResponseWriter: rw}
+		_, err := rec.Write([]byte("ok"))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, rec.status)
+		require.Equal(t, http.StatusOK, rw.Code)
+		require.Equal(t, "ok", rw.Body.String())
+	})
 }
 
 func TestThrottleWithCount(t *testing.T) {

--- a/internal/pkg/api/router_test.go
+++ b/internal/pkg/api/router_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPathToOperation(t *testing.T) {
@@ -104,4 +105,43 @@ func TestLimiter(t *testing.T) {
 			assert.Equal(t, tt.status, resp.StatusCode)
 		})
 	}
+}
+
+func TestStatusRecorder(t *testing.T) {
+	rw := httptest.NewRecorder()
+	rec := &statusRecorder{ResponseWriter: rw}
+	rec.WriteHeader(http.StatusTeapot)
+	require.Equal(t, http.StatusTeapot, rec.status)
+	require.Equal(t, http.StatusTeapot, rw.Code)
+}
+
+func TestThrottleWithCount(t *testing.T) {
+	t.Run("does not increment counter on success", func(t *testing.T) {
+		before := cntHTTPRejected.Load()
+		h := throttleWithCount(5)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, before, cntHTTPRejected.Load())
+	})
+
+	t.Run("increments counter when connection cap is hit", func(t *testing.T) {
+		before := cntHTTPRejected.Load()
+
+		started := make(chan struct{})
+		h := throttleWithCount(1)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			close(started)
+			time.Sleep(100 * time.Millisecond)
+		}))
+
+		go h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+		<-started // first request has acquired the connection slot
+
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+		require.Equal(t, http.StatusTooManyRequests, w.Code)
+		require.Equal(t, before+1, cntHTTPRejected.Load())
+	})
 }

--- a/internal/pkg/api/router_test.go
+++ b/internal/pkg/api/router_test.go
@@ -5,7 +5,6 @@
 package api
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -144,12 +143,21 @@ func TestThrottleWithCount(t *testing.T) {
 		before := cntHTTPRejected.Load()
 
 		started := make(chan struct{})
+		release := make(chan struct{})
+		requestDone := make(chan struct{})
 		h := throttleWithCount(1)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			close(started)
-			time.Sleep(100 * time.Millisecond)
+			<-release
 		}))
 
-		go h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
+		go func() {
+			defer close(requestDone)
+			h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil))
+		}()
+		t.Cleanup(func() {
+			close(release)
+			<-requestDone
+		})
 		<-started // first request has acquired the connection slot
 
 		w := httptest.NewRecorder()

--- a/internal/pkg/server/fleet.go
+++ b/internal/pkg/server/fleet.go
@@ -527,12 +527,12 @@ func (f *Fleet) runSubsystems(ctx context.Context, cfg *config.Config, g *errgro
 	// Samples the checkin capacity-rejection counter into a rate gauge, exposed via
 	// /stats for use as an autoscaling signal. See api.RunCheckinRejectionRateSampler.
 	g.Go(loggedRunFunc(ctx, "Checkin rejection rate sampler", func(ctx context.Context) error {
-		return api.RunCheckinRejectionRateSampler(ctx, api.CheckinRateSampleInterval)
+		return api.RunCheckinRejectionRateSampler(ctx, api.RejectionRateSampleInterval)
 	}))
 	// Samples the connection-cap rejection counter into a rate gauge, exposed via
 	// /stats for use as an autoscaling signal. See api.RunConnRejectionRateSampler.
 	g.Go(loggedRunFunc(ctx, "Connection rejection rate sampler", func(ctx context.Context) error {
-		return api.RunConnRejectionRateSampler(ctx, api.ConnRejectionRateSampleInterval)
+		return api.RunConnRejectionRateSampler(ctx, api.RejectionRateSampleInterval)
 	}))
 
 	ct, err := api.NewCheckinT(f.verCon, &cfg.Inputs[0].Server, f.cache, bc, pm, am, ad, bulker)

--- a/internal/pkg/server/fleet.go
+++ b/internal/pkg/server/fleet.go
@@ -529,6 +529,11 @@ func (f *Fleet) runSubsystems(ctx context.Context, cfg *config.Config, g *errgro
 	g.Go(loggedRunFunc(ctx, "Checkin rejection rate sampler", func(ctx context.Context) error {
 		return api.RunCheckinRejectionRateSampler(ctx, api.CheckinRateSampleInterval)
 	}))
+	// Samples the connection-cap rejection counter into a rate gauge, exposed via
+	// /stats for use as an autoscaling signal. See api.RunConnRejectionRateSampler.
+	g.Go(loggedRunFunc(ctx, "Connection rejection rate sampler", func(ctx context.Context) error {
+		return api.RunConnRejectionRateSampler(ctx, api.ConnRejectionRateSampleInterval)
+	}))
 
 	ct, err := api.NewCheckinT(f.verCon, &cfg.Inputs[0].Server, f.cache, bc, pm, am, ad, bulker)
 	if err != nil {


### PR DESCRIPTION
## What is the problem this PR solves?

Fleet Server's existing autoscaling metric, `http_server.tcp_active`, is a utilization signal: EPA uses it to maintain headroom by targeting N active connections per pod. This works well at steady state but understates demand when connections are short-lived — specifically during large-scale agent enrollment, where each enrollment connection completes in under a second.

`tcp_active` is a point-in-time gauge: it reflects the instantaneous count of open HTTP connections at the moment EPA polls `/stats`. A burst of enrollment connections that arrive and clear between two EPA polls leaves no trace in the metric. The result is that pods plateau well below the theoretical requirement, agents receive HTTP 429s, and enter exponential backoff — turning a short enrollment phase into a multi-hour convergence tail.

## How does this PR solve the problem?

Adds `http_server.tcp_rejected_rate` to `/stats`: a gauge, in rejections/sec, derived from an internal counter that increments whenever the chi `Throttle` middleware returns HTTP 429 due to the per-pod connection cap (`max_connections`). The rate is sampled every 10 s by a new `RunConnRejectionRateSampler` goroutine.

**`tcp_rejected_rate` vs `tcp_active`**

| | `tcp_active` | `tcp_rejected_rate` |
|---|---|---|
| Signal type | Utilization | Saturation |
| When it fires | Active connections approach the per-pod target | Pod is already at its connection ceiling and returning 429s |
| Enrollment bursts | Understates demand — burst clears before next EPA poll | Catches the burst; rejections accumulate in the counter until sampled |
| Steady state | Correct — long-held checkin connections register reliably | Zero — pod is not at ceiling, no 429s |
| EPA behavior | Scale to maintain headroom | Scale the moment a pod is overwhelmed |

Because EPA takes the **maximum** desired replica count across all configured metrics, wiring both allows proactive scaling (`tcp_active`: headroom at steady state) and reactive scaling (`tcp_rejected_rate`: act immediately under a burst). Neither metric suppresses the other.

The raw rejection count is kept as an unexported `atomic.Uint64` — only the derived rate gauge is exposed in `/stats`, since that is the only value EPA consumes. The chi `Throttle` middleware behaviour is unchanged; the wrapper only observes the response status code.

## How to test this PR locally

1. Configure Fleet Server with `max_connections: N` and start it.
2. Send more than N concurrent requests (e.g. with `hey` or `wrk`).
3. `curl localhost:5066/stats | python3 -m json.tool | grep tcp_rejected` — confirm `tcp_rejected_rate` becomes non-zero after ~10 s.
4. Let load drop — `tcp_rejected_rate` should return to 0 within the next sample interval.

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [x] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Relates https://github.com/elastic/fleet-controller/pull/638