### PR TITLE
fix: gracefully handle missing secrets in policy monitor

### DIFF
--- a/changelog/fragments/1786053515-graceful-missing-secrets.yaml
+++ b/changelog/fragments/1786053515-graceful-missing-secrets.yaml
@@ -1,0 +1,20 @@
+kind: bug-fix
+
+summary: Gracefully handle missing secrets in policy monitor instead of crash-looping
+
+description: |
+  Fleet Server no longer crash-loops when a secret referenced in an agent
+  policy's `secret_references` cannot be found in the Fleet secrets store.
+  Previously, any 404 from `GET /_fleet/secret/{id}` was treated as a fatal
+  error, causing the entire policy monitor to abort and fleet-server to
+  restart indefinitely — taking all agents offline.
+
+  Now, a missing secret is logged as a warning and skipped. The policy loads
+  without that secret value; affected integration credentials will not be
+  substituted (the raw `$co.elastic.secret{id}` placeholder remains), causing
+  only that integration to degrade, while fleet-server itself continues
+  serving all other agents normally.
+
+component: fleet-server
+
+pr: https://github.com/elastic/fleet-server/pull/7566

--- a/changelog/fragments/1786053515-graceful-missing-secrets.yaml
+++ b/changelog/fragments/1786053515-graceful-missing-secrets.yaml
@@ -17,4 +17,4 @@ description: |
 
 component: fleet-server
 
-pr: https://github.com/elastic/fleet-server/pull/7566
+pr: https://github.com/elastic/fleet-server/pull/7571

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -330,6 +330,10 @@ func (b *Bulker) ReadSecrets(ctx context.Context, secretIds []string) (map[strin
 	for _, id := range secretIds {
 		val, err := ReadSecret(ctx, esClient, id)
 		if err != nil {
+			if errors.Is(err, ErrSecretNotFound) {
+				zerolog.Ctx(ctx).Warn().Str("secret_id", id).Msg("secret not found; policy will load without it")
+				continue
+			}
 			return nil, err
 		}
 		result[id] = val

--- a/internal/pkg/bulk/secret.go
+++ b/internal/pkg/bulk/secret.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,9 @@ import (
 	"github.com/elastic/go-elasticsearch/v8"
 	"go.elastic.co/apm/v2"
 )
+
+// ErrSecretNotFound is returned when a secret document does not exist in the Fleet secrets store.
+var ErrSecretNotFound = errors.New("secret not found")
 
 type ExtendedClient struct {
 	*elasticsearch.Client
@@ -40,6 +44,9 @@ func (c *ExtendedAPI) Read(ctx context.Context, secretID string) (*SecretRespons
 		return nil, err
 	}
 	defer res.Body.Close()
+	if res.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("%q: %w", secretID, ErrSecretNotFound)
+	}
 	if res.StatusCode >= 400 {
 		body, _ := io.ReadAll(res.Body)
 		return nil, fmt.Errorf("unexpected status %d from fleet secret read: %s", res.StatusCode, body)

--- a/internal/pkg/bulk/secret_test.go
+++ b/internal/pkg/bulk/secret_test.go
@@ -1,0 +1,63 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package bulk
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newExtendedAPIWithStatus(t *testing.T, status int, body string) *ExtendedAPI {
+	t.Helper()
+	cli, err := elasticsearch.NewClient(elasticsearch.Config{
+		Addresses: []string{"http://localhost:9200"},
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			h := make(http.Header)
+			h.Set("X-Elastic-Product", "Elasticsearch")
+			return &http.Response{
+				StatusCode: status,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     h,
+			}, nil
+		}),
+	})
+	require.NoError(t, err)
+	return &ExtendedAPI{Client: cli}
+}
+
+func TestExtendedAPIRead_NotFound_ReturnsSentinel(t *testing.T) {
+	api := newExtendedAPIWithStatus(t, http.StatusNotFound, `{"error":{"reason":"No secret with id [abc]"}}`)
+	_, err := api.Read(t.Context(), "abc")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSecretNotFound), "expected ErrSecretNotFound, got: %v", err)
+}
+
+func TestExtendedAPIRead_ServerError_ReturnsGenericError(t *testing.T) {
+	api := newExtendedAPIWithStatus(t, http.StatusInternalServerError, `{"error":"internal"}`)
+	_, err := api.Read(t.Context(), "abc")
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrSecretNotFound))
+}
+
+func TestExtendedAPIRead_Success(t *testing.T) {
+	api := newExtendedAPIWithStatus(t, http.StatusOK, `{"value":"my-secret-value"}`)
+	resp, err := api.Read(t.Context(), "abc")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "my-secret-value", resp.Value)
+}


### PR DESCRIPTION
<!-- Type of change: Bug -->

## What is the problem this PR solves?

Fleet Server crash-loops when any secret referenced in an agent policy's `secret_references` cannot be found in the Fleet secrets store. A single missing secret — from a deleted or orphaned integration credential — causes the entire policy monitor to abort with:

```
Error: failed to get secret values: unexpected status 404 from fleet secret read: ...
Fleet Server failed
```

Fleet Server then restarts, re-reads the same stale policy document from the policy monitor (the checkpoint hasn't advanced), encounters the same 404, and crashes again — indefinitely. Every agent on that fleet-server instance goes offline for the duration.

This is a disproportionate blast radius: one deleted integration credential (unrelated to fleet-server's own connectivity) can take the entire Fleet Server offline.

The root causes that produce missing secrets are tracked in Kibana (elastic/kibana#282911 and elastic/kibana#282912) and in fleet-server (#7533, #7534). This PR is a **defense-in-depth fix**: even after those root causes are resolved, fleet-server should not treat a single missing package-policy credential as a reason to crash-loop and take all agents offline.

## How does this PR solve the problem?

Two changes:

1. **`bulk/secret.go` — `ExtendedAPI.Read`**: Returns a typed `ErrSecretNotFound` sentinel when the Fleet secrets API responds with 404. This lets callers distinguish "this secret document doesn't exist" from network/auth failures (403, 500, etc.), which should still be fatal.

2. **`bulk/engine.go` — `ReadSecrets`**: When `ReadSecret` returns `ErrSecretNotFound`, logs a warning with the secret ID and skips it (continues the loop) rather than aborting. The returned map contains only the secrets that were successfully fetched.

With this change, a missing secret causes the policy to load without that secret value — the raw `$co.elastic.secret{id}` placeholder remains unsubstituted in the affected integration's config. That integration's credentials won't resolve (it will fail to authenticate), but fleet-server itself stays up and continues serving all other agents.

Callers that need hard failure for missing secrets (e.g. output API key resolution, where an empty key would silently break agent→ES connectivity) can check whether the expected ID is present in the returned map — as the second commit in #7416 already does.

## How to test this PR locally

1. Start a local stack with fleet-server
2. Create an integration that uses secrets (e.g. any OAuth-based integration)
3. Directly delete the secret document from Elasticsearch: `DELETE /_fleet/secret/<id>`
4. Restart fleet-server and observe that it:
   - Logs `WARN secret not found; policy will load without it secret_id=<id>`
   - Continues to start successfully
   - Serves other agents normally
5. Verify (via agent diagnostics) that the affected integration's credential field contains the raw `$co.elastic.secret{id}` placeholder rather than the secret value

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer. (Each instance evaluates `ReadSecrets` independently per policy load; skipping is per-request with no shared state.)
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected. (The change reduces work on failure — skipping a secret is cheaper than returning an error — so scale impact is neutral or positive.)
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc. (No new load introduced; 404s are now fast-path skips.)

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Closes #7536
- Root cause (how secrets become dangling in the first place):
  - elastic/kibana#282911 — `agentPolicyService.delete()` can leave orphaned `.fleet-policies` documents when the cleanup call after package-policy deletion fails silently
  - elastic/kibana#282912 — `deleteSecretsIfNotReferenced` only checks live package-policy saved objects, not `.fleet-policies`, so secrets are deleted even when an orphaned policy document still references them
- Mitigation for the agent-update-failure source of dangling secrets: #7533, #7534
- Context: the `>= 400` check in `ExtendedAPI.Read` was introduced in #7416. That PR's own second commit described the *original* tolerant design — `ReadSecrets` was not expected to fail on a missing secret; hard failure for the output API key was added at the caller level. This PR restores that layered design by making 404 non-fatal in `ReadSecrets` while preserving fatal behavior for other 4xx/5xx responses.