### PR TITLE
Reconcile orphaned output secrets after agent update failures

### DIFF
--- a/changelog/fragments/1785539201-reconcile-orphaned-output-secrets.yaml
+++ b/changelog/fragments/1785539201-reconcile-orphaned-output-secrets.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Reconcile orphaned output secrets after ambiguous agent update failures
+component: fleet-server

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -85,8 +85,20 @@ type CheckinT struct {
 	// gwPool is a gzip.Writer pool intended to lower the amount of writers created when responding to checkin requests.
 	// gzip.Writer allocations are expensive (~1.2MB each) and can exhaust an instance's memory if a lot of concurrent responses are sent (this occurs when a mass-action such as an upgrade is detected).
 	// effectiveness of the pool is controlled by rate limiter configured through the limit.action_limit attribute.
-	gwPool sync.Pool
-	bulker bulk.Bulk
+	gwPool                         sync.Pool
+	bulker                         bulk.Bulk
+	outputSecretCandidateCollector policy.OutputSecretCandidateCollector
+}
+
+// CheckinOption configures check-in handling.
+type CheckinOption func(*CheckinT)
+
+// WithOutputSecretCandidateCollector enables out-of-band reconciliation of
+// secrets retained after ambiguous agent update failures.
+func WithOutputSecretCandidateCollector(collector policy.OutputSecretCandidateCollector) CheckinOption {
+	return func(ct *CheckinT) {
+		ct.outputSecretCandidateCollector = collector
+	}
 }
 
 func NewCheckinT(
@@ -98,6 +110,7 @@ func NewCheckinT(
 	gcp monitor.GlobalCheckpointProvider,
 	ad *action.Dispatcher,
 	bulker bulk.Bulk,
+	opts ...CheckinOption,
 ) (*CheckinT, error) {
 	tr, err := action.NewTokenResolver(bulker)
 	if err != nil {
@@ -122,6 +135,9 @@ func NewCheckinT(
 			},
 		},
 		bulker: bulker,
+	}
+	for _, opt := range opts {
+		opt(ct)
 	}
 
 	return ct, nil
@@ -413,7 +429,7 @@ func (ct *CheckinT) ProcessRequest(zlog zerolog.Logger, w http.ResponseWriter, r
 				actions = append(actions, acs...)
 				break LOOP
 			case policy := <-sub.Output():
-				actionResp, err := processPolicy(ctx, zlog, ct.bulker, agent, policy)
+				actionResp, err := processPolicy(ctx, zlog, ct.bulker, agent, policy, ct.outputSecretCandidateCollector)
 				if err != nil {
 					span.End()
 					return fmt.Errorf("processPolicy: %w", err)
@@ -878,7 +894,7 @@ func convertActions(zlog zerolog.Logger, agentID string, actions []model.Action)
 // A new policy exists for this agent.  Perform the following:
 //   - Generate and update default ApiKey if roles have changed.
 //   - Rewrite the policy for delivery to the agent injecting the key material.
-func processPolicy(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, agent *model.Agent, pp *policy.ParsedPolicy) (*Action, error) {
+func processPolicy(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, agent *model.Agent, pp *policy.ParsedPolicy, secretCandidateCollector policy.OutputSecretCandidateCollector) (*Action, error) {
 	var links []apm.SpanLink = nil // set to a nil array to preserve default behaviour if no policy links are found
 	if err := pp.Links.Trace.Validate(); err == nil {
 		links = []apm.SpanLink{pp.Links}
@@ -913,7 +929,7 @@ func processPolicy(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, a
 	}
 	// Iterate through the policy outputs and prepare them
 	for _, policyOutput := range pp.Outputs {
-		if err := policyOutput.Prepare(ctx, zlog, bulker, agent, data.Outputs); err != nil {
+		if err := policyOutput.Prepare(ctx, zlog, bulker, agent, data.Outputs, policy.WithOutputSecretCandidateCollector(secretCandidateCollector)); err != nil {
 			return nil, fmt.Errorf("failed to prepare output %q: %w",
 				policyOutput.Name, err)
 		}

--- a/internal/pkg/gc/doc.go
+++ b/internal/pkg/gc/doc.go
@@ -2,5 +2,6 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-// Package gc provides utilities to cleanup expired (elastic-agent) actions.
+// Package gc provides utilities to clean up expired Elastic Agent actions and
+// orphaned Fleet Server resources.
 package gc

--- a/internal/pkg/gc/orphaned_output_secrets.go
+++ b/internal/pkg/gc/orphaned_output_secrets.go
@@ -1,0 +1,181 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package gc
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
+	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
+	"github.com/elastic/fleet-server/v7/internal/pkg/model"
+	"github.com/elastic/fleet-server/v7/internal/pkg/policy"
+	"github.com/elastic/fleet-server/v7/internal/pkg/secret"
+)
+
+const (
+	defaultOutputSecretCandidateQueueSize = 10_000
+	defaultOutputSecretGracePeriod        = 10 * time.Minute
+	defaultOutputSecretCheckInterval      = time.Minute
+	defaultOutputSecretConfirmationPeriod = 5 * time.Minute
+	defaultOutputSecretOperationTimeout   = 30 * time.Second
+	defaultOutputSecretMaxChecksPerRun    = 100
+)
+
+type outputSecretCandidateState struct {
+	policy.OutputSecretCandidate
+	createdAt           time.Time
+	firstUnreferencedAt time.Time
+}
+
+// OrphanedOutputSecretReconciler conservatively removes output secrets that
+// were retained after an ambiguous agent update failure but are not referenced
+// by the resulting agent document.
+//
+// Candidates intentionally live only in memory. Losing one during a Fleet
+// Server restart can leak a secret, but can never delete a secret still in use.
+type OrphanedOutputSecretReconciler struct {
+	bulker             bulk.Bulk
+	candidates         chan policy.OutputSecretCandidate
+	pending            map[string]*outputSecretCandidateState
+	gracePeriod        time.Duration
+	checkInterval      time.Duration
+	confirmationPeriod time.Duration
+	operationTimeout   time.Duration
+	maxChecksPerRun    int
+	now                func() time.Time
+}
+
+// NewOrphanedOutputSecretReconciler creates an in-memory candidate reconciler.
+func NewOrphanedOutputSecretReconciler(bulker bulk.Bulk) *OrphanedOutputSecretReconciler {
+	return &OrphanedOutputSecretReconciler{
+		bulker:             bulker,
+		candidates:         make(chan policy.OutputSecretCandidate, defaultOutputSecretCandidateQueueSize),
+		pending:            make(map[string]*outputSecretCandidateState),
+		gracePeriod:        defaultOutputSecretGracePeriod,
+		checkInterval:      defaultOutputSecretCheckInterval,
+		confirmationPeriod: defaultOutputSecretConfirmationPeriod,
+		operationTimeout:   defaultOutputSecretOperationTimeout,
+		maxChecksPerRun:    defaultOutputSecretMaxChecksPerRun,
+		now:                time.Now,
+	}
+}
+
+// Add queues a candidate without delaying the check-in request. A full queue
+// fails safe by leaking the candidate rather than blocking or deleting it.
+func (r *OrphanedOutputSecretReconciler) Add(candidate policy.OutputSecretCandidate) bool {
+	select {
+	case r.candidates <- candidate:
+		return true
+	default:
+		return false
+	}
+}
+
+// Run reconciles candidates until the Fleet Server context is cancelled.
+func (r *OrphanedOutputSecretReconciler) Run(ctx context.Context) error {
+	ticker := time.NewTicker(r.checkInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case candidate := <-r.candidates:
+			r.pending[candidate.SecretID] = &outputSecretCandidateState{
+				OutputSecretCandidate: candidate,
+				createdAt:             r.now(),
+			}
+		case <-ticker.C:
+			r.reconcile(ctx)
+		}
+	}
+}
+
+func (r *OrphanedOutputSecretReconciler) reconcile(ctx context.Context) {
+	now := r.now()
+	checks := 0
+	for secretID, candidate := range r.pending {
+		if now.Sub(candidate.createdAt) < r.gracePeriod {
+			continue
+		}
+		if checks >= r.maxChecksPerRun {
+			return
+		}
+		checks++
+
+		opCtx, cancel := context.WithTimeout(ctx, r.operationTimeout)
+		agent, err := dl.GetAgent(opCtx, r.bulker, candidate.AgentID)
+		cancel()
+		if err != nil && !errors.Is(err, dl.ErrNotFound) {
+			zerolog.Ctx(ctx).Warn().Err(err).
+				Str("agent.id", candidate.AgentID).
+				Str("fleet.policy.output.name", candidate.OutputName).
+				Str("secret.id", candidate.SecretID).
+				Msg("failed to inspect output secret reconciliation candidate")
+			continue
+		}
+
+		if err == nil && outputSecretIsReferenced(&agent, candidate.OutputSecretCandidate) {
+			delete(r.pending, secretID)
+			continue
+		}
+
+		if candidate.firstUnreferencedAt.IsZero() {
+			candidate.firstUnreferencedAt = now
+			continue
+		}
+		if now.Sub(candidate.firstUnreferencedAt) < r.confirmationPeriod {
+			continue
+		}
+
+		opCtx, cancel = context.WithTimeout(ctx, r.operationTimeout)
+		err = r.bulker.DeleteSecret(opCtx, candidate.SecretID)
+		cancel()
+		if err != nil {
+			zerolog.Ctx(ctx).Warn().Err(err).
+				Str("agent.id", candidate.AgentID).
+				Str("fleet.policy.output.name", candidate.OutputName).
+				Str("secret.id", candidate.SecretID).
+				Msg("failed to delete orphaned output secret candidate")
+			continue
+		}
+
+		delete(r.pending, secretID)
+		zerolog.Ctx(ctx).Info().
+			Str("agent.id", candidate.AgentID).
+			Str("fleet.policy.output.name", candidate.OutputName).
+			Str("secret.id", candidate.SecretID).
+			Msg("deleted orphaned output secret candidate")
+	}
+}
+
+func outputSecretIsReferenced(agent *model.Agent, candidate policy.OutputSecretCandidate) bool {
+	if agent.DefaultAPIKey == candidate.SecretRef {
+		return true
+	}
+	for _, output := range agent.Outputs {
+		if output.APIKey == candidate.SecretRef {
+			return true
+		}
+		for _, retired := range output.ToRetireAPIKeyIds {
+			if retired.SecretID == candidate.SecretID {
+				return true
+			}
+		}
+	}
+	for _, retired := range agent.DefaultAPIKeyHistory {
+		if retired.SecretID == candidate.SecretID {
+			return true
+		}
+	}
+	if secretID, ok := secret.ParseSecretReference(agent.DefaultAPIKey); ok {
+		return secretID == candidate.SecretID
+	}
+	return false
+}

--- a/internal/pkg/gc/orphaned_output_secrets_test.go
+++ b/internal/pkg/gc/orphaned_output_secrets_test.go
@@ -1,0 +1,154 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build !integration
+
+package gc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/fleet-server/v7/internal/pkg/bulk"
+	"github.com/elastic/fleet-server/v7/internal/pkg/dl"
+	"github.com/elastic/fleet-server/v7/internal/pkg/model"
+	"github.com/elastic/fleet-server/v7/internal/pkg/policy"
+	ftesting "github.com/elastic/fleet-server/v7/internal/pkg/testing"
+)
+
+func TestOutputSecretIsReferenced(t *testing.T) {
+	candidate := policy.OutputSecretCandidate{
+		OutputName: "default",
+		SecretID:   "candidate-secret",
+		SecretRef:  "$co.elastic.secret{candidate-secret}",
+	}
+
+	tests := []struct {
+		name  string
+		agent model.Agent
+		want  bool
+	}{
+		{
+			name: "current output reference",
+			agent: model.Agent{Outputs: map[string]*model.PolicyOutput{
+				"default": {APIKey: candidate.SecretRef},
+			}},
+			want: true,
+		},
+		{
+			name: "retired output reference",
+			agent: model.Agent{Outputs: map[string]*model.PolicyOutput{
+				"other": {ToRetireAPIKeyIds: []model.ToRetireAPIKeyIdsItems{{SecretID: candidate.SecretID}}},
+			}},
+			want: true,
+		},
+		{
+			name: "unreferenced",
+			agent: model.Agent{Outputs: map[string]*model.PolicyOutput{
+				"default": {APIKey: "$co.elastic.secret{different-secret}"},
+			}},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, outputSecretIsReferenced(&tc.agent, candidate))
+		})
+	}
+}
+
+func TestOrphanedOutputSecretReconcilerRequiresTwoUnreferencedObservations(t *testing.T) {
+	ctx := context.Background()
+	bulker := ftesting.NewMockBulk()
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	candidate := policy.OutputSecretCandidate{
+		AgentID:    "agent-id",
+		OutputName: "default",
+		SecretID:   "candidate-secret",
+		SecretRef:  "$co.elastic.secret{candidate-secret}",
+	}
+	agentSource, err := json.Marshal(model.Agent{Outputs: map[string]*model.PolicyOutput{}})
+	require.NoError(t, err)
+	bulker.On("ReadRaw", mock.Anything, dl.FleetAgents, candidate.AgentID, mock.Anything).
+		Return(&bulk.MgetResponseItem{Found: true, Source: agentSource}, nil).Twice()
+	bulker.On("DeleteSecret", mock.Anything, candidate.SecretID).Return(nil).Once()
+
+	reconciler := NewOrphanedOutputSecretReconciler(bulker)
+	reconciler.now = func() time.Time { return now }
+	reconciler.pending[candidate.SecretID] = &outputSecretCandidateState{
+		OutputSecretCandidate: candidate,
+		createdAt:             now.Add(-reconciler.gracePeriod),
+	}
+
+	reconciler.reconcile(ctx)
+	bulker.AssertNotCalled(t, "DeleteSecret", mock.Anything, candidate.SecretID)
+	require.Contains(t, reconciler.pending, candidate.SecretID)
+
+	now = now.Add(reconciler.confirmationPeriod)
+	reconciler.reconcile(ctx)
+	require.NotContains(t, reconciler.pending, candidate.SecretID)
+	bulker.AssertExpectations(t)
+}
+
+func TestOrphanedOutputSecretReconcilerPreservesReferencedCandidate(t *testing.T) {
+	ctx := context.Background()
+	bulker := ftesting.NewMockBulk()
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	candidate := policy.OutputSecretCandidate{
+		AgentID:    "agent-id",
+		OutputName: "default",
+		SecretID:   "candidate-secret",
+		SecretRef:  "$co.elastic.secret{candidate-secret}",
+	}
+	agentSource, err := json.Marshal(model.Agent{Outputs: map[string]*model.PolicyOutput{
+		"default": {APIKey: candidate.SecretRef},
+	}})
+	require.NoError(t, err)
+	bulker.On("ReadRaw", mock.Anything, dl.FleetAgents, candidate.AgentID, mock.Anything).
+		Return(&bulk.MgetResponseItem{Found: true, Source: agentSource}, nil).Once()
+
+	reconciler := NewOrphanedOutputSecretReconciler(bulker)
+	reconciler.now = func() time.Time { return now }
+	reconciler.pending[candidate.SecretID] = &outputSecretCandidateState{
+		OutputSecretCandidate: candidate,
+		createdAt:             now.Add(-reconciler.gracePeriod),
+	}
+
+	reconciler.reconcile(ctx)
+	require.NotContains(t, reconciler.pending, candidate.SecretID)
+	bulker.AssertNotCalled(t, "DeleteSecret", mock.Anything, candidate.SecretID)
+	bulker.AssertExpectations(t)
+}
+
+func TestOrphanedOutputSecretReconcilerRetriesReadErrors(t *testing.T) {
+	ctx := context.Background()
+	bulker := ftesting.NewMockBulk()
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	candidate := policy.OutputSecretCandidate{
+		AgentID:  "agent-id",
+		SecretID: "candidate-secret",
+	}
+	bulker.On("ReadRaw", mock.Anything, dl.FleetAgents, candidate.AgentID, mock.Anything).
+		Return((*bulk.MgetResponseItem)(nil), errors.New("read failed")).Once()
+
+	reconciler := NewOrphanedOutputSecretReconciler(bulker)
+	reconciler.now = func() time.Time { return now }
+	reconciler.pending[candidate.SecretID] = &outputSecretCandidateState{
+		OutputSecretCandidate: candidate,
+		createdAt:             now.Add(-reconciler.gracePeriod),
+	}
+
+	reconciler.reconcile(ctx)
+	require.Contains(t, reconciler.pending, candidate.SecretID)
+	require.True(t, reconciler.pending[candidate.SecretID].firstUnreferencedAt.IsZero())
+	bulker.AssertNotCalled(t, "DeleteSecret", mock.Anything, candidate.SecretID)
+	bulker.AssertExpectations(t)
+}

--- a/internal/pkg/policy/policy_output.go
+++ b/internal/pkg/policy/policy_output.go
@@ -47,9 +47,43 @@ type Output struct {
 	Role         *RoleT
 }
 
+// OutputSecretCandidate identifies a secret whose reference may or may not have
+// been committed to an agent document after an ambiguous update failure.
+type OutputSecretCandidate struct {
+	AgentID    string
+	OutputName string
+	SecretID   string
+	SecretRef  string
+}
+
+// OutputSecretCandidateCollector accepts secrets for out-of-band reconciliation.
+type OutputSecretCandidateCollector interface {
+	Add(OutputSecretCandidate) bool
+}
+
+type outputPrepareConfig struct {
+	secretCandidateCollector OutputSecretCandidateCollector
+}
+
+// OutputPrepareOption configures output preparation.
+type OutputPrepareOption func(*outputPrepareConfig)
+
+// WithOutputSecretCandidateCollector records secrets created before ambiguous
+// agent update failures so they can be reconciled outside the request path.
+func WithOutputSecretCandidateCollector(collector OutputSecretCandidateCollector) OutputPrepareOption {
+	return func(c *outputPrepareConfig) {
+		c.secretCandidateCollector = collector
+	}
+}
+
 // Prepare prepares the output p to be sent to the elastic-agent
 // The agent might be mutated for an elasticsearch output
-func (p *Output) Prepare(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, agent *model.Agent, outputMap map[string]map[string]any) error {
+func (p *Output) Prepare(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, agent *model.Agent, outputMap map[string]map[string]any, opts ...OutputPrepareOption) error {
+	cfg := outputPrepareConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	span, ctx := apm.StartSpan(ctx, "prepareOutput", "process")
 	defer span.End()
 	span.Context.SetLabel("output_type", p.Type)
@@ -60,7 +94,7 @@ func (p *Output) Prepare(ctx context.Context, zlog zerolog.Logger, bulker bulk.B
 	switch p.Type {
 	case OutputTypeElasticsearch:
 		zlog.Debug().Msg("preparing elasticsearch output")
-		if err := p.prepareElasticsearch(ctx, zlog, bulker, bulker, agent, outputMap, false); err != nil {
+		if err := p.prepareElasticsearch(ctx, zlog, bulker, bulker, agent, outputMap, false, cfg.secretCandidateCollector); err != nil {
 			return fmt.Errorf("failed to prepare elasticsearch output %q: %w", p.Name, err)
 		}
 	case OutputTypeRemoteElasticsearch:
@@ -70,7 +104,7 @@ func (p *Output) Prepare(ctx context.Context, zlog zerolog.Logger, bulker bulk.B
 			return err
 		}
 		// the outputBulker is different for remote ES, it is used to create/update Api keys in the remote ES client
-		if err := p.prepareElasticsearch(ctx, zlog, bulker, newBulker, agent, outputMap, hasConfigChanged); err != nil {
+		if err := p.prepareElasticsearch(ctx, zlog, bulker, newBulker, agent, outputMap, hasConfigChanged, cfg.secretCandidateCollector); err != nil {
 			return fmt.Errorf("failed to prepare remote elasticsearch output %q: %w", p.Name, err)
 		}
 	case OutputTypeLogstash:
@@ -93,7 +127,8 @@ func (p *Output) prepareElasticsearch(
 	outputBulker bulk.Bulk,
 	agent *model.Agent,
 	outputMap map[string]map[string]any,
-	hasConfigChanged bool) error {
+	hasConfigChanged bool,
+	secretCandidateCollector OutputSecretCandidateCollector) error {
 	// The role is required to do api key management
 	if p.Role == nil {
 		zlog.Error().
@@ -346,6 +381,17 @@ func (p *Output) prepareElasticsearch(
 			// returns an error, for example when the request context expires while
 			// waiting for the response. Deleting the secret here can therefore leave
 			// the agent document pointing at a missing secret.
+			if secretCandidateCollector != nil {
+				candidate := OutputSecretCandidate{
+					AgentID:    agent.Id,
+					OutputName: p.Name,
+					SecretID:   secretID,
+					SecretRef:  apiKeyRef,
+				}
+				if !secretCandidateCollector.Add(candidate) {
+					zlog.Warn().Str("secret.id", secretID).Msg("failed to enqueue output secret reconciliation candidate")
+				}
+			}
 			return fmt.Errorf("fail update agent record: %w", err)
 		}
 

--- a/internal/pkg/policy/policy_output_integration_test.go
+++ b/internal/pkg/policy/policy_output_integration_test.go
@@ -174,7 +174,7 @@ func TestPolicyOutputESPrepareRealES(t *testing.T) {
 	}
 
 	err = output.prepareElasticsearch(
-		ctx, zerolog.Nop(), bulker, bulker, &agent, policyMap, false)
+		ctx, zerolog.Nop(), bulker, bulker, &agent, policyMap, false, nil)
 	require.NoError(t, err)
 
 	// need to wait a bit before querying the agent again
@@ -250,7 +250,7 @@ func TestPolicyOutputESPrepareRemoteES(t *testing.T) {
 	}
 
 	err = output.prepareElasticsearch(
-		ctx, zerolog.Nop(), bulker, bulker, &agent, policyMap, false)
+		ctx, zerolog.Nop(), bulker, bulker, &agent, policyMap, false, nil)
 	require.NoError(t, err)
 
 	ftesting.Retry(t, ctx, func(ctx context.Context) error {
@@ -302,7 +302,7 @@ func TestPolicyOutputESPrepareESRetireRemoteAPIKeys(t *testing.T) {
 	}
 
 	err = output.prepareElasticsearch(
-		ctx, zerolog.Nop(), bulker, bulker, &agent, policyMap, false)
+		ctx, zerolog.Nop(), bulker, bulker, &agent, policyMap, false, nil)
 	require.NoError(t, err)
 
 	// need to wait a bit before querying the agent again

--- a/internal/pkg/policy/policy_output_test.go
+++ b/internal/pkg/policy/policy_output_test.go
@@ -69,6 +69,15 @@ func TestRenderRemoveOutputPainlessScriptParameterizesOutputName(t *testing.T) {
 	assert.Equal(t, outputName, request.Script.Params["output_name"])
 }
 
+type recordingOutputSecretCandidateCollector struct {
+	candidates []OutputSecretCandidate
+}
+
+func (c *recordingOutputSecretCandidateCollector) Add(candidate OutputSecretCandidate) bool {
+	c.candidates = append(c.candidates, candidate)
+	return true
+}
+
 func TestPolicyLogstashOutputPrepare(t *testing.T) {
 	logger := testlog.SetLogger(t)
 	bulker := ftesting.NewMockBulk()
@@ -365,11 +374,19 @@ func TestPolicyOutputESPrepare(t *testing.T) {
 			Role: &RoleT{Sha2: "new-hash", Raw: TestPayload},
 		}
 		policyMap := map[string]map[string]any{"test output": {}}
-		testAgent := &model.Agent{Outputs: map[string]*model.PolicyOutput{}}
+		testAgent := &model.Agent{ESDocument: model.ESDocument{Id: "agent-id"}, Outputs: map[string]*model.PolicyOutput{}}
+		collector := &recordingOutputSecretCandidateCollector{}
 
-		err := output.Prepare(context.Background(), logger, bulker, testAgent, policyMap)
+		err := output.Prepare(context.Background(), logger, bulker, testAgent, policyMap,
+			WithOutputSecretCandidateCollector(collector))
 		require.Error(t, err)
 		bulker.AssertNotCalled(t, "DeleteSecret", mock.Anything, secretID)
+		require.Equal(t, []OutputSecretCandidate{{
+			AgentID:    "agent-id",
+			OutputName: "test output",
+			SecretID:   secretID,
+			SecretRef:  "$co.elastic.secret{test-secret-id}",
+		}}, collector.candidates)
 		bulker.AssertExpectations(t)
 	})
 

--- a/internal/pkg/server/fleet.go
+++ b/internal/pkg/server/fleet.go
@@ -524,6 +524,9 @@ func (f *Fleet) runSubsystems(ctx context.Context, cfg *config.Config, g *errgro
 	bc := checkin.NewBulk(bulker)
 	g.Go(loggedRunFunc(ctx, "Bulk checkin", bc.Run))
 
+	outputSecretReconciler := gc.NewOrphanedOutputSecretReconciler(bulker)
+	g.Go(loggedRunFunc(ctx, "Orphaned output secret reconciler", outputSecretReconciler.Run))
+
 	// Samples the checkin capacity-rejection counter into a rate gauge, exposed via
 	// /stats for use as an autoscaling signal. See api.RunCheckinRejectionRateSampler.
 	g.Go(loggedRunFunc(ctx, "Checkin rejection rate sampler", func(ctx context.Context) error {
@@ -535,7 +538,8 @@ func (f *Fleet) runSubsystems(ctx context.Context, cfg *config.Config, g *errgro
 		return api.RunConnRejectionRateSampler(ctx, api.RejectionRateSampleInterval)
 	}))
 
-	ct, err := api.NewCheckinT(f.verCon, &cfg.Inputs[0].Server, f.cache, bc, pm, am, ad, bulker)
+	ct, err := api.NewCheckinT(f.verCon, &cfg.Inputs[0].Server, f.cache, bc, pm, am, ad, bulker,
+		api.WithOutputSecretCandidateCollector(outputSecretReconciler))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What is the problem this PR solves?

#7533 prevents an ambiguous `.fleet-agents` update failure from deleting a secret that Elasticsearch may already have referenced. The safe failure behavior can leave an orphaned `.fleet-secrets` document when the update truly did not commit.

This failure mode was observed under load during a 100k-agent scale test.

## How does this PR solve the problem?

Add an out-of-band, candidate-based reconciler:

- The failed update path only enqueues the newly created secret and returns; it performs no cleanup I/O in the check-in request.
- Candidates remain in memory for a 10-minute grace period.
- The reconciler rereads the agent with a fresh background context and preserves candidates referenced by either the current output or output API-key retirement history.
- A secret must be observed unreferenced twice, at least 5 minutes apart, before deletion.
- Read and delete failures retain the candidate for retry.
- Work is capped at 100 candidate checks per minute per Fleet Server to avoid creating a cleanup load spike.
- A full queue fails safe by leaking a secret rather than blocking a check-in or risking deletion.

Candidates intentionally do not survive a Fleet Server restart. A restart during the reconciliation window can therefore leave an orphaned secret, but cannot damage an agent by deleting a referenced secret.

This PR is stacked on and depends on #7533. Its implementation is the second commit (`b3f11ce9`). Once #7533 merges, GitHub will remove the shared first commit from this PR's diff.

## How to test

- `go test ./internal/pkg/policy ./internal/pkg/gc ./internal/pkg/api ./internal/pkg/server`
- `mage test:unit`

`mage check:all` currently reports the same 58 pre-existing linter findings as #7533 in unrelated files. None are in files changed by this PR.

## Design Checklist

- The reconciler is local to each horizontally scaled Fleet Server and requires no cross-instance coordination because each secret candidate is created by one request on one instance.
- The queue, grace period, confirmation reads, and per-run cap are designed for 100k-agent deployments.
- Every uncertain state fails safe by retaining the secret.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.md`

Configuration changes are not applicable. Package documentation was updated and the changelog entry is supplied as a fragment.
