### PR TITLE
chore: group Go Dependabot updates into a single weekly PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,9 @@ updates:
       - "/pkg/api/"
       - "/testing/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
     labels:
       - automation
       - dependency
@@ -15,9 +17,9 @@ updates:
       - backport-active-all
     open-pull-requests-limit: 10
     groups:
-      elastic-apm:
+      go-dependencies:
         patterns:
-          - "go.elastic.co/apm/*"
+          - "*"
 
   - package-ecosystem: github-actions
     directories:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,17 @@ updates:
       - backport-active-all
     open-pull-requests-limit: 10
     groups:
+      elastic:
+        patterns:
+          - "github.com/elastic/*"
+          - "go.elastic.co/*"
+      test-tooling:
+        patterns:
+          - "github.com/testcontainers/*"
+          - "github.com/Shopify/*"
+          - "github.com/moby/*"
+          - "github.com/magefile/mage"
+          - "github.com/stretchr/*"
       go-dependencies:
         patterns:
           - "*"


### PR DESCRIPTION
## Summary

Reduces weekly Dependabot noise by batching Go module updates into three focused groups instead of one PR per package:

- **elastic**: all `github.com/elastic/*` and `go.elastic.co/*` modules
- **test-tooling**: testcontainers, toxiproxy, moby (Docker infra for tests), mage (build tool), stretchr (testify/objx)
- **go-dependencies**: catch-all for everything else

Dependabot assigns each package to the first matching group, so the catch-all only captures what the two specific groups don't cover. Schedule is weekly on Mondays at 08:00, matching the existing github-actions and pre-commit schedules.

Mirrors the approach taken in elastic/elastic-agent#14105.