### PR TITLE
fix: size ristretto cache from GOMEMLIMIT instead of host RAM

### DIFF
--- a/changelog/fragments/1786038287-fix-cache-container-memory.yaml
+++ b/changelog/fragments/1786038287-fix-cache-container-memory.yaml
@@ -1,0 +1,13 @@
+kind: bug-fix
+
+summary: Fix ristretto cache sized from host RAM instead of container memory limit
+
+description: >
+  memEnvLimits() called memory.TotalMemory() to select the ristretto cache tier.
+  On a Kubernetes node with >=16 GB of RAM this picked a MaxCost of 256-512 MB --
+  2-4x the pod's GOMEMLIMIT -- causing OOMKills even at modest agent counts.
+  The fix reads GOMEMLIMIT via debug.SetMemoryLimit(-1) and uses that value to
+  select the cache tier, falling back to memory.TotalMemory() only when GOMEMLIMIT
+  is unset (non-containerised deployments).
+
+component: fleet-server

--- a/internal/pkg/config/env_defaults.go
+++ b/internal/pkg/config/env_defaults.go
@@ -312,9 +312,9 @@ func loadLimits(log *zerolog.Logger, agentLimit int) *envLimits {
 		// get nearest limits for configured agent numbers
 		if l.Agents.Min <= agentLimit && agentLimit <= l.Agents.Max {
 			log.Info().Msgf("Using system limits for %d to %d agents for a configured value of %d agents", l.Agents.Min, l.Agents.Max, agentLimit)
-			ramSize := memory.TotalMemory() / 1024 / 1024
+			ramSize := memMB()
 			if ramSize < l.RecommendedRAM {
-				log.Warn().Msgf("Detected %d MB of system RAM, which is lower than the recommended amount (%d MB) for the configured agent limit", ramSize, l.RecommendedRAM)
+				log.Warn().Msgf("Detected %d MB of available memory, which is lower than the recommended amount (%d MB) for the configured agent limit", ramSize, l.RecommendedRAM)
 			}
 			return l
 		}

--- a/internal/pkg/config/env_defaults.go
+++ b/internal/pkg/config/env_defaults.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"math"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -322,11 +323,20 @@ func loadLimits(log *zerolog.Logger, agentLimit int) *envLimits {
 	return defaultEnvLimits()
 }
 
-// memMB returns the system total memory in MB
-// It wraps memory.TotalMemory() so that we can replace the var in unit tests.
-var memMB func() uint64 = func() uint64 {
+// containerMemoryMB returns available memory in MiB, preferring the GOMEMLIMIT
+// runtime setting over host RAM so the ristretto cache is sized for the container,
+// not the node. Falls back to memory.TotalMemory() when GOMEMLIMIT is unset.
+func containerMemoryMB() uint64 {
+	limit := debug.SetMemoryLimit(-1)
+	if limit > 0 && limit != math.MaxInt64 {
+		return uint64(limit) / 1024 / 1024
+	}
 	return memory.TotalMemory() / 1024 / 1024
 }
+
+// memMB returns available memory in MiB.
+// It is a var so that unit tests can replace it.
+var memMB func() uint64 = containerMemoryMB
 
 func memEnvLimits(log *zerolog.Logger) *envLimits {
 	mem := memMB()

--- a/internal/pkg/config/env_defaults_test.go
+++ b/internal/pkg/config/env_defaults_test.go
@@ -7,11 +7,14 @@ package config
 import (
 	"io"
 	"io/fs"
+	"math"
 	"reflect"
+	"runtime/debug"
 	"strings"
 	"testing"
 
 	testlog "github.com/elastic/fleet-server/v7/internal/pkg/testing/log"
+	"github.com/pbnjay/memory"
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
@@ -85,4 +88,25 @@ func TestDefaultLimitsYAMLKeys(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
+}
+
+// TestContainerMemoryMB verifies that containerMemoryMB prefers GOMEMLIMIT over
+// host RAM so the ristretto cache is sized for the container, not the node.
+func TestContainerMemoryMB(t *testing.T) {
+	t.Run("uses GOMEMLIMIT when set", func(t *testing.T) {
+		const setLimit = int64(256 * 1024 * 1024) // 256 MiB
+		prev := debug.SetMemoryLimit(setLimit)
+		t.Cleanup(func() { debug.SetMemoryLimit(prev) })
+
+		got := containerMemoryMB()
+		assert.Equal(t, uint64(256), got)
+	})
+
+	t.Run("falls back to host RAM when GOMEMLIMIT is unset", func(t *testing.T) {
+		prev := debug.SetMemoryLimit(math.MaxInt64)
+		t.Cleanup(func() { debug.SetMemoryLimit(prev) })
+
+		got := containerMemoryMB()
+		assert.Equal(t, memory.TotalMemory()/1024/1024, got)
+	})
 }


### PR DESCRIPTION
<!-- Type of change: Bug -->

## What is the problem this PR solves?

`memEnvLimits()` in `internal/pkg/config/env_defaults.go` calls `memory.TotalMemory()` to select the ristretto cache tier. `memory.TotalMemory()` returns the **host node's total physical RAM**, not the container's cgroup memory limit. On a Kubernetes node with ≥16 GB of RAM, this selects a `MaxCost` of 256–512 MB — 2–4× the pod's GOMEMLIMIT (128 MB at the 256 M default pod limit). The cache is allowed to grow past the GOMEMLIMIT, triggering OOMKills even when live application heap is within budget.

This was the primary driver of the OOMKills observed for a high-volume serverless project in [elastic/ingest-dev#8991](https://github.com/elastic/ingest-dev/issues/8991).

## How does this PR solve the problem?

Introduces `containerMemoryMB()`, which reads the current GOMEMLIMIT via `debug.SetMemoryLimit(-1)` and converts it to MiB. When GOMEMLIMIT is set (i.e. ≠ `math.MaxInt64`), that value drives cache tier selection — so a pod with a 256 M limit and GOMEMLIMIT = 128 M will select a cache sized for 128 MB of available memory, not 16+ GB of node RAM.

When GOMEMLIMIT is unset (`math.MaxInt64`), the function falls back to `memory.TotalMemory()`, preserving the existing behaviour for non-containerised deployments.

`memMB` remains a `var` pointing to `containerMemoryMB`, so existing tests that stub `memMB` are unaffected.

## How to test this PR locally

Run the config package tests:

```
go test ./internal/pkg/config/... -run TestContainerMemoryMB -v
```

`TestContainerMemoryMB` covers both the GOMEMLIMIT path (sets a 256 MiB limit and asserts the function returns 256) and the fallback path (clears the limit and asserts the function returns host RAM in MiB).

To verify the end-to-end effect: start fleet-server with `GOMEMLIMIT=128MiB` (or via `server.runtime.memory_limit`) and observe that the logged `recommended_mb` value is ≤ 128, not 256–512.

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [x] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Closes elastic/ingest-dev#8991