### PR TITLE
docs: update Testing on cloud section to use mage targets

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -413,7 +413,7 @@ SNAPSHOT=true PLATFORMS=linux/amd64 \
 EC_API_KEY=yourapikey mage test:cloudE2EDown
 ```
 
-`SNAPSHOT=true` and `PLATFORMS=linux/amd64` build the required snapshot binary. The registry is shared, so choose a globally unique `DOCKER_IMAGE_TAG`; keeping the same `DOCKER_IMAGE` and tag in the shell session ensures that `docker:customAgentImage`, `docker:push`, `test:cloudE2EUp`, and `test:cloudE2EDown` all refer to the same image.
+Run this workflow from an `amd64` host: `docker:customAgentImage` creates an image for the host architecture, while ECH runs on `linux/amd64`. `SNAPSHOT=true` and `PLATFORMS=linux/amd64` build the required snapshot binary. The registry is shared, so choose a globally unique `DOCKER_IMAGE_TAG`; keeping the same `DOCKER_IMAGE` and tag in the shell session ensures that `docker:customAgentImage`, `docker:push`, `test:cloudE2EUp`, and `test:cloudE2EDown` all refer to the same image.
 
 These steps do the following:
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -420,7 +420,7 @@ These steps do the following:
 
 The `DOCKER_IMAGE` and `DOCKER_IMAGE_TAG` environment variables can be used to override the image name and tag. Run `mage -h test:cloudE2EUp` for all available options.
 
-To also run the automated cloud E2E test suite after deploying, use the all-in-one target (equivalent to the above steps plus `mage test:cloudE2ERun`):
+To also run the automated cloud E2E test suite against the deployment (and tear it down afterwards), use the all-in-one target — equivalent to the above steps with `mage test:cloudE2ERun` inserted between `test:cloudE2EUp` and `test:cloudE2EDown`:
 
 ```bash
 EC_API_KEY=yourapikey mage test:cloudE2E

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -400,23 +400,30 @@ cp build/binaries/fleet-server-8.7.0-SNAPSHOT-linux-x86_64/fleet-server ./data/e
 
 ## Testing on cloud
 
-Elastic employees can create an Elastic Cloud deployment with a locally built Fleet Server.
+Elastic employees can create an Elastic Cloud (ECH) deployment with a locally built Fleet Server.
 
-To deploy it you can use the following commands:
-
-```bash
-EC_API_KEY=yourapikey make -C dev-tools/cloud cloud-deploy
-```
-
-And then to clean the deployment
+The full end-to-end flow — build, push, deploy, test, and teardown — can be run with a single mage target:
 
 ```bash
-EC_API_KEY=yourapikey make -C dev-tools/cloud cloud-clean
+EC_API_KEY=yourapikey mage test:cloudE2E
 ```
 
-For more advanced scenario you can build a custom docker image that you could use in your own terraform.
+This runs the following steps in sequence:
 
+1. **`mage docker:cover`** — builds a coverage-instrumented `fleet-server` binary inside Docker
+2. **`mage docker:customAgentImage`** — creates a custom `elastic-agent-cloud` image with the locally built `fleet-server` binary swapped in (base image: `docker.elastic.co/cloud-release/elastic-agent-cloud`)
+3. **`mage docker:push`** — pushes the custom image to the registry (`docker.elastic.co/beats-ci/elastic-agent-cloud-fleet`)
+4. **`mage test:cloudE2EUp`** — provisions an ECH deployment via Terraform using the custom image
+5. **`mage test:cloudE2ERun`** — runs the cloud E2E tests against the deployment
+6. **`mage test:cloudE2EDown`** — destroys the ECH deployment
+
+You can also run each step individually. For example, to provision and tear down a deployment without running tests:
+
+```bash
+EC_API_KEY=yourapikey mage docker:cover docker:customAgentImage docker:push test:cloudE2EUp
+# ... manual testing ...
+EC_API_KEY=yourapikey mage test:cloudE2EDown
 ```
-make -C dev-tools/cloud build-and-push-cloud-image
-```
+
+The `DOCKER_IMAGE` and `DOCKER_IMAGE_TAG` environment variables can be used to override the image name and tag used for the ECH deployment. Run `mage -h test:cloudE2EUp` for all available options.
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -415,7 +415,7 @@ These steps do the following:
 1. **`mage docker:cover`** — builds a coverage-instrumented `fleet-server` binary inside Docker
 2. **`mage docker:customAgentImage`** — creates a custom `elastic-agent-cloud` image with the locally built `fleet-server` binary swapped in (base image: `docker.elastic.co/cloud-release/elastic-agent-cloud`)
 3. **`mage docker:push`** — pushes the custom image to the registry (`docker.elastic.co/beats-ci/elastic-agent-cloud-fleet`)
-4. **`mage test:cloudE2EUp`** — provisions an ECH deployment via Terraform using the custom image
+4. **`mage test:cloudE2EUp`** — provisions an ECH deployment in the Cloud-First Testing (CFT) region via Terraform using the custom image
 5. **`mage test:cloudE2EDown`** — destroys the ECH deployment when done
 
 The `DOCKER_IMAGE` and `DOCKER_IMAGE_TAG` environment variables can be used to override the image name and tag. Run `mage -h test:cloudE2EUp` for all available options.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -402,22 +402,7 @@ cp build/binaries/fleet-server-8.7.0-SNAPSHOT-linux-x86_64/fleet-server ./data/e
 
 Elastic employees can create an Elastic Cloud (ECH) deployment with a locally built Fleet Server.
 
-The full end-to-end flow — build, push, deploy, test, and teardown — can be run with a single mage target:
-
-```bash
-EC_API_KEY=yourapikey mage test:cloudE2E
-```
-
-This runs the following steps in sequence:
-
-1. **`mage docker:cover`** — builds a coverage-instrumented `fleet-server` binary inside Docker
-2. **`mage docker:customAgentImage`** — creates a custom `elastic-agent-cloud` image with the locally built `fleet-server` binary swapped in (base image: `docker.elastic.co/cloud-release/elastic-agent-cloud`)
-3. **`mage docker:push`** — pushes the custom image to the registry (`docker.elastic.co/beats-ci/elastic-agent-cloud-fleet`)
-4. **`mage test:cloudE2EUp`** — provisions an ECH deployment via Terraform using the custom image
-5. **`mage test:cloudE2ERun`** — runs the cloud E2E tests against the deployment
-6. **`mage test:cloudE2EDown`** — destroys the ECH deployment
-
-You can also run each step individually. For example, to provision and tear down a deployment without running tests:
+To build a custom image and deploy it to ECH for manual testing:
 
 ```bash
 EC_API_KEY=yourapikey mage docker:cover docker:customAgentImage docker:push test:cloudE2EUp
@@ -425,5 +410,19 @@ EC_API_KEY=yourapikey mage docker:cover docker:customAgentImage docker:push test
 EC_API_KEY=yourapikey mage test:cloudE2EDown
 ```
 
-The `DOCKER_IMAGE` and `DOCKER_IMAGE_TAG` environment variables can be used to override the image name and tag used for the ECH deployment. Run `mage -h test:cloudE2EUp` for all available options.
+These steps do the following:
+
+1. **`mage docker:cover`** — builds a coverage-instrumented `fleet-server` binary inside Docker
+2. **`mage docker:customAgentImage`** — creates a custom `elastic-agent-cloud` image with the locally built `fleet-server` binary swapped in (base image: `docker.elastic.co/cloud-release/elastic-agent-cloud`)
+3. **`mage docker:push`** — pushes the custom image to the registry (`docker.elastic.co/beats-ci/elastic-agent-cloud-fleet`)
+4. **`mage test:cloudE2EUp`** — provisions an ECH deployment via Terraform using the custom image
+5. **`mage test:cloudE2EDown`** — destroys the ECH deployment when done
+
+The `DOCKER_IMAGE` and `DOCKER_IMAGE_TAG` environment variables can be used to override the image name and tag. Run `mage -h test:cloudE2EUp` for all available options.
+
+To run the full automated cloud E2E test suite (build, deploy, test, and teardown in one shot), use:
+
+```bash
+EC_API_KEY=yourapikey mage test:cloudE2E
+```
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -418,7 +418,7 @@ These steps do the following:
 4. **`mage test:cloudE2EUp`** — provisions an ECH deployment in the Cloud-First Testing (CFT) region via Terraform using the custom image
 5. **`mage test:cloudE2EDown`** — destroys the ECH deployment when done
 
-The `DOCKER_IMAGE` and `DOCKER_IMAGE_TAG` environment variables can be used to override the image name and tag. Run `mage -h test:cloudE2EUp` for all available options.
+When running the individual targets, `DOCKER_IMAGE` and `DOCKER_IMAGE_TAG` can be used to override the image name and tag used for the ECH deployment. Note that `mage test:cloudE2E` sets these variables internally, so external overrides have no effect on the all-in-one target. Run `mage -h test:cloudE2EUp` for all available options.
 
 To also run the automated cloud E2E test suite against the deployment (and tear it down afterwards), use the all-in-one target — equivalent to the above steps with `mage test:cloudE2ERun` inserted between `test:cloudE2EUp` and `test:cloudE2EDown`:
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -405,13 +405,15 @@ Elastic employees can create an Elastic Cloud Hosted (ECH) deployment with a loc
 To build a custom image and deploy it to ECH for manual testing:
 
 ```bash
-SNAPSHOT=true PLATFORMS=linux/amd64 DOCKER_IMAGE_TAG=my-custom-tag \
+export DOCKER_IMAGE=docker.elastic.co/beats-ci/elastic-agent-cloud-fleet
+export DOCKER_IMAGE_TAG=my-username-$(date +%s)
+SNAPSHOT=true PLATFORMS=linux/amd64 \
   EC_API_KEY=yourapikey mage docker:cover docker:customAgentImage docker:push test:cloudE2EUp
 # ... manual testing ...
-DOCKER_IMAGE_TAG=my-custom-tag EC_API_KEY=yourapikey mage test:cloudE2EDown
+EC_API_KEY=yourapikey mage test:cloudE2EDown
 ```
 
-`SNAPSHOT=true` and `PLATFORMS=linux/amd64` are required — ECH runs on `linux/amd64`, so omitting `PLATFORMS` on Apple Silicon will produce an `arm64` image that won't run in the deployment. Setting a consistent `DOCKER_IMAGE_TAG` ensures that `docker:customAgentImage`, `docker:push`, and `test:cloudE2EUp`/`test:cloudE2EDown` all refer to the same image.
+`SNAPSHOT=true` and `PLATFORMS=linux/amd64` build the required snapshot binary. The registry is shared, so choose a globally unique `DOCKER_IMAGE_TAG`; keeping the same `DOCKER_IMAGE` and tag in the shell session ensures that `docker:customAgentImage`, `docker:push`, `test:cloudE2EUp`, and `test:cloudE2EDown` all refer to the same image.
 
 These steps do the following:
 
@@ -430,4 +432,3 @@ EC_API_KEY=yourapikey mage test:cloudE2E
 ```
 
 If `mage test:cloudE2E` fails partway through, the deployment may be left running. Run `mage test:cloudE2EDown` to clean it up.
-

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -420,7 +420,7 @@ These steps do the following:
 
 The `DOCKER_IMAGE` and `DOCKER_IMAGE_TAG` environment variables can be used to override the image name and tag. Run `mage -h test:cloudE2EUp` for all available options.
 
-To run the full automated cloud E2E test suite (build, deploy, test, and teardown in one shot), use:
+To also run the automated cloud E2E test suite after deploying, use the all-in-one target (equivalent to the above steps plus `mage test:cloudE2ERun`):
 
 ```bash
 EC_API_KEY=yourapikey mage test:cloudE2E

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -400,15 +400,18 @@ cp build/binaries/fleet-server-8.7.0-SNAPSHOT-linux-x86_64/fleet-server ./data/e
 
 ## Testing on cloud
 
-Elastic employees can create an Elastic Cloud (ECH) deployment with a locally built Fleet Server.
+Elastic employees can create an Elastic Cloud Hosted (ECH) deployment with a locally built Fleet Server.
 
 To build a custom image and deploy it to ECH for manual testing:
 
 ```bash
-EC_API_KEY=yourapikey mage docker:cover docker:customAgentImage docker:push test:cloudE2EUp
+SNAPSHOT=true PLATFORMS=linux/amd64 DOCKER_IMAGE_TAG=my-custom-tag \
+  EC_API_KEY=yourapikey mage docker:cover docker:customAgentImage docker:push test:cloudE2EUp
 # ... manual testing ...
-EC_API_KEY=yourapikey mage test:cloudE2EDown
+DOCKER_IMAGE_TAG=my-custom-tag EC_API_KEY=yourapikey mage test:cloudE2EDown
 ```
+
+`SNAPSHOT=true` and `PLATFORMS=linux/amd64` are required — ECH runs on `linux/amd64`, so omitting `PLATFORMS` on Apple Silicon will produce an `arm64` image that won't run in the deployment. Setting a consistent `DOCKER_IMAGE_TAG` ensures that `docker:customAgentImage`, `docker:push`, and `test:cloudE2EUp`/`test:cloudE2EDown` all refer to the same image.
 
 These steps do the following:
 
@@ -418,11 +421,13 @@ These steps do the following:
 4. **`mage test:cloudE2EUp`** — provisions an ECH deployment in the Cloud-First Testing (CFT) region via Terraform using the custom image
 5. **`mage test:cloudE2EDown`** — destroys the ECH deployment when done
 
-When running the individual targets, `DOCKER_IMAGE` and `DOCKER_IMAGE_TAG` can be used to override the image name and tag used for the ECH deployment. Note that `mage test:cloudE2E` sets these variables internally, so external overrides have no effect on the all-in-one target. Run `mage -h test:cloudE2EUp` for all available options.
+`DOCKER_IMAGE` and `DOCKER_IMAGE_TAG` can be used to override the image name and tag. Note that `mage test:cloudE2E` sets these variables internally, so external overrides have no effect on the all-in-one target. Run `mage -h test:cloudE2EUp` for all available options.
 
 To also run the automated cloud E2E test suite against the deployment (and tear it down afterwards), use the all-in-one target — equivalent to the above steps with `mage test:cloudE2ERun` inserted between `test:cloudE2EUp` and `test:cloudE2EDown`:
 
 ```bash
 EC_API_KEY=yourapikey mage test:cloudE2E
 ```
+
+If `mage test:cloudE2E` fails partway through, the deployment may be left running. Run `mage test:cloudE2EDown` to clean it up.
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What is the problem this PR solves?

The "Testing on cloud" section of the developer guide references `make -C dev-tools/cloud` targets (`cloud-deploy`, `cloud-clean`, `build-and-push-cloud-image`) that no longer exist — `dev-tools/cloud` contains only a `terraform/` directory with no Makefile.

## How does this PR solve the problem?

Replaces the stale `make` commands with the current mage-based workflow that CI actually uses (via `.buildkite/scripts/cloud_e2e_test.sh`):

- Documents the manual deploy workflow (`docker:cover`, `docker:customAgentImage`, `docker:push`, `test:cloudE2EUp`, `test:cloudE2EDown`) as the primary path for developers who want a live ECH deployment for manual testing.
- Documents `mage test:cloudE2E` as the all-in-one CI target — equivalent to the manual steps with `test:cloudE2ERun` inserted between `test:cloudE2EUp` and `test:cloudE2EDown`.

## How to test this PR locally

No code changes — docs only.

## Design Checklist

N/A — docs change only.

## Checklist

- [x] I have made corresponding changes to the documentation

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->