### PR TITLE
fix: add revision guard to updatePolicy to reject stale policy revisions

### DIFF
--- a/changelog/fragments/1786053515-revision-guard-policy-monitor.yaml
+++ b/changelog/fragments/1786053515-revision-guard-policy-monitor.yaml
@@ -1,0 +1,15 @@
+kind: bug-fix
+
+summary: Reject stale policy revisions before secret resolution in the policy monitor
+
+description: |
+  After a Kibana index migration, the `.fleet-policies` change-feed can deliver
+  older revision documents (with higher _seq_no values) after the policy monitor
+  has already cached a newer revision. Fleet Server now checks the incoming
+  revision_idx against the cached revision before attempting to parse the policy
+  or resolve its secrets. Stale revisions are dropped with a warning log and do
+  not overwrite the cached policy.
+
+component: fleet-server
+
+pr: https://github.com/elastic/fleet-server/pull/7572

--- a/internal/pkg/policy/monitor.go
+++ b/internal/pkg/policy/monitor.go
@@ -451,16 +451,6 @@ func (m *monitorT) updatePolicy(ctx context.Context, pp *ParsedPolicy) bool {
 		return false
 	}
 
-	// Secondary stale-revision guard (primary check is in processPolicies before parsing).
-	// Rejects any revision whose revision_idx is not newer than the cached revision,
-	// guarding against races or direct callers that bypass the pre-parse check.
-	if newPolicy.RevisionIdx <= p.pp.Policy.RevisionIdx {
-		zlog.Warn().
-			Int64("cached_revision_idx", p.pp.Policy.RevisionIdx).
-			Msg("ignoring stale policy revision from policy monitor")
-		return false
-	}
-
 	// Cache the old stored policy for logging
 	oldPolicy := p.pp.Policy
 

--- a/internal/pkg/policy/monitor.go
+++ b/internal/pkg/policy/monitor.go
@@ -434,6 +434,17 @@ func (m *monitorT) updatePolicy(ctx context.Context, pp *ParsedPolicy) bool {
 		return false
 	}
 
+	// Reject stale revisions — the change-feed can deliver old documents (e.g. after a
+	// Kibana index migration that assigns higher _seq_no values to older revisions) after
+	// a newer revision has already been cached. Without this guard, an old revision with
+	// dangling secrets would overwrite the good cache entry and crash-loop fleet-server.
+	if newPolicy.RevisionIdx <= p.pp.Policy.RevisionIdx {
+		zlog.Warn().
+			Int64("cached_revision_idx", p.pp.Policy.RevisionIdx).
+			Msg("ignoring stale policy revision from change-feed")
+		return false
+	}
+
 	// Cache the old stored policy for logging
 	oldPolicy := p.pp.Policy
 

--- a/internal/pkg/policy/monitor.go
+++ b/internal/pkg/policy/monitor.go
@@ -378,6 +378,13 @@ func (m *monitorT) processPolicies(ctx context.Context, policies []model.Policy)
 
 	latest := m.groupByLatest(policies)
 	for _, policy := range latest {
+		if m.isStaleRevision(policy.PolicyID, policy.RevisionIdx) {
+			m.log.Warn().
+				Str(ecs.PolicyID, policy.PolicyID).
+				Int64(ecs.RevisionIdx, policy.RevisionIdx).
+				Msg("skipping stale policy revision; secret resolution and policy parse skipped")
+			continue
+		}
 		pp, err := NewParsedPolicy(ctx, m.bulker, policy)
 		if err != nil {
 			return err
@@ -386,6 +393,16 @@ func (m *monitorT) processPolicies(ctx context.Context, policies []model.Policy)
 		m.updatePolicy(ctx, pp)
 	}
 	return nil
+}
+
+// isStaleRevision reports whether the incoming revision_idx is not newer than
+// the cached revision for the given policy. Returns false for unknown policies
+// (first-seen policies must be processed regardless).
+func (m *monitorT) isStaleRevision(policyID string, revisionIdx int64) bool {
+	m.mut.Lock()
+	defer m.mut.Unlock()
+	p, ok := m.policies[policyID]
+	return ok && revisionIdx <= p.pp.Policy.RevisionIdx
 }
 
 func groupByLatest(policies []model.Policy) map[string]model.Policy {
@@ -434,11 +451,9 @@ func (m *monitorT) updatePolicy(ctx context.Context, pp *ParsedPolicy) bool {
 		return false
 	}
 
-	// Reject stale revisions — the policy monitor can deliver old documents (e.g. after a
-	// Kibana index migration assigns higher _seq_no values to older revisions) in a later
-	// batch than the clean revision. Applying a stale revision would push an outdated
-	// policy to all subscribed agents; inputs referencing deleted secrets would also fail
-	// to authenticate.
+	// Secondary stale-revision guard (primary check is in processPolicies before parsing).
+	// Rejects any revision whose revision_idx is not newer than the cached revision,
+	// guarding against races or direct callers that bypass the pre-parse check.
 	if newPolicy.RevisionIdx <= p.pp.Policy.RevisionIdx {
 		zlog.Warn().
 			Int64("cached_revision_idx", p.pp.Policy.RevisionIdx).

--- a/internal/pkg/policy/monitor.go
+++ b/internal/pkg/policy/monitor.go
@@ -434,14 +434,14 @@ func (m *monitorT) updatePolicy(ctx context.Context, pp *ParsedPolicy) bool {
 		return false
 	}
 
-	// Reject stale revisions — the change-feed can deliver old documents (e.g. after a
+	// Reject stale revisions — the policy monitor can deliver old documents (e.g. after a
 	// Kibana index migration that assigns higher _seq_no values to older revisions) after
 	// a newer revision has already been cached. Without this guard, an old revision with
 	// dangling secrets would overwrite the good cache entry and crash-loop fleet-server.
 	if newPolicy.RevisionIdx <= p.pp.Policy.RevisionIdx {
 		zlog.Warn().
 			Int64("cached_revision_idx", p.pp.Policy.RevisionIdx).
-			Msg("ignoring stale policy revision from change-feed")
+			Msg("ignoring stale policy revision from policy monitor")
 		return false
 	}
 

--- a/internal/pkg/policy/monitor.go
+++ b/internal/pkg/policy/monitor.go
@@ -435,9 +435,10 @@ func (m *monitorT) updatePolicy(ctx context.Context, pp *ParsedPolicy) bool {
 	}
 
 	// Reject stale revisions — the policy monitor can deliver old documents (e.g. after a
-	// Kibana index migration that assigns higher _seq_no values to older revisions) after
-	// a newer revision has already been cached. Without this guard, an old revision with
-	// dangling secrets would overwrite the good cache entry and crash-loop fleet-server.
+	// Kibana index migration assigns higher _seq_no values to older revisions) in a later
+	// batch than the clean revision. Applying a stale revision would push an outdated
+	// policy to all subscribed agents; inputs referencing deleted secrets would also fail
+	// to authenticate.
 	if newPolicy.RevisionIdx <= p.pp.Policy.RevisionIdx {
 		zlog.Warn().
 			Int64("cached_revision_idx", p.pp.Policy.RevisionIdx).

--- a/internal/pkg/policy/monitor_test.go
+++ b/internal/pkg/policy/monitor_test.go
@@ -668,3 +668,57 @@ func TestMonitor_StaleRevisionIgnored(t *testing.T) {
 		assert.Equal(t, int64(9), pm.policies[policyID].pp.Policy.RevisionIdx, "cached revision must be updated")
 	})
 }
+
+// failingSecretsBulk wraps MockBulk and makes ReadSecrets return an error,
+// letting tests verify that secret resolution is never attempted for stale revisions.
+type failingSecretsBulk struct {
+	ftesting.MockBulk
+}
+
+func (b *failingSecretsBulk) ReadSecrets(_ context.Context, _ []string) (map[string]string, error) {
+	return nil, fmt.Errorf("ReadSecrets must not be called for stale revisions")
+}
+
+// TestMonitor_StaleRevisionSkipsSecretResolution verifies that processPolicies
+// skips NewParsedPolicy (and therefore secret resolution) for stale revisions.
+// Without the pre-parse guard a stale doc with deleted secrets would fail during
+// secret resolution and cause processPolicies to return an error.
+func TestMonitor_StaleRevisionSkipsSecretResolution(t *testing.T) {
+	ctx := testlog.SetLogger(t).WithContext(t.Context())
+	policyID := uuid.Must(uuid.NewV4()).String()
+
+	// A policy with a secret reference so that NewParsedPolicy calls ReadSecrets.
+	policyWithSecret := model.Policy{
+		PolicyID:    policyID,
+		RevisionIdx: 7, // stale: cached is 8
+		Data: &model.PolicyData{
+			Outputs: map[string]map[string]any{
+				"default": {"type": "elasticsearch"},
+			},
+			SecretReferences: []model.SecretReferencesItems{{ID: "some-secret-id"}},
+		},
+	}
+
+	bulker := &failingSecretsBulk{}
+	pm := &monitorT{
+		log:    zerolog.Ctx(ctx).With().Logger(),
+		bulker: bulker,
+		policies: map[string]policyT{
+			policyID: {
+				pp: ParsedPolicy{
+					Policy: model.Policy{
+						PolicyID:    policyID,
+						RevisionIdx: 8,
+						Data:        policyDataDefault,
+					},
+				},
+				head: makeHead(),
+			},
+		},
+		pendingQ: makeHead(),
+	}
+
+	err := pm.processPolicies(ctx, []model.Policy{policyWithSecret})
+	assert.NoError(t, err, "stale revision should be skipped without error, not trigger secret resolution")
+	assert.Equal(t, int64(8), pm.policies[policyID].pp.Policy.RevisionIdx, "cached revision must not change for stale input")
+}

--- a/internal/pkg/policy/monitor_test.go
+++ b/internal/pkg/policy/monitor_test.go
@@ -619,7 +619,7 @@ func TestMonitor_LatestRev(t *testing.T) {
 
 // TestMonitor_StaleRevisionIgnored verifies that updatePolicy rejects an incoming
 // document whose revision_idx is not greater than the cached revision. This guards
-// against the change-feed delivering old revisions (e.g. after a Kibana index
+// against the policy monitor delivering old revisions (e.g. after a Kibana index
 // migration assigns higher _seq_no values to older documents) and overwriting a
 // clean cached policy with one that may reference deleted secrets.
 func TestMonitor_StaleRevisionIgnored(t *testing.T) {

--- a/internal/pkg/policy/monitor_test.go
+++ b/internal/pkg/policy/monitor_test.go
@@ -617,12 +617,10 @@ func TestMonitor_LatestRev(t *testing.T) {
 	})
 }
 
-// TestMonitor_StaleRevisionIgnored verifies that updatePolicy rejects an incoming
-// document whose revision_idx is not greater than the cached revision. This guards
-// against the policy monitor delivering old revisions (e.g. after a Kibana index
-// migration assigns higher _seq_no values to older documents) and overwriting a
-// clean cached policy with one that may reference deleted secrets.
-func TestMonitor_StaleRevisionIgnored(t *testing.T) {
+// TestUpdatePolicy_NewerRevisionIsApplied verifies that updatePolicy stores an
+// incoming document and returns true when its revision_idx is greater than the
+// cached revision.
+func TestUpdatePolicy_NewerRevisionIsApplied(t *testing.T) {
 	ctx := testlog.SetLogger(t).WithContext(t.Context())
 	policyID := uuid.Must(uuid.NewV4()).String()
 
@@ -647,26 +645,10 @@ func TestMonitor_StaleRevisionIgnored(t *testing.T) {
 		pendingQ: makeHead(),
 	}
 
-	t.Run("equal revision is ignored", func(t *testing.T) {
-		stale := makePolicy(8)
-		updated := pm.updatePolicy(ctx, &stale)
-		assert.False(t, updated, "expected updatePolicy to return false for equal revision")
-		assert.Equal(t, int64(8), pm.policies[policyID].pp.Policy.RevisionIdx, "cached revision must not change")
-	})
-
-	t.Run("older revision is ignored", func(t *testing.T) {
-		stale := makePolicy(7)
-		updated := pm.updatePolicy(ctx, &stale)
-		assert.False(t, updated, "expected updatePolicy to return false for older revision")
-		assert.Equal(t, int64(8), pm.policies[policyID].pp.Policy.RevisionIdx, "cached revision must not change")
-	})
-
-	t.Run("newer revision is applied", func(t *testing.T) {
-		fresh := makePolicy(9)
-		updated := pm.updatePolicy(ctx, &fresh)
-		assert.True(t, updated, "expected updatePolicy to return true for newer revision")
-		assert.Equal(t, int64(9), pm.policies[policyID].pp.Policy.RevisionIdx, "cached revision must be updated")
-	})
+	fresh := makePolicy(9)
+	updated := pm.updatePolicy(ctx, &fresh)
+	assert.True(t, updated, "expected updatePolicy to return true for newer revision")
+	assert.Equal(t, int64(9), pm.policies[policyID].pp.Policy.RevisionIdx, "cached revision must be updated")
 }
 
 // failingSecretsBulk wraps MockBulk and makes ReadSecrets return an error,

--- a/internal/pkg/policy/monitor_test.go
+++ b/internal/pkg/policy/monitor_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gofrs/uuid/v5"
 	"github.com/google/go-cmp/cmp"
 	"github.com/rs/xid"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -613,5 +614,57 @@ func TestMonitor_LatestRev(t *testing.T) {
 		}
 		idx := pm.LatestRev(t.Context(), "test-id")
 		assert.Equal(t, int64(1), idx)
+	})
+}
+
+// TestMonitor_StaleRevisionIgnored verifies that updatePolicy rejects an incoming
+// document whose revision_idx is not greater than the cached revision. This guards
+// against the change-feed delivering old revisions (e.g. after a Kibana index
+// migration assigns higher _seq_no values to older documents) and overwriting a
+// clean cached policy with one that may reference deleted secrets.
+func TestMonitor_StaleRevisionIgnored(t *testing.T) {
+	ctx := testlog.SetLogger(t).WithContext(t.Context())
+	policyID := uuid.Must(uuid.NewV4()).String()
+
+	makePolicy := func(rev int64) ParsedPolicy {
+		return ParsedPolicy{
+			Policy: model.Policy{
+				PolicyID:    policyID,
+				RevisionIdx: rev,
+				Data:        policyDataDefault,
+			},
+		}
+	}
+
+	pm := &monitorT{
+		log: zerolog.Ctx(ctx).With().Logger(),
+		policies: map[string]policyT{
+			policyID: {
+				pp:   makePolicy(8),
+				head: makeHead(),
+			},
+		},
+		pendingQ: makeHead(),
+	}
+
+	t.Run("equal revision is ignored", func(t *testing.T) {
+		stale := makePolicy(8)
+		updated := pm.updatePolicy(ctx, &stale)
+		assert.False(t, updated, "expected updatePolicy to return false for equal revision")
+		assert.Equal(t, int64(8), pm.policies[policyID].pp.Policy.RevisionIdx, "cached revision must not change")
+	})
+
+	t.Run("older revision is ignored", func(t *testing.T) {
+		stale := makePolicy(7)
+		updated := pm.updatePolicy(ctx, &stale)
+		assert.False(t, updated, "expected updatePolicy to return false for older revision")
+		assert.Equal(t, int64(8), pm.policies[policyID].pp.Policy.RevisionIdx, "cached revision must not change")
+	})
+
+	t.Run("newer revision is applied", func(t *testing.T) {
+		fresh := makePolicy(9)
+		updated := pm.updatePolicy(ctx, &fresh)
+		assert.True(t, updated, "expected updatePolicy to return true for newer revision")
+		assert.Equal(t, int64(9), pm.policies[policyID].pp.Policy.RevisionIdx, "cached revision must be updated")
 	})
 }


### PR DESCRIPTION
## Summary

- `updatePolicy()` in `internal/pkg/policy/monitor.go` unconditionally overwrote the in-memory policy cache with any document the policy monitor delivered, regardless of its `revision_idx`.
- After a Kibana index migration (e.g. 8.9→9.3→9.5→9.6), older revision documents can be reindexed with a higher `_seq_no` than the latest revision. The policy monitor then delivers the stale revision in a later batch (after `groupByLatest()` has already passed the clean revision through), overwriting the cache.
- If the stale revision references deleted secrets, `NewParsedPolicy` fails and fleet-server crash-loops indefinitely (the checkpoint never advances past the stale doc).
- This adds a strict `revision_idx` guard: incoming documents whose `revision_idx` is not greater than the cached revision are rejected with a warning log. Unit tests cover the equal, older, and newer revision cases.

## References

Closes #7570
Related: #7536 (missing-secrets crash that this guard also mitigates)