### PR TITLE
fix: add memory tiers for 256 MB and 512 MB pods

### DIFF
--- a/internal/pkg/config/defaults/lte0500_limits.yml
+++ b/internal/pkg/config/defaults/lte0500_limits.yml
@@ -1,0 +1,59 @@
+num_agents:
+  min: 0
+  max: 500
+recommended_min_ram: 256
+cache_limits:
+  num_counters: 5000
+  max_cost: 52428800 # 50MiB
+server_limits:
+  max_connections: 1500
+  action_limit:
+    interval: 5ms
+    burst: 1
+  policy_limit:
+    interval: 5ms
+    burst: 1
+  checkin_limit:
+    interval: 5ms
+    burst: 100
+    max: 500
+  artifact_limit:
+    interval: 5ms
+    burst: 100
+    max: 200
+  enroll_limit:
+    interval: 10ms
+    burst: 10
+    max: 20
+  ack_limit:
+    interval: 4ms
+    burst: 100
+    max: 200
+  status_limit:
+    interval: 5ms
+    burst: 10
+    max: 20
+  upload_start_limit:
+    interval: 2s
+    burst: 5
+    max: 5
+  upload_end_limit:
+    interval: 2s
+    burst: 5
+    max: 5
+  upload_chunk_limit:
+    interval: 3ms
+    burst: 5
+    max: 5
+  file_delivery_limit:
+    interval: 100ms
+    burst: 5
+    max: 5
+  pgp_retrieval_limit:
+    interval: 5ms
+    burst: 100
+    max: 200
+  audit_unenroll_limit:
+    interval: 4ms
+    burst: 100
+    max: 200

--- a/internal/pkg/config/defaults/lte1000_limits.yml
+++ b/internal/pkg/config/defaults/lte1000_limits.yml
@@ -1,0 +1,59 @@
+num_agents:
+  min: 501
+  max: 1000
+recommended_min_ram: 512
+cache_limits:
+  num_counters: 10000
+  max_cost: 67108864 # 64MiB
+server_limits:
+  max_connections: 3000
+  action_limit:
+    interval: 5ms
+    burst: 1
+  policy_limit:
+    interval: 5ms
+    burst: 1
+  checkin_limit:
+    interval: 5ms
+    burst: 200
+    max: 1000
+  artifact_limit:
+    interval: 5ms
+    burst: 200
+    max: 400
+  enroll_limit:
+    interval: 10ms
+    burst: 20
+    max: 40
+  ack_limit:
+    interval: 4ms
+    burst: 200
+    max: 400
+  status_limit:
+    interval: 5ms
+    burst: 20
+    max: 40
+  upload_start_limit:
+    interval: 2s
+    burst: 5
+    max: 10
+  upload_end_limit:
+    interval: 2s
+    burst: 5
+    max: 10
+  upload_chunk_limit:
+    interval: 3ms
+    burst: 5
+    max: 10
+  file_delivery_limit:
+    interval: 100ms
+    burst: 5
+    max: 10
+  pgp_retrieval_limit:
+    interval: 5ms
+    burst: 200
+    max: 400
+  audit_unenroll_limit:
+    interval: 4ms
+    burst: 200
+    max: 400

--- a/internal/pkg/config/defaults/lte1000_limits.yml
+++ b/internal/pkg/config/defaults/lte1000_limits.yml
@@ -4,7 +4,7 @@ num_agents:
 recommended_min_ram: 512
 cache_limits:
   num_counters: 10000
-  max_cost: 67108864 # 64MiB
+  max_cost: 52428800 # 50MiB
 server_limits:
   max_connections: 3000
   action_limit:

--- a/internal/pkg/config/defaults/lte2500_limits.yml
+++ b/internal/pkg/config/defaults/lte2500_limits.yml
@@ -1,5 +1,5 @@
 num_agents:
-  min: 0
+  min: 1001
   max: 2500
 recommended_min_ram: 1024
 cache_limits:

--- a/internal/pkg/config/env_defaults_test.go
+++ b/internal/pkg/config/env_defaults_test.go
@@ -31,8 +31,9 @@ func TestLoadLimits(t *testing.T) {
 		ExpectedAgentLimit   int
 	}{
 		{"default", -1, int(getMaxInt())},
-		{"few agents", 5, 2500},
-		{"512", 512, 2500},
+		{"few agents", 5, 500},
+		{"512", 512, 1000},
+		{"lte2500 lower bound", 1001, 2500},
 		{"lesser bound", 5001, 10000},
 		{"upper bound", 10000, 10000},
 		{"above max", 40001, int(getMaxInt())},


### PR DESCRIPTION
Related: elastic/fleet-controller#645

## What

Adds two new memory tiers below the existing 1024 MB floor:

| File | RAM | Agents | Cache |
|---|---|---|---|
| `lte0500_limits.yml` | 256 MB | 0–500 | 50 MiB |
| `lte1000_limits.yml` | 512 MB | 501–1000 | 64 MiB |

All other limits (checkin burst/max, enroll, ack, connections, etc.) are derived from `lte2500` with minimum floors applied where strict proportional scaling would produce impractically low values. Also bumps `lte2500`'s `min` from 0 to 1001 to make all agent count ranges non-overlapping.

## Why

Previously, the lowest tier required `recommended_min_ram: 1024`. Pods with less memory — common in containerised deployments such as Elastic Cloud Serverless — fell through to `defaultEnvLimits`, receiving a 50 MB cache regardless of their actual agent load. After elastic/fleet-server#7573 correctly began reading the pod's cgroup memory limit instead of host RAM, this became a problem in practice: Staging fleet-server pods with a 256 MB cgroup limit started getting bare-default configs, causing cache misses and ES overload at scale.

The proper fix is for fleet-controller to set cache limits explicitly (elastic/fleet-controller#645), but adding these tiers means fleet-server degrades gracefully for any small-memory deployment not managed by fleet-controller.