### PR TITLE
Parameterize output names in Elasticsearch update scripts

### DIFF
--- a/changelog/fragments/1785505460-parameterize-output-painless-scripts.yaml
+++ b/changelog/fragments/1785505460-parameterize-output-painless-scripts.yaml
@@ -1,0 +1,3 @@
+kind: security
+summary: Treat output names as parameters in Elasticsearch update scripts
+component: fleet-server

--- a/internal/pkg/policy/policy_output.go
+++ b/internal/pkg/policy/policy_output.go
@@ -163,12 +163,7 @@ func (p *Output) prepareElasticsearch(
 		}
 
 		// remove output from agent doc
-		body, err = json.Marshal(map[string]any{
-			"script": map[string]any{
-				"lang":   "painless",
-				"source": fmt.Sprintf("ctx._source['outputs'].remove(\"%s\")", removedOutputName),
-			},
-		})
+		body, err = renderRemoveOutputPainlessScript(removedOutputName)
 		if err != nil {
 			return fmt.Errorf("could not create request body to update agent: %w", err)
 		}
@@ -506,12 +501,12 @@ func renderUpdatePainlessScript(outputName string, fields map[string]any) ([]byt
 	var source strings.Builder
 
 	// prepare agent.elasticsearch_outputs[OUTPUT_NAME]
-	fmt.Fprintf(&source, `
+	source.WriteString(`
 if (ctx._source['outputs']==null)
   {ctx._source['outputs']=new HashMap();}
-if (ctx._source['outputs']['%s']==null)
-  {ctx._source['outputs']['%s']=new HashMap();}
-`, outputName, outputName)
+if (ctx._source['outputs'][params.output_name]==null)
+  {ctx._source['outputs'][params.output_name]=new HashMap();}
+`)
 
 	for field := range fields {
 		if field == dl.FieldPolicyOutputToRetireAPIKeyIDs {
@@ -519,28 +514,40 @@ if (ctx._source['outputs']['%s']==null)
 			// It's an array that gets deleted when the keys are invalidated.
 			// Thus, append the old API key ID, create the field if necessary.
 			fmt.Fprintf(&source, `
-if (ctx._source['outputs']['%s'].%s==null)
-  {ctx._source['outputs']['%s'].%s=new ArrayList();}
-if (!ctx._source['outputs']['%s'].%s.contains(params.%s))
-  {ctx._source['outputs']['%s'].%s.add(params.%s);}
-`, outputName, field, outputName, field, outputName, field, field, outputName, field, field)
+if (ctx._source['outputs'][params.output_name].%s==null)
+  {ctx._source['outputs'][params.output_name].%s=new ArrayList();}
+if (!ctx._source['outputs'][params.output_name].%s.contains(params.%s))
+  {ctx._source['outputs'][params.output_name].%s.add(params.%s);}
+`, field, field, field, field, field, field)
 		} else {
 			// Update the other fields
 			fmt.Fprintf(&source, `
-ctx._source['outputs']['%s'].%s=params.%s;`,
-				outputName, field, field)
+ctx._source['outputs'][params.output_name].%s=params.%s;`, field, field)
 		}
 	}
+	params := make(map[string]any, len(fields)+1)
+	maps.Copy(params, fields)
+	params["output_name"] = outputName
 
 	body, err := json.Marshal(map[string]any{
 		"script": map[string]any{
 			"lang":   "painless",
 			"source": source.String(),
-			"params": fields,
+			"params": params,
 		},
 	})
 
 	return body, err
+}
+
+func renderRemoveOutputPainlessScript(outputName string) ([]byte, error) {
+	return json.Marshal(map[string]any{
+		"script": map[string]any{
+			"lang":   "painless",
+			"source": "ctx._source['outputs'].remove(params.output_name)",
+			"params": map[string]any{"output_name": outputName},
+		},
+	})
 }
 
 func generateOutputAPIKey(

--- a/internal/pkg/policy/policy_output_integration_test.go
+++ b/internal/pkg/policy/policy_output_integration_test.go
@@ -131,6 +131,25 @@ func TestRenderUpdatePainlessScript(t *testing.T) {
 	}
 }
 
+func TestRenderRemoveOutputPainlessScript(t *testing.T) {
+	const outputName = `x"); ctx._source.pwned=("true`
+
+	ctx := testlog.SetLogger(t).WithContext(t.Context())
+	index, bulker := ftesting.SetupCleanIndex(ctx, t, dl.FleetAgents)
+	agentID := createAgent(ctx, t, index, bulker, map[string]*model.PolicyOutput{
+		outputName: {},
+	})
+
+	body, err := renderRemoveOutputPainlessScript(outputName)
+	require.NoError(t, err)
+	require.NoError(t, bulker.Update(ctx, dl.FleetAgents, agentID, body, bulk.WithRefresh()))
+
+	agent, err := dl.FindAgent(
+		ctx, bulker, dl.QueryAgentByID, dl.FieldID, agentID, dl.WithIndexName(index))
+	require.NoError(t, err)
+	assert.Empty(t, agent.Outputs)
+}
+
 func TestPolicyOutputESPrepareRealES(t *testing.T) {
 	ctx := testlog.SetLogger(t).WithContext(t.Context())
 	index, bulker := ftesting.SetupCleanIndex(ctx, t, dl.FleetAgents)

--- a/internal/pkg/policy/policy_output_test.go
+++ b/internal/pkg/policy/policy_output_test.go
@@ -26,6 +26,49 @@ import (
 
 var TestPayload []byte
 
+func TestRenderUpdatePainlessScriptParameterizesOutputName(t *testing.T) {
+	const outputName = `output"';\()`
+	fields := map[string]any{
+		dl.FieldPolicyOutputAPIKeyID: "api-key-id",
+	}
+
+	body, err := renderUpdatePainlessScript(outputName, fields)
+	require.NoError(t, err)
+
+	var request struct {
+		Script struct {
+			Source string         `json:"source"`
+			Params map[string]any `json:"params"`
+		} `json:"script"`
+	}
+	require.NoError(t, json.Unmarshal(body, &request))
+
+	assert.NotContains(t, request.Script.Source, outputName)
+	assert.Contains(t, request.Script.Source, "params.output_name")
+	assert.Equal(t, outputName, request.Script.Params["output_name"])
+	assert.Equal(t, "api-key-id", request.Script.Params[dl.FieldPolicyOutputAPIKeyID])
+	assert.NotContains(t, fields, "output_name")
+}
+
+func TestRenderRemoveOutputPainlessScriptParameterizesOutputName(t *testing.T) {
+	const outputName = `output"';\()`
+
+	body, err := renderRemoveOutputPainlessScript(outputName)
+	require.NoError(t, err)
+
+	var request struct {
+		Script struct {
+			Source string         `json:"source"`
+			Params map[string]any `json:"params"`
+		} `json:"script"`
+	}
+	require.NoError(t, json.Unmarshal(body, &request))
+
+	assert.Equal(t, "ctx._source['outputs'].remove(params.output_name)", request.Script.Source)
+	assert.NotContains(t, request.Script.Source, outputName)
+	assert.Equal(t, outputName, request.Script.Params["output_name"])
+}
+
 func TestPolicyLogstashOutputPrepare(t *testing.T) {
 	logger := testlog.SetLogger(t)
 	bulker := ftesting.NewMockBulk()


### PR DESCRIPTION
<!-- Type of change: Bug -->

## What is the problem this PR solves?

Policy output names were rendered directly into Painless source used to update Fleet agent documents. An output name containing script syntax could therefore change the meaning of the update or removal script.

## How does this PR solve the problem?

Pass output names through Painless `params` in both the output update and output removal scripts. Output names are now handled only as map keys and are never included in script source.

Regression tests verify the generated requests and exercise a script-shaped output name against Elasticsearch.

## How to test this PR locally

```bash
mage test:unit
TEST_RUN=TestRenderUpdatePainlessScript mage test:integration
TEST_RUN=TestRenderRemoveOutputPainlessScript mage test:integration
```

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test these changes; the request structure and execution model are unchanged.
- [ ] I have included fail safe mechanisms; no new load-producing behavior is introduced.

## Checklist

- [x] The parameterized script construction makes the intent explicit.
- [x] No documentation changes are required.
- [x] No default configuration changes are required.
- [x] I have added tests that prove the fix is effective.
- [x] I have added a changelog fragment.
