### PR TITLE
fix: anchor artifact authorization on enrollment-derived PolicyID

### DIFF
--- a/changelog/fragments/1753776000-artifact-authz-policy-id.yaml
+++ b/changelog/fragments/1753776000-artifact-authz-policy-id.yaml
@@ -1,0 +1,9 @@
+kind: security
+
+# Anchor artifact authorization on enrollment-derived PolicyID, not the
+# check-in-supplied AgentPolicyID, to prevent cross-policy artifact download.
+summary: Anchor artifact authorization on enrollment-derived policy ID
+
+component: fleet-server
+
+issue: https://github.com/elastic/security/issues/12861

--- a/changelog/fragments/1753776000-artifact-authz-policy-id.yaml
+++ b/changelog/fragments/1753776000-artifact-authz-policy-id.yaml
@@ -6,4 +6,3 @@ summary: Anchor artifact authorization on enrollment-derived policy ID
 
 component: fleet-server
 
-issue: https://github.com/elastic/security/issues/12861

--- a/internal/pkg/api/handleArtifacts.go
+++ b/internal/pkg/api/handleArtifacts.go
@@ -160,12 +160,13 @@ func (at ArtifactT) authorizeArtifact(ctx context.Context, agent *model.Agent, i
 	span, ctx := apm.StartSpan(ctx, "authorizeArtifacts", "auth")
 	defer span.End()
 
-	// AgentPolicyID (agent_policy_id) is set at first checkin; PolicyID (policy_id) is set
-	// at enrollment. Fall back to PolicyID so newly enrolled agents that have not yet
-	// checked in can still download artifacts for their assigned policy.
-	policyID := agent.AgentPolicyID
+	// PolicyID (policy_id) is set at enrollment and is the server-authoritative policy
+	// assignment. AgentPolicyID (agent_policy_id) is derived from the check-in request
+	// body (client-controlled) and must not be used as the authorization anchor.
+	// Fall back to AgentPolicyID only for agents that predate enrollment-time PolicyID tracking.
+	policyID := agent.PolicyID
 	if policyID == "" {
-		policyID = agent.PolicyID
+		policyID = agent.AgentPolicyID
 	}
 	if policyID == "" {
 		return ErrAgentPolicyIDMissing

--- a/internal/pkg/api/handleArtifacts_test.go
+++ b/internal/pkg/api/handleArtifacts_test.go
@@ -278,10 +278,10 @@ func TestAuthorizeArtifact(t *testing.T) {
 // (enrollment-derived) rather than AgentPolicyID (check-in-supplied).
 func TestAuthorizeArtifact_CrossPolicyBypass(t *testing.T) {
 	const (
-		victimPolicy  = "victim-policy-A"
-		targetPolicy  = "target-policy-B"
-		artifactID    = "endpoint-trustlist-windows-v1"
-		targetSHA2    = "044488cd5c93e311453951fba706bc78c83f295aff75c8a5a2e309656eb3ef2a"
+		victimPolicy = "victim-policy-A"
+		targetPolicy = "target-policy-B"
+		artifactID   = "endpoint-trustlist-windows-v1"
+		targetSHA2   = "044488cd5c93e311453951fba706bc78c83f295aff75c8a5a2e309656eb3ef2a"
 	)
 
 	policyBWithArtifact := &model.Policy{

--- a/internal/pkg/api/handleArtifacts_test.go
+++ b/internal/pkg/api/handleArtifacts_test.go
@@ -268,3 +268,69 @@ func TestAuthorizeArtifact(t *testing.T) {
 		})
 	}
 }
+
+// TestAuthorizeArtifact_CrossPolicyBypass exercises the cross-policy bypass:
+// an agent enrolled in policy A sets agent_policy_id to policy B at check-in,
+// then requests policy B's artifact.
+//
+// Before the fix, STEP 2 returned nil (200 OK). After the fix both steps return
+// ErrUnauthorizedArtifact (403) because authorization is anchored on PolicyID
+// (enrollment-derived) rather than AgentPolicyID (check-in-supplied).
+func TestAuthorizeArtifact_CrossPolicyBypass(t *testing.T) {
+	const (
+		victimPolicy  = "victim-policy-A"
+		targetPolicy  = "target-policy-B"
+		artifactID    = "endpoint-trustlist-windows-v1"
+		targetSHA2    = "044488cd5c93e311453951fba706bc78c83f295aff75c8a5a2e309656eb3ef2a"
+	)
+
+	policyBWithArtifact := &model.Policy{
+		Data: &model.PolicyData{
+			Inputs: []map[string]any{
+				{
+					"type": "endpoint",
+					"artifact_manifest": map[string]any{
+						"artifacts": map[string]any{
+							artifactID: map[string]any{
+								"decoded_sha256": targetSHA2,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	policyAWithoutArtifact := &model.Policy{Data: &model.PolicyData{}}
+
+	// STEP 1: agent enrolled in policy A, AgentPolicyID not yet set (pre-checkin).
+	// Baseline: policy A has no matching artifact → denied.
+	t.Run("STEP1: baseline denied before spoofed checkin", func(t *testing.T) {
+		pm := &mockPolicyMonitor{}
+		pm.On("GetPolicy", context.Background(), victimPolicy).Return(policyAWithoutArtifact, nil)
+		at := ArtifactT{pm: pm}
+
+		err := at.authorizeArtifact(context.Background(), &model.Agent{PolicyID: victimPolicy}, artifactID, targetSHA2)
+		require.ErrorIs(t, err, ErrUnauthorizedArtifact)
+		pm.AssertExpectations(t)
+	})
+
+	// STEP 2: same agent after a spoofed checkin sets AgentPolicyID to the target policy.
+	// Before the fix: authorizeArtifact used AgentPolicyID → queried policy B → returned nil (200).
+	// After the fix:  authorizeArtifact uses PolicyID     → queries policy A → returns 403.
+	t.Run("STEP2: denied after spoofed checkin sets AgentPolicyID to target", func(t *testing.T) {
+		pm := &mockPolicyMonitor{}
+		// Policy A (the real assignment) must be queried and must not contain the artifact.
+		pm.On("GetPolicy", context.Background(), victimPolicy).Return(policyAWithoutArtifact, nil)
+		// Policy B (the attacker's target) must never be queried.
+		_ = policyBWithArtifact // referenced to make the intent clear; must NOT appear in mock calls
+		at := ArtifactT{pm: pm}
+
+		agent := &model.Agent{
+			PolicyID:      victimPolicy, // set at enrollment, server-authoritative
+			AgentPolicyID: targetPolicy, // set by spoofed checkin, client-controlled
+		}
+		err := at.authorizeArtifact(context.Background(), agent, artifactID, targetSHA2)
+		require.ErrorIs(t, err, ErrUnauthorizedArtifact)
+		pm.AssertExpectations(t) // asserts policy B was never queried
+	})
+}

--- a/internal/pkg/api/handleArtifacts_test.go
+++ b/internal/pkg/api/handleArtifacts_test.go
@@ -182,7 +182,7 @@ func TestAuthorizeArtifact(t *testing.T) {
 	}{
 		{
 			name:  "authorized: artifact in policy",
-			agent: &model.Agent{AgentPolicyID: policyID},
+			agent: &model.Agent{PolicyID: policyID},
 			setupMock: func(pm *mockPolicyMonitor) {
 				pm.On("GetPolicy", context.Background(), policyID).Return(policyWithArtifact, nil)
 			},
@@ -190,7 +190,7 @@ func TestAuthorizeArtifact(t *testing.T) {
 		},
 		{
 			name:  "unauthorized: artifact not in policy",
-			agent: &model.Agent{AgentPolicyID: policyID},
+			agent: &model.Agent{PolicyID: policyID},
 			setupMock: func(pm *mockPolicyMonitor) {
 				pm.On("GetPolicy", context.Background(), policyID).Return(&model.Policy{
 					Data: &model.PolicyData{},
@@ -200,7 +200,7 @@ func TestAuthorizeArtifact(t *testing.T) {
 		},
 		{
 			name:  "unauthorized: policy not found maps to 403",
-			agent: &model.Agent{AgentPolicyID: policyID},
+			agent: &model.Agent{PolicyID: policyID},
 			setupMock: func(pm *mockPolicyMonitor) {
 				pm.On("GetPolicy", context.Background(), policyID).Return(nil, policy.ErrPolicyNotFound)
 			},
@@ -208,19 +208,37 @@ func TestAuthorizeArtifact(t *testing.T) {
 		},
 		{
 			name:  "error: GetPolicy returns unexpected error",
-			agent: &model.Agent{AgentPolicyID: policyID},
+			agent: &model.Agent{PolicyID: policyID},
 			setupMock: func(pm *mockPolicyMonitor) {
 				pm.On("GetPolicy", context.Background(), policyID).Return(nil, errors.New("elasticsearch unavailable"))
 			},
 			wantErr: nil, // wrapped, so we check IsUnauthorized is false
 		},
 		{
-			name:  "authorized: uses PolicyID when AgentPolicyID is empty (pre-checkin)",
-			agent: &model.Agent{PolicyID: policyID},
+			name:  "authorized: uses AgentPolicyID when PolicyID is empty (legacy fallback)",
+			agent: &model.Agent{AgentPolicyID: policyID},
 			setupMock: func(pm *mockPolicyMonitor) {
 				pm.On("GetPolicy", context.Background(), policyID).Return(policyWithArtifact, nil)
 			},
 			wantErr: nil,
+		},
+		{
+			// Regression test: an attacker checks in with agent_policy_id=<victim-policy> to
+			// gain access to that policy's artifacts. authorizeArtifact must anchor on
+			// PolicyID (enrollment-derived, server-trusted), not AgentPolicyID (client-controlled).
+			name: "unauthorized: AgentPolicyID does not override PolicyID (cross-policy bypass)",
+			agent: &model.Agent{
+				PolicyID:      policyID,
+				AgentPolicyID: "attacker-chosen-policy",
+			},
+			setupMock: func(pm *mockPolicyMonitor) {
+				// Authorization must use PolicyID ("test-policy-id"), which has no artifact.
+				// "attacker-chosen-policy" must never be queried.
+				pm.On("GetPolicy", context.Background(), policyID).Return(&model.Policy{
+					Data: &model.PolicyData{},
+				}, nil)
+			},
+			wantErr: ErrUnauthorizedArtifact,
 		},
 		{
 			name:      "forbidden: agent has no policy ID",


### PR DESCRIPTION
<!-- Type of change: Bug -->

## What is the problem this PR solves?

`authorizeArtifact` (introduced in #7009) resolved the policy to check against using `agent.AgentPolicyID` as the primary value, falling back to `agent.PolicyID`. `AgentPolicyID` is written verbatim from the client-supplied `agent_policy_id` field in the check-in request body with no ownership validation.

This allows any enrolled agent to:
1. Check in with `agent_policy_id=<target-policy>` → fleet-server persists that value to the agent document
2. Request artifacts for that policy → `authorizeArtifact` reads the now-persisted `AgentPolicyID` → grants access

The result is cross-policy download of another policy's Elastic Defend artifacts (trustlists, blocklists, event filters, host-isolation exceptions). The fix in #7009 was incomplete because it anchored the new authorization check on a client-mutable field.

The 8.19 branch (`b70d3ea`) correctly anchors authorization on `agent.PolicyID` only and is not affected.

## How does this PR solve the problem?

Swap the priority in `authorizeArtifact` so that `agent.PolicyID` — set server-side at enrollment from the enrollment API key and never writable by the agent — is the authorization anchor. `agent.AgentPolicyID` is retained as a legacy fallback only for agents where `PolicyID` was never set.

```go
// Before (vulnerable):
policyID := agent.AgentPolicyID   // client-controlled
if policyID == "" {
    policyID = agent.PolicyID
}

// After (fixed):
policyID := agent.PolicyID        // server-authoritative
if policyID == "" {
    policyID = agent.AgentPolicyID // legacy fallback
}
```

Existing tests that used `AgentPolicyID` as the auth anchor are updated to use `PolicyID`. A new table entry (`"unauthorized: AgentPolicyID does not override PolicyID (cross-policy bypass)"`) directly encodes the exploit scenario: an agent enrolled in policy A with `AgentPolicyID` pointing at policy B receives 403 when requesting policy B's artifact.

## How to test this PR locally

```bash
go test ./internal/pkg/api/ -run "Artifact|artifact" -v
```

All existing artifact authorization tests pass. The new cross-policy bypass test confirms that `AgentPolicyID` cannot be used to escalate access beyond the enrollment-derived `PolicyID`.

To reproduce the original vulnerability against an unpatched build:
```bash
# Enroll agent in policy A, note access_api_key ($KEY) and agent id ($AID)
# Get sha256 of policy B's artifact ($SHA) and policy B's id ($OTHER)
curl -s "$FS/api/fleet/artifacts/endpoint-trustlist-windows-v1/$SHA" -H "Authorization: ApiKey $KEY"
# ^ 403 (baseline)
curl -sX POST "$FS/api/fleet/agents/$AID/checkin" -H "Authorization: ApiKey $KEY" \
  -H 'Content-Type: application/json' \
  -d "{\"status\":\"online\",\"message\":\"online\",\"agent_policy_id\":\"$OTHER\",\"policy_revision_idx\":1}"
sleep 15  # wait for bulk flush
curl -s "$FS/api/fleet/artifacts/endpoint-trustlist-windows-v1/$SHA" -H "Authorization: ApiKey $KEY"
# ^ 200 on unpatched, 403 on this fix
```

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [x] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Incomplete fix of #7009