### PR TITLE
Retain output secret when agent update fails

### DIFF
--- a/changelog/fragments/1785539200-retain-output-secret-on-agent-update-failure.yaml
+++ b/changelog/fragments/1785539200-retain-output-secret-on-agent-update-failure.yaml
@@ -1,0 +1,11 @@
+kind: bug-fix
+
+summary: Retain output API key secrets when agent document updates fail
+
+description: |
+  Fleet Server no longer deletes a newly created output API key secret when the
+  corresponding agent document update returns an error. Elasticsearch may have
+  committed an update even when the client times out waiting for its response;
+  deleting the secret in that case leaves the agent with a dangling reference.
+
+component: fleet-server

--- a/internal/pkg/policy/policy_output.go
+++ b/internal/pkg/policy/policy_output.go
@@ -347,9 +347,10 @@ func (p *Output) prepareElasticsearch(
 
 		if err = bulker.Update(ctx, dl.FleetAgents, agent.Id, body, bulk.WithRefresh(), bulk.WithRetryOnConflict(3)); err != nil {
 			zlog.Error().Err(err).Msg("fail update agent record")
-			if delErr := bulker.DeleteSecret(ctx, secretID); delErr != nil {
-				zlog.Warn().Err(delErr).Str("secret_id", secretID).Msg("failed to delete orphaned output API key secret after agent update failure")
-			}
+			// The update may have been committed by Elasticsearch even when the client
+			// returns an error, for example when the request context expires while
+			// waiting for the response. Deleting the secret here can therefore leave
+			// the agent document pointing at a missing secret.
 			return fmt.Errorf("fail update agent record: %w", err)
 		}
 

--- a/internal/pkg/policy/policy_output_test.go
+++ b/internal/pkg/policy/policy_output_test.go
@@ -303,7 +303,7 @@ func TestPolicyOutputESPrepare(t *testing.T) {
 		bulker.AssertExpectations(t)
 	})
 
-	t.Run("Secret is deleted when agent document update fails", func(t *testing.T) {
+	t.Run("Secret is retained when agent document update fails", func(t *testing.T) {
 		logger := testlog.SetLogger(t)
 		bulker := ftesting.NewMockBulk()
 		apiKey := bulk.APIKey{ID: "abc", Key: "new-key"}
@@ -315,7 +315,6 @@ func TestPolicyOutputESPrepare(t *testing.T) {
 		bulker.On("Update",
 			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(errors.New("ES update failed")).Once()
-		bulker.On("DeleteSecret", mock.Anything, secretID).Return(nil).Once()
 
 		output := Output{
 			Type: OutputTypeElasticsearch,
@@ -327,6 +326,7 @@ func TestPolicyOutputESPrepare(t *testing.T) {
 
 		err := output.Prepare(context.Background(), logger, bulker, testAgent, policyMap)
 		require.Error(t, err)
+		bulker.AssertNotCalled(t, "DeleteSecret", mock.Anything, secretID)
 		bulker.AssertExpectations(t)
 	})
 


### PR DESCRIPTION
## What is the problem this PR solves?

When Fleet Server creates an output API key, it stores the encoded key in `.fleet-secrets` and then updates the agent document in `.fleet-agents` with the secret reference. Elasticsearch can commit that update while the client still receives an error, for example when the request context expires while waiting for the response. This can happen under scale load and was observed during a 100k-agent scale test.

The existing error path immediately deleted the secret. In the ambiguous-commit case, this left the agent document pointing at a missing secret and subsequent check-ins failed while resolving the output API key.

## How does this PR solve the problem?

Retain the newly created secret whenever the agent update returns an error. This chooses a possible orphaned secret over damaging an agent document with a dangling reference.

A follow-up PR adds conservative, out-of-band reconciliation for these retained candidates.

## How to test

- `go test ./internal/pkg/policy -run TestPolicyOutputESPrepare -count=1`
- `mage test:unit`

`mage check:all` currently reports 58 pre-existing linter findings in unrelated files under the repository's pinned Go/toolchain configuration. The files changed by this PR are clean.

## Design Checklist

- The solution is stateless and assumes a horizontally scaled Fleet Server deployment.
- The changed path is intended for 100k-agent deployments.
- The error behavior is fail-safe: an uncertain write retains the secret so a committed agent reference remains usable.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.md`

Documentation and configuration changes are not applicable. The changelog entry is supplied as a fragment.
