### PR TITLE
bulk: add configurable concurrency limit for ReadSecrets

### DIFF
--- a/changelog/fragments/1786037058-rate-limit-read-secrets.yaml
+++ b/changelog/fragments/1786037058-rate-limit-read-secrets.yaml
@@ -1,6 +1,6 @@
 kind: bug
 
-summary: Add configurable limit on concurrent secret reads to reduce memory pressure under high agent check-in load
+summary: Limit concurrent secret reads to reduce memory pressure under high agent check-in load
 
 description: |
   Under high concurrent agent check-in load, fleet-server could open an
@@ -8,8 +8,7 @@ description: |
   policy secret references, contributing to out-of-memory conditions on
   large deployments.
 
-  A new configuration option, server.bulk.max_concurrent_secret_reads
-  (default 32), limits how many secret reads can be in-flight at once.
+  Secret reads are now capped at 32 concurrent in-flight requests.
   Excess reads wait until a slot is available.
 
 component: fleet-server

--- a/changelog/fragments/1786037058-rate-limit-read-secrets.yaml
+++ b/changelog/fragments/1786037058-rate-limit-read-secrets.yaml
@@ -1,19 +1,15 @@
 kind: bug
 
-summary: Add configurable concurrency limit for ReadSecrets to reduce memory pressure under high checkin load
+summary: Add configurable limit on concurrent secret reads to reduce memory pressure under high agent check-in load
 
 description: |
-  ReadSecrets makes direct HTTP calls to the ES Fleet secrets API (one per
-  secret reference per agent checkin) outside the bulk dispatch queue, so it
-  is not subject to the max_pending_bulk_dispatches cap. Under high concurrent
-  checkin load this can cause unbounded concurrent ES connections and additional
-  goroutine and heap pressure, contributing to OOM conditions on large
-  serverless projects.
+  Under high concurrent agent check-in load, fleet-server could open an
+  unbounded number of concurrent connections to Elasticsearch to resolve
+  policy secret references, contributing to out-of-memory conditions on
+  large deployments.
 
-  A new max_concurrent_secret_reads option (server.bulk.max_concurrent_secret_reads,
-  default 32) is added to ServerBulk, backed by a semaphore.Weighted in the
-  Bulker struct. ReadSecrets acquires one slot per secret read and releases it
-  immediately after, matching the existing apikeyLimit pattern. Setting the
-  value to 0 is not supported.
+  A new configuration option, server.bulk.max_concurrent_secret_reads
+  (default 32), limits how many secret reads can be in-flight at once.
+  Excess reads wait until a slot is available.
 
 component: fleet-server

--- a/changelog/fragments/1786037058-rate-limit-read-secrets.yaml
+++ b/changelog/fragments/1786037058-rate-limit-read-secrets.yaml
@@ -1,0 +1,19 @@
+kind: bug
+
+summary: Add configurable concurrency limit for ReadSecrets to reduce memory pressure under high checkin load
+
+description: |
+  ReadSecrets makes direct HTTP calls to the ES Fleet secrets API (one per
+  secret reference per agent checkin) outside the bulk dispatch queue, so it
+  is not subject to the max_pending_bulk_dispatches cap. Under high concurrent
+  checkin load this can cause unbounded concurrent ES connections and additional
+  goroutine and heap pressure, contributing to OOM conditions on large
+  serverless projects.
+
+  A new max_concurrent_secret_reads option (server.bulk.max_concurrent_secret_reads,
+  default 32) is added to ServerBulk, backed by a semaphore.Weighted in the
+  Bulker struct. ReadSecrets acquires one slot per secret read and releases it
+  immediately after, matching the existing apikeyLimit pattern. Setting the
+  value to 0 is not supported.
+
+component: fleet-server

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -139,6 +139,7 @@ const (
 	defaultMaxPending                     = 32
 	defaultBlockQueueSz                   = 32 // Small capacity to allow multiOp to spin fast
 	defaultAPIKeyMaxParallel              = 32
+	defaultMaxConcurrentSecretReads       = 32
 	defaultApikeyMaxReqSize               = 100 * 1024 * 1024
 	defaultFlushContextTimeout            = time.Minute * 1
 	defaultMaxPendingBulkDispatches int64 = 0 // 0 means no limit
@@ -159,19 +160,22 @@ func NewBulker(es esapi.Transport, tracer *apm.Tracer, opts ...BulkOpt) *Bulker 
 		return &bulkT{ch: make(chan respT, 1)}
 	}
 
-	return &Bulker{
+	b := &Bulker{
 		opts:                  bopts,
 		es:                    es,
 		ch:                    make(chan *bulkT, bopts.blockQueueSz),
 		blkPool:               sync.Pool{New: poolFunc},
 		flushBufPool:          sync.Pool{New: func() any { return new(bytes.Buffer) }},
 		apikeyLimit:           semaphore.NewWeighted(int64(bopts.apikeyMaxParallel)),
-		readSecretsLimit:      semaphore.NewWeighted(int64(bopts.maxConcurrentSecretReads)),
 		tracer:                tracer,
 		remoteOutputConfigMap: make(map[string]map[string]any),
 		// remote ES bulkers
 		bulkerMap: make(map[string]Bulk),
 	}
+	if bopts.maxConcurrentSecretReads > 0 {
+		b.readSecretsLimit = semaphore.NewWeighted(int64(bopts.maxConcurrentSecretReads))
+	}
+	return b
 }
 
 func (b *Bulker) GetBulker(outputName string) Bulk {
@@ -331,12 +335,15 @@ func (b *Bulker) ReadSecrets(ctx context.Context, secretIds []string) (map[strin
 	result := make(map[string]string)
 	esClient := b.Client()
 	for _, id := range secretIds {
-		// limit concurrent direct ES secret reads
-		if err := b.readSecretsLimit.Acquire(ctx, 1); err != nil {
-			return nil, err
+		if b.readSecretsLimit != nil {
+			if err := b.readSecretsLimit.Acquire(ctx, 1); err != nil {
+				return nil, err
+			}
 		}
 		val, err := ReadSecret(ctx, esClient, id)
-		b.readSecretsLimit.Release(1)
+		if b.readSecretsLimit != nil {
+			b.readSecretsLimit.Release(1)
+		}
 		if err != nil {
 			if errors.Is(err, ErrSecretNotFound) {
 				zerolog.Ctx(ctx).Warn().Str("secret_id", id).Msg("secret not found; policy will load without it")

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -172,6 +172,7 @@ func NewBulker(es esapi.Transport, tracer *apm.Tracer, opts ...BulkOpt) *Bulker 
 		// remote ES bulkers
 		bulkerMap: make(map[string]Bulk),
 	}
+	// 0 means no limit; leave readSecretsLimit nil so ReadSecrets skips the semaphore.
 	if bopts.maxConcurrentSecretReads > 0 {
 		b.readSecretsLimit = semaphore.NewWeighted(int64(bopts.maxConcurrentSecretReads))
 	}

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -330,7 +330,7 @@ func (b *Bulker) ReadSecrets(ctx context.Context, secretIds []string) (map[strin
 	result := make(map[string]string)
 	esClient := b.Client()
 	for _, id := range secretIds {
-		// limit concurrent direct ES secret reads, matching apikeyLimit granularity
+		// limit concurrent direct ES secret reads
 		if err := b.readSecretsLimit.Acquire(ctx, 1); err != nil {
 			return nil, err
 		}

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -165,12 +165,7 @@ func NewBulker(es esapi.Transport, tracer *apm.Tracer, opts ...BulkOpt) *Bulker 
 		blkPool:               sync.Pool{New: poolFunc},
 		flushBufPool:          sync.Pool{New: func() any { return new(bytes.Buffer) }},
 		apikeyLimit:           semaphore.NewWeighted(int64(bopts.apikeyMaxParallel)),
-		readSecretsLimit: func() *semaphore.Weighted {
-			if bopts.maxConcurrentSecretReads > 0 {
-				return semaphore.NewWeighted(bopts.maxConcurrentSecretReads)
-			}
-			return nil
-		}(),
+		readSecretsLimit: semaphore.NewWeighted(int64(bopts.maxConcurrentSecretReads)),
 		tracer:                tracer,
 		remoteOutputConfigMap: make(map[string]map[string]any),
 		// remote ES bulkers
@@ -332,12 +327,10 @@ func (b *Bulker) hasChangedAndUpdateRemoteOutputConfig(zlog zerolog.Logger, name
 
 // read secrets one by one as there is no bulk API yet to read them in one request
 func (b *Bulker) ReadSecrets(ctx context.Context, secretIds []string) (map[string]string, error) {
-	if b.readSecretsLimit != nil {
-		if err := b.readSecretsLimit.Acquire(ctx, 1); err != nil {
-			return nil, err
-		}
-		defer b.readSecretsLimit.Release(1)
+	if err := b.readSecretsLimit.Acquire(ctx, 1); err != nil {
+		return nil, err
 	}
+	defer b.readSecretsLimit.Release(1)
 	result := make(map[string]string)
 	esClient := b.Client()
 	for _, id := range secretIds {

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -327,14 +327,14 @@ func (b *Bulker) hasChangedAndUpdateRemoteOutputConfig(zlog zerolog.Logger, name
 
 // read secrets one by one as there is no bulk API yet to read them in one request
 func (b *Bulker) ReadSecrets(ctx context.Context, secretIds []string) (map[string]string, error) {
-	if err := b.readSecretsLimit.Acquire(ctx, 1); err != nil {
-		return nil, err
-	}
-	defer b.readSecretsLimit.Release(1)
 	result := make(map[string]string)
 	esClient := b.Client()
 	for _, id := range secretIds {
+		if err := b.readSecretsLimit.Acquire(ctx, 1); err != nil {
+			return nil, err
+		}
 		val, err := ReadSecret(ctx, esClient, id)
+		b.readSecretsLimit.Release(1)
 		if err != nil {
 			if errors.Is(err, ErrSecretNotFound) {
 				zerolog.Ctx(ctx).Warn().Str("secret_id", id).Msg("secret not found; policy will load without it")

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -140,8 +140,8 @@ const (
 	defaultAPIKeyMaxParallel              = 32
 	defaultApikeyMaxReqSize               = 100 * 1024 * 1024
 	defaultFlushContextTimeout            = time.Minute * 1
-	defaultMaxPendingBulkDispatches    int64 = 0 // 0 means no limit
-	defaultMaxConcurrentSecretReads int64 = 0 // 0 means no limit
+	defaultMaxPendingBulkDispatches int64 = 0  // 0 means no limit
+	defaultMaxConcurrentSecretReads int64 = 32
 
 	// dispatchAbortDrainTimeout bounds how long the drain helper waits for
 	// a late response from the Run loop on an abort from the second

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -141,7 +141,6 @@ const (
 	defaultApikeyMaxReqSize               = 100 * 1024 * 1024
 	defaultFlushContextTimeout            = time.Minute * 1
 	defaultMaxPendingBulkDispatches int64 = 0 // 0 means no limit
-	defaultMaxConcurrentSecretReads int64 = 32
 
 	// dispatchAbortDrainTimeout bounds how long the drain helper waits for
 	// a late response from the Run loop on an abort from the second

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -121,6 +121,7 @@ type Bulker struct {
 	blkPool               sync.Pool
 	flushBufPool          sync.Pool
 	apikeyLimit           *semaphore.Weighted
+	readSecretsLimit      *semaphore.Weighted
 	tracer                *apm.Tracer
 	cancelFn              context.CancelFunc
 	pendingBulkDispatches atomic.Int64
@@ -139,7 +140,8 @@ const (
 	defaultAPIKeyMaxParallel              = 32
 	defaultApikeyMaxReqSize               = 100 * 1024 * 1024
 	defaultFlushContextTimeout            = time.Minute * 1
-	defaultMaxPendingBulkDispatches int64 = 0 // 0 means no limit
+	defaultMaxPendingBulkDispatches    int64 = 0 // 0 means no limit
+	defaultMaxConcurrentSecretReads int64 = 0 // 0 means no limit
 
 	// dispatchAbortDrainTimeout bounds how long the drain helper waits for
 	// a late response from the Run loop on an abort from the second
@@ -164,6 +166,12 @@ func NewBulker(es esapi.Transport, tracer *apm.Tracer, opts ...BulkOpt) *Bulker 
 		blkPool:               sync.Pool{New: poolFunc},
 		flushBufPool:          sync.Pool{New: func() any { return new(bytes.Buffer) }},
 		apikeyLimit:           semaphore.NewWeighted(int64(bopts.apikeyMaxParallel)),
+		readSecretsLimit: func() *semaphore.Weighted {
+			if bopts.maxConcurrentSecretReads > 0 {
+				return semaphore.NewWeighted(bopts.maxConcurrentSecretReads)
+			}
+			return nil
+		}(),
 		tracer:                tracer,
 		remoteOutputConfigMap: make(map[string]map[string]any),
 		// remote ES bulkers
@@ -325,6 +333,12 @@ func (b *Bulker) hasChangedAndUpdateRemoteOutputConfig(zlog zerolog.Logger, name
 
 // read secrets one by one as there is no bulk API yet to read them in one request
 func (b *Bulker) ReadSecrets(ctx context.Context, secretIds []string) (map[string]string, error) {
+	if b.readSecretsLimit != nil {
+		if err := b.readSecretsLimit.Acquire(ctx, 1); err != nil {
+			return nil, err
+		}
+		defer b.readSecretsLimit.Release(1)
+	}
 	result := make(map[string]string)
 	esClient := b.Client()
 	for _, id := range secretIds {

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -330,6 +330,7 @@ func (b *Bulker) ReadSecrets(ctx context.Context, secretIds []string) (map[strin
 	result := make(map[string]string)
 	esClient := b.Client()
 	for _, id := range secretIds {
+		// limit concurrent direct ES secret reads, matching apikeyLimit granularity
 		if err := b.readSecretsLimit.Acquire(ctx, 1); err != nil {
 			return nil, err
 		}

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -140,7 +140,7 @@ const (
 	defaultAPIKeyMaxParallel              = 32
 	defaultApikeyMaxReqSize               = 100 * 1024 * 1024
 	defaultFlushContextTimeout            = time.Minute * 1
-	defaultMaxPendingBulkDispatches int64 = 0  // 0 means no limit
+	defaultMaxPendingBulkDispatches int64 = 0 // 0 means no limit
 	defaultMaxConcurrentSecretReads int64 = 32
 
 	// dispatchAbortDrainTimeout bounds how long the drain helper waits for

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -17,12 +17,13 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/elastic/go-ucfg"
+
 	"github.com/elastic/fleet-server/v7/internal/pkg/apikey"
 	"github.com/elastic/fleet-server/v7/internal/pkg/build"
 	"github.com/elastic/fleet-server/v7/internal/pkg/config"
 	"github.com/elastic/fleet-server/v7/internal/pkg/es"
 	"github.com/elastic/fleet-server/v7/internal/pkg/logger/ecs"
-	"github.com/elastic/go-ucfg"
 
 	"github.com/rs/zerolog"
 	"go.elastic.co/apm/v2"
@@ -165,7 +166,7 @@ func NewBulker(es esapi.Transport, tracer *apm.Tracer, opts ...BulkOpt) *Bulker 
 		blkPool:               sync.Pool{New: poolFunc},
 		flushBufPool:          sync.Pool{New: func() any { return new(bytes.Buffer) }},
 		apikeyLimit:           semaphore.NewWeighted(int64(bopts.apikeyMaxParallel)),
-		readSecretsLimit: semaphore.NewWeighted(int64(bopts.maxConcurrentSecretReads)),
+		readSecretsLimit:      semaphore.NewWeighted(int64(bopts.maxConcurrentSecretReads)),
 		tracer:                tracer,
 		remoteOutputConfigMap: make(map[string]map[string]any),
 		// remote ES bulkers

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -217,7 +217,6 @@ func BulkOptsFromCfg(cfg *config.Config) []BulkOpt {
 		WithAPIKeyMaxParallel(maxKeyParallel),
 		WithAPIKeyMaxRequestSize(cfg.Output.Elasticsearch.MaxContentLength),
 		WithMaxPendingBulkDispatches(bulkCfg.MaxPendingBulkDispatches),
-		WithMaxConcurrentSecretReads(bulkCfg.MaxConcurrentSecretReads),
 		WithPolicyTokens(policyTokens),
 	}
 }

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -172,6 +172,7 @@ func parseBulkOpts(opts ...BulkOpt) bulkOptT {
 		blockQueueSz:             defaultBlockQueueSz,
 		apikeyMaxReqSize:         defaultApikeyMaxReqSize,
 		maxPendingBulkDispatches: defaultMaxPendingBulkDispatches,
+		maxConcurrentSecretReads: defaultMaxConcurrentSecretReads,
 		policyTokens:             []config.PolicyToken{}, // default is empty
 	}
 

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -75,7 +75,7 @@ type bulkOptT struct {
 	apikeyMaxParallel        int
 	apikeyMaxReqSize         int
 	maxPendingBulkDispatches int64
-	maxConcurrentSecretReads int64
+	maxConcurrentSecretReads int
 	policyTokens             []config.PolicyToken
 	bi                       build.Info
 }
@@ -127,7 +127,7 @@ func WithMaxPendingBulkDispatches(max int64) BulkOpt {
 
 // WithMaxConcurrentSecretReads sets the upper bound on concurrent ReadSecrets calls.
 // When the limit is reached, ReadSecrets blocks until a slot is available. 0 means no limit.
-func WithMaxConcurrentSecretReads(max int64) BulkOpt {
+func WithMaxConcurrentSecretReads(max int) BulkOpt {
 	return func(opt *bulkOptT) {
 		opt.maxConcurrentSecretReads = max
 	}
@@ -172,7 +172,7 @@ func parseBulkOpts(opts ...BulkOpt) bulkOptT {
 		blockQueueSz:             defaultBlockQueueSz,
 		apikeyMaxReqSize:         defaultApikeyMaxReqSize,
 		maxPendingBulkDispatches: defaultMaxPendingBulkDispatches,
-		maxConcurrentSecretReads: int64(defaultAPIKeyMaxParallel),
+		maxConcurrentSecretReads: defaultAPIKeyMaxParallel,
 		policyTokens:             []config.PolicyToken{}, // default is empty
 	}
 
@@ -192,7 +192,7 @@ func (o *bulkOptT) MarshalZerologObject(e *zerolog.Event) {
 	e.Int("apikeyMaxParallel", o.apikeyMaxParallel)
 	e.Int("apikeyMaxReqSize", o.apikeyMaxReqSize)
 	e.Int64("maxPendingBulkDispatches", o.maxPendingBulkDispatches)
-	e.Int64("maxConcurrentSecretReads", o.maxConcurrentSecretReads)
+	e.Int("maxConcurrentSecretReads", o.maxConcurrentSecretReads)
 }
 
 // BulkOptsFromCfg transforms config to a slize of BulkOpt

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -75,6 +75,7 @@ type bulkOptT struct {
 	apikeyMaxParallel        int
 	apikeyMaxReqSize         int
 	maxPendingBulkDispatches int64
+	maxConcurrentSecretReads int64
 	policyTokens             []config.PolicyToken
 	bi                       build.Info
 }
@@ -121,6 +122,14 @@ func WithBlockQueueSize(sz int) BulkOpt {
 func WithMaxPendingBulkDispatches(max int64) BulkOpt {
 	return func(opt *bulkOptT) {
 		opt.maxPendingBulkDispatches = max
+	}
+}
+
+// WithMaxConcurrentSecretReads sets the upper bound on concurrent ReadSecrets calls.
+// When the limit is reached, ReadSecrets blocks until a slot is available. 0 means no limit.
+func WithMaxConcurrentSecretReads(max int64) BulkOpt {
+	return func(opt *bulkOptT) {
+		opt.maxConcurrentSecretReads = max
 	}
 }
 
@@ -182,6 +191,7 @@ func (o *bulkOptT) MarshalZerologObject(e *zerolog.Event) {
 	e.Int("apikeyMaxParallel", o.apikeyMaxParallel)
 	e.Int("apikeyMaxReqSize", o.apikeyMaxReqSize)
 	e.Int64("maxPendingBulkDispatches", o.maxPendingBulkDispatches)
+	e.Int64("maxConcurrentSecretReads", o.maxConcurrentSecretReads)
 }
 
 // BulkOptsFromCfg transforms config to a slize of BulkOpt
@@ -206,6 +216,7 @@ func BulkOptsFromCfg(cfg *config.Config) []BulkOpt {
 		WithAPIKeyMaxParallel(maxKeyParallel),
 		WithAPIKeyMaxRequestSize(cfg.Output.Elasticsearch.MaxContentLength),
 		WithMaxPendingBulkDispatches(bulkCfg.MaxPendingBulkDispatches),
+		WithMaxConcurrentSecretReads(bulkCfg.MaxConcurrentSecretReads),
 		WithPolicyTokens(policyTokens),
 	}
 }

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -172,7 +172,7 @@ func parseBulkOpts(opts ...BulkOpt) bulkOptT {
 		blockQueueSz:             defaultBlockQueueSz,
 		apikeyMaxReqSize:         defaultApikeyMaxReqSize,
 		maxPendingBulkDispatches: defaultMaxPendingBulkDispatches,
-		maxConcurrentSecretReads: defaultMaxConcurrentSecretReads,
+		maxConcurrentSecretReads: int64(defaultAPIKeyMaxParallel),
 		policyTokens:             []config.PolicyToken{}, // default is empty
 	}
 

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -172,7 +172,7 @@ func parseBulkOpts(opts ...BulkOpt) bulkOptT {
 		blockQueueSz:             defaultBlockQueueSz,
 		apikeyMaxReqSize:         defaultApikeyMaxReqSize,
 		maxPendingBulkDispatches: defaultMaxPendingBulkDispatches,
-		maxConcurrentSecretReads: defaultAPIKeyMaxParallel,
+		maxConcurrentSecretReads: defaultMaxConcurrentSecretReads,
 		policyTokens:             []config.PolicyToken{}, // default is empty
 	}
 

--- a/internal/pkg/bulk/secret_limit_test.go
+++ b/internal/pkg/bulk/secret_limit_test.go
@@ -29,10 +29,12 @@ func (m *blockingTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
 	m.inFlight.Add(1)
 	defer m.inFlight.Add(-1)
 	<-m.gate
+	h := http.Header{}
+	h.Set("X-Elastic-Product", "Elasticsearch")
 	body := `{"value":"test"}`
 	return &http.Response{
 		StatusCode: http.StatusOK,
-		Header:     make(http.Header),
+		Header:     h,
 		Body:       io.NopCloser(strings.NewReader(body)),
 	}, nil
 }

--- a/internal/pkg/bulk/secret_limit_test.go
+++ b/internal/pkg/bulk/secret_limit_test.go
@@ -60,15 +60,12 @@ func TestReadSecretsLimitsConcurrency(t *testing.T) {
 	var wg sync.WaitGroup
 	errs := make([]error, 2)
 
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		_, errs[0] = b.ReadSecrets(t.Context(), []string{"id1"})
-	}()
-	go func() {
-		defer wg.Done()
+	})
+	wg.Go(func() {
 		_, errs[1] = b.ReadSecrets(t.Context(), []string{"id2"})
-	}()
+	})
 
 	require.Eventually(t, func() bool {
 		return mt.inFlight.Load() >= 1

--- a/internal/pkg/bulk/secret_limit_test.go
+++ b/internal/pkg/bulk/secret_limit_test.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/stretchr/testify/require"
@@ -69,10 +70,9 @@ func TestReadSecretsLimitsConcurrency(t *testing.T) {
 		_, errs[1] = b.ReadSecrets(context.Background(), []string{"id2"})
 	}()
 
-	// Spin until at least one request is in the transport.
-	for mt.inFlight.Load() < 1 {
-		// wait for the first goroutine to enter the transport
-	}
+	require.Eventually(t, func() bool {
+		return mt.inFlight.Load() >= 1
+	}, time.Second, time.Millisecond, "wait for the first goroutine to enter the transport")
 
 	// With semaphore capacity 1, the second goroutine is blocked on Acquire
 	// and cannot have entered the transport yet.
@@ -147,10 +147,9 @@ func TestReadSecretsDefaultConcurrency(t *testing.T) {
 		})
 	}
 
-	// Spin until all slots are occupied.
-	for mt.inFlight.Load() < int64(defaultMaxConcurrentSecretReads) {
-		// wait for all goroutines to enter the transport
-	}
+	require.Eventually(t, func() bool {
+		return mt.inFlight.Load() >= int64(defaultMaxConcurrentSecretReads)
+	}, time.Second, time.Millisecond, "wait for all goroutines to enter the transport")
 
 	// The semaphore is now full; a cancelled-context acquire must return immediately.
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/pkg/bulk/secret_limit_test.go
+++ b/internal/pkg/bulk/secret_limit_test.go
@@ -23,7 +23,12 @@ import (
 // and tracks how many requests are currently in-flight.
 type blockingTransport struct {
 	gate     chan struct{}
+	gateOnce sync.Once
 	inFlight atomic.Int64
+}
+
+func (m *blockingTransport) unblock() {
+	m.gateOnce.Do(func() { close(m.gate) })
 }
 
 func (m *blockingTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
@@ -55,6 +60,7 @@ func newTestBulkerWithTransport(t *testing.T, transport http.RoundTripper, opts 
 // ReadSecrets callers.
 func TestReadSecretsLimitsConcurrency(t *testing.T) {
 	mt := &blockingTransport{gate: make(chan struct{})}
+	defer mt.unblock()
 	b := newTestBulkerWithTransport(t, mt, WithMaxConcurrentSecretReads(1))
 
 	var wg sync.WaitGroup
@@ -76,7 +82,7 @@ func TestReadSecretsLimitsConcurrency(t *testing.T) {
 	require.Equal(t, int64(1), mt.inFlight.Load())
 
 	// Unblock both goroutines and wait for them to finish.
-	close(mt.gate)
+	mt.unblock()
 	wg.Wait()
 
 	require.NoError(t, errs[0])
@@ -128,6 +134,7 @@ func TestReadSecretsNoLimitWhenZero(t *testing.T) {
 // returns context.Canceled immediately.
 func TestReadSecretsDefaultConcurrency(t *testing.T) {
 	mt := &blockingTransport{gate: make(chan struct{})}
+	defer mt.unblock()
 
 	// No WithMaxConcurrentSecretReads option → uses defaultMaxConcurrentSecretReads.
 	b := newTestBulkerWithTransport(t, mt)
@@ -155,6 +162,6 @@ func TestReadSecretsDefaultConcurrency(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 
 	// Unblock all goroutines.
-	close(mt.gate)
+	mt.unblock()
 	wg.Wait()
 }

--- a/internal/pkg/bulk/secret_limit_test.go
+++ b/internal/pkg/bulk/secret_limit_test.go
@@ -142,11 +142,9 @@ func TestReadSecretsDefaultConcurrency(t *testing.T) {
 	// slot and block in the transport, filling all capacity.
 	var wg sync.WaitGroup
 	for i := range defaultMaxConcurrentSecretReads {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			_, _ = b.ReadSecrets(context.Background(), []string{fmt.Sprintf("id%d", i)})
-		}()
+		})
 	}
 
 	// Spin until all slots are occupied.

--- a/internal/pkg/bulk/secret_limit_test.go
+++ b/internal/pkg/bulk/secret_limit_test.go
@@ -63,11 +63,11 @@ func TestReadSecretsLimitsConcurrency(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		_, errs[0] = b.ReadSecrets(context.Background(), []string{"id1"})
+		_, errs[0] = b.ReadSecrets(t.Context(), []string{"id1"})
 	}()
 	go func() {
 		defer wg.Done()
-		_, errs[1] = b.ReadSecrets(context.Background(), []string{"id2"})
+		_, errs[1] = b.ReadSecrets(t.Context(), []string{"id2"})
 	}()
 
 	require.Eventually(t, func() bool {
@@ -96,12 +96,12 @@ func TestReadSecretsContextCancelledWhileWaiting(t *testing.T) {
 	b := newTestBulkerWithTransport(t, mt, WithMaxConcurrentSecretReads(1))
 
 	// Manually hold the only semaphore slot so ReadSecrets must wait.
-	err := b.readSecretsLimit.Acquire(context.Background(), 1)
+	err := b.readSecretsLimit.Acquire(t.Context(), 1)
 	require.NoError(t, err)
 	defer b.readSecretsLimit.Release(1)
 
 	// Call ReadSecrets with an already-cancelled context.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	_, err = b.ReadSecrets(ctx, []string{"id1"})
@@ -119,7 +119,7 @@ func TestReadSecretsNoLimitWhenZero(t *testing.T) {
 
 	require.Nil(t, b.readSecretsLimit)
 
-	_, err := b.ReadSecrets(context.Background(), []string{"id1"})
+	_, err := b.ReadSecrets(t.Context(), []string{"id1"})
 	require.NoError(t, err)
 }
 
@@ -143,7 +143,7 @@ func TestReadSecretsDefaultConcurrency(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := range defaultMaxConcurrentSecretReads {
 		wg.Go(func() {
-			_, _ = b.ReadSecrets(context.Background(), []string{fmt.Sprintf("id%d", i)})
+			_, _ = b.ReadSecrets(t.Context(), []string{fmt.Sprintf("id%d", i)})
 		})
 	}
 
@@ -152,7 +152,7 @@ func TestReadSecretsDefaultConcurrency(t *testing.T) {
 	}, time.Second, time.Millisecond, "wait for all goroutines to enter the transport")
 
 	// The semaphore is now full; a cancelled-context acquire must return immediately.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	err := b.readSecretsLimit.Acquire(ctx, 1)
 	require.ErrorIs(t, err, context.Canceled)

--- a/internal/pkg/bulk/secret_limit_test.go
+++ b/internal/pkg/bulk/secret_limit_test.go
@@ -106,25 +106,40 @@ func TestReadSecretsContextCancelledWhileWaiting(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+// TestReadSecretsNoLimitWhenZero verifies that WithMaxConcurrentSecretReads(0)
+// disables the concurrency limit: readSecretsLimit is nil and ReadSecrets
+// completes without blocking.
+func TestReadSecretsNoLimitWhenZero(t *testing.T) {
+	mt := &blockingTransport{gate: make(chan struct{})}
+	close(mt.gate) // unblocked so ReadSecrets returns immediately
+
+	b := newTestBulkerWithTransport(t, mt, WithMaxConcurrentSecretReads(0))
+
+	require.Nil(t, b.readSecretsLimit)
+
+	_, err := b.ReadSecrets(context.Background(), []string{"id1"})
+	require.NoError(t, err)
+}
+
 // TestReadSecretsDefaultConcurrency verifies that a Bulker created without
 // WithMaxConcurrentSecretReads initialises readSecretsLimit with the default
-// capacity of defaultAPIKeyMaxParallel (32). It confirms the capacity
-// indirectly: after filling all 32 slots via concurrent ReadSecrets calls
-// that block in the transport, an additional Acquire with a cancelled context
+// capacity of defaultMaxConcurrentSecretReads (32). It confirms the capacity
+// indirectly: after filling all slots via concurrent ReadSecrets calls that
+// block in the transport, an additional Acquire with a cancelled context
 // returns context.Canceled immediately.
 func TestReadSecretsDefaultConcurrency(t *testing.T) {
 	mt := &blockingTransport{gate: make(chan struct{})}
 
-	// No WithMaxConcurrentSecretReads option → uses defaultAPIKeyMaxParallel.
+	// No WithMaxConcurrentSecretReads option → uses defaultMaxConcurrentSecretReads.
 	b := newTestBulkerWithTransport(t, mt)
 
 	require.NotNil(t, b.readSecretsLimit)
 
-	// Launch defaultAPIKeyMaxParallel goroutines, each calling ReadSecrets with
-	// a single unique secret ID. Each goroutine will acquire one semaphore slot
-	// and block in the transport, filling all capacity.
+	// Launch defaultMaxConcurrentSecretReads goroutines, each calling ReadSecrets
+	// with a single unique secret ID. Each goroutine will acquire one semaphore
+	// slot and block in the transport, filling all capacity.
 	var wg sync.WaitGroup
-	for i := range defaultAPIKeyMaxParallel {
+	for i := range defaultMaxConcurrentSecretReads {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -133,7 +148,7 @@ func TestReadSecretsDefaultConcurrency(t *testing.T) {
 	}
 
 	// Spin until all slots are occupied.
-	for mt.inFlight.Load() < int64(defaultAPIKeyMaxParallel) {
+	for mt.inFlight.Load() < int64(defaultMaxConcurrentSecretReads) {
 		// wait for all goroutines to enter the transport
 	}
 

--- a/internal/pkg/bulk/secret_limit_test.go
+++ b/internal/pkg/bulk/secret_limit_test.go
@@ -1,0 +1,149 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package bulk
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/stretchr/testify/require"
+)
+
+// blockingTransport is an http.RoundTripper that blocks until gate is closed
+// and tracks how many requests are currently in-flight.
+type blockingTransport struct {
+	gate     chan struct{}
+	inFlight atomic.Int64
+}
+
+func (m *blockingTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	m.inFlight.Add(1)
+	defer m.inFlight.Add(-1)
+	<-m.gate
+	body := `{"value":"test"}`
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+func newTestBulkerWithTransport(t *testing.T, transport http.RoundTripper, opts ...BulkOpt) *Bulker {
+	t.Helper()
+	esClient, err := elasticsearch.NewClient(elasticsearch.Config{
+		Transport: transport,
+		Addresses: []string{"http://localhost:9200"},
+	})
+	require.NoError(t, err)
+	return NewBulker(esClient, nil, opts...)
+}
+
+// TestReadSecretsLimitsConcurrency verifies that WithMaxConcurrentSecretReads(1)
+// allows at most one ReadSecret HTTP call in-flight at a time across concurrent
+// ReadSecrets callers.
+func TestReadSecretsLimitsConcurrency(t *testing.T) {
+	mt := &blockingTransport{gate: make(chan struct{})}
+	b := newTestBulkerWithTransport(t, mt, WithMaxConcurrentSecretReads(1))
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, errs[0] = b.ReadSecrets(context.Background(), []string{"id1"})
+	}()
+	go func() {
+		defer wg.Done()
+		_, errs[1] = b.ReadSecrets(context.Background(), []string{"id2"})
+	}()
+
+	// Spin until at least one request is in the transport.
+	for mt.inFlight.Load() < 1 {
+		// wait for the first goroutine to enter the transport
+	}
+
+	// With semaphore capacity 1, the second goroutine is blocked on Acquire
+	// and cannot have entered the transport yet.
+	require.Equal(t, int64(1), mt.inFlight.Load())
+
+	// Unblock both goroutines and wait for them to finish.
+	close(mt.gate)
+	wg.Wait()
+
+	require.NoError(t, errs[0])
+	require.NoError(t, errs[1])
+}
+
+// TestReadSecretsContextCancelledWhileWaiting verifies that ReadSecrets returns
+// context.Canceled immediately when the semaphore is full and the caller's context
+// is already cancelled.
+func TestReadSecretsContextCancelledWhileWaiting(t *testing.T) {
+	mt := &blockingTransport{gate: make(chan struct{})}
+	defer close(mt.gate)
+
+	b := newTestBulkerWithTransport(t, mt, WithMaxConcurrentSecretReads(1))
+
+	// Manually hold the only semaphore slot so ReadSecrets must wait.
+	err := b.readSecretsLimit.Acquire(context.Background(), 1)
+	require.NoError(t, err)
+	defer b.readSecretsLimit.Release(1)
+
+	// Call ReadSecrets with an already-cancelled context.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = b.ReadSecrets(ctx, []string{"id1"})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestReadSecretsDefaultConcurrency verifies that a Bulker created without
+// WithMaxConcurrentSecretReads initialises readSecretsLimit with the default
+// capacity of defaultAPIKeyMaxParallel (32). It confirms the capacity
+// indirectly: after filling all 32 slots via concurrent ReadSecrets calls
+// that block in the transport, an additional Acquire with a cancelled context
+// returns context.Canceled immediately.
+func TestReadSecretsDefaultConcurrency(t *testing.T) {
+	mt := &blockingTransport{gate: make(chan struct{})}
+
+	// No WithMaxConcurrentSecretReads option → uses defaultAPIKeyMaxParallel.
+	b := newTestBulkerWithTransport(t, mt)
+
+	require.NotNil(t, b.readSecretsLimit)
+
+	// Launch defaultAPIKeyMaxParallel goroutines, each calling ReadSecrets with
+	// a single unique secret ID. Each goroutine will acquire one semaphore slot
+	// and block in the transport, filling all capacity.
+	var wg sync.WaitGroup
+	for i := range defaultAPIKeyMaxParallel {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = b.ReadSecrets(context.Background(), []string{fmt.Sprintf("id%d", i)})
+		}()
+	}
+
+	// Spin until all slots are occupied.
+	for mt.inFlight.Load() < int64(defaultAPIKeyMaxParallel) {
+		// wait for all goroutines to enter the transport
+	}
+
+	// The semaphore is now full; a cancelled-context acquire must return immediately.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := b.readSecretsLimit.Acquire(ctx, 1)
+	require.ErrorIs(t, err, context.Canceled)
+
+	// Unblock all goroutines.
+	close(mt.gate)
+	wg.Wait()
+}

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -44,13 +44,16 @@ type ServerTLS struct {
 	Cert string `config:"cert"`
 }
 
+// defaultMaxConcurrentSecretReads matches defaultAPIKeyMaxParallel in the bulk package.
+const defaultMaxConcurrentSecretReads = 32
+
 type ServerBulk struct {
 	FlushInterval            time.Duration `config:"flush_interval"`
 	FlushThresholdCount      int           `config:"flush_threshold_cnt"`
 	FlushThresholdSize       int           `config:"flush_threshold_size"`
 	FlushMaxPending          int           `config:"flush_max_pending"`
 	MaxPendingBulkDispatches int64         `config:"max_pending_bulk_dispatches"`
-	MaxConcurrentSecretReads int64         `config:"max_concurrent_secret_reads"`
+	MaxConcurrentSecretReads int           `config:"max_concurrent_secret_reads"`
 }
 
 func (c *ServerBulk) InitDefaults() {
@@ -58,7 +61,7 @@ func (c *ServerBulk) InitDefaults() {
 	c.FlushThresholdCount = 2048
 	c.FlushThresholdSize = 1024 * 1024
 	c.FlushMaxPending = 8
-	c.MaxConcurrentSecretReads = 32
+	c.MaxConcurrentSecretReads = defaultMaxConcurrentSecretReads
 }
 
 // Server is the configuration for the server

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -58,6 +58,7 @@ func (c *ServerBulk) InitDefaults() {
 	c.FlushThresholdCount = 2048
 	c.FlushThresholdSize = 1024 * 1024
 	c.FlushMaxPending = 8
+	c.MaxConcurrentSecretReads = 32
 }
 
 // Server is the configuration for the server

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -44,7 +44,6 @@ type ServerTLS struct {
 	Cert string `config:"cert"`
 }
 
-// defaultMaxConcurrentSecretReads matches defaultAPIKeyMaxParallel in the bulk package.
 const defaultMaxConcurrentSecretReads = 32
 
 type ServerBulk struct {

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -50,6 +50,7 @@ type ServerBulk struct {
 	FlushThresholdSize       int           `config:"flush_threshold_size"`
 	FlushMaxPending          int           `config:"flush_max_pending"`
 	MaxPendingBulkDispatches int64         `config:"max_pending_bulk_dispatches"`
+	MaxConcurrentSecretReads int64         `config:"max_concurrent_secret_reads"`
 }
 
 func (c *ServerBulk) InitDefaults() {

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -44,15 +44,12 @@ type ServerTLS struct {
 	Cert string `config:"cert"`
 }
 
-const defaultMaxConcurrentSecretReads = 32
-
 type ServerBulk struct {
 	FlushInterval            time.Duration `config:"flush_interval"`
 	FlushThresholdCount      int           `config:"flush_threshold_cnt"`
 	FlushThresholdSize       int           `config:"flush_threshold_size"`
 	FlushMaxPending          int           `config:"flush_max_pending"`
 	MaxPendingBulkDispatches int64         `config:"max_pending_bulk_dispatches"`
-	MaxConcurrentSecretReads int           `config:"max_concurrent_secret_reads"`
 }
 
 func (c *ServerBulk) InitDefaults() {
@@ -60,7 +57,6 @@ func (c *ServerBulk) InitDefaults() {
 	c.FlushThresholdCount = 2048
 	c.FlushThresholdSize = 1024 * 1024
 	c.FlushMaxPending = 8
-	c.MaxConcurrentSecretReads = defaultMaxConcurrentSecretReads
 }
 
 // Server is the configuration for the server


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

`ReadSecrets` makes direct HTTP calls to the ES Fleet secrets API (one per secret reference per agent checkin) without going through the bulk dispatch queue. This means it is **not subject to the `max_pending_bulk_dispatches` cap** introduced in #6751. Under high concurrent checkin load — as seen in large serverless projects — each checkin goroutine issues an independent ES connection, causing unbounded concurrent ES connections and additional memory pressure (goroutines, HTTP buffers, response allocations).

This was observed as a contributing factor in an OOM incident for a large production serverless security project. PR #7416 added the `ReadSecrets` per-checkin call ~24h before OOMs began.

## How does this PR solve the problem?

Adds a `semaphore.Weighted` (`readSecretsLimit`) to `Bulker`, capping concurrent in-flight secret reads at 32 (matching `apikeyLimit`). `ReadSecrets` acquires a slot before each ES call and releases it immediately after — callers that arrive when all slots are taken block until one is free or their context is cancelled. Setting `readSecretsLimit` to `nil` (by passing `WithMaxConcurrentSecretReads(0)`) disables the cap entirely; the default is always 32.

The limit is intentionally not exposed as a user-facing config option, consistent with how `apikeyMaxParallel` is handled.

## Files changed

- `internal/pkg/bulk/engine.go`: add `readSecretsLimit *semaphore.Weighted` to `Bulker`; initialize in `NewBulker` when limit > 0; nil-check acquire/release in `ReadSecrets`; add `defaultMaxConcurrentSecretReads = 32`
- `internal/pkg/bulk/opt.go`: add `maxConcurrentSecretReads` field, `WithMaxConcurrentSecretReads` BulkOpt, zerolog logging
- `internal/pkg/bulk/secret_limit_test.go`: unit tests covering the concurrency limit, context cancellation while waiting, zero-value (no limit), and default capacity

## How to test this PR locally

```
go test -v -count=1 -run=TestReadSecrets ./internal/pkg/bulk
```

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Relates elastic/ingest-dev#8991
- Relates #7416
- Relates #6751