### PR TITLE
fix: pass nil OutputSecretCandidateCollector to processPolicy in test

### DIFF
--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -1604,7 +1604,7 @@ func TestProcessPolicyRemoteESServiceTokenSecretPaths(t *testing.T) {
 		},
 	}
 
-	action, err := processPolicy(t.Context(), logger, bulker, agent, pp)
+	action, err := processPolicy(t.Context(), logger, bulker, agent, pp, nil)
 	require.NoError(t, err)
 
 	pc, err := action.Data.AsActionPolicyChange()


### PR DESCRIPTION
`processPolicy` was updated in #7468 to accept an `OutputSecretCandidateCollector` argument, but `TestProcessPolicyRemoteESServiceTokenSecretPaths` was not updated to match the new signature. This caused a compile failure in CI.

The fix passes `nil`, which is safe — `prepareElasticsearch` already guards against a nil collector before calling `Add`.