### PR TITLE
test: demonstrate enrollment_id race condition under concurrent retries

### DIFF
--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -133,6 +133,16 @@ func WithAPM(url string, enabled bool) Option {
 	}
 }
 
+// WithNoEnrollRateLimit disables the enroll rate limiter so concurrent enrollment
+// requests are not rejected with 503, allowing race conditions to be observed.
+func WithNoEnrollRateLimit() Option {
+	return func(cfg *config.Config) error {
+		cfg.Inputs[0].Server.Limits.EnrollLimit.Interval = 0
+		cfg.Inputs[0].Server.Limits.EnrollLimit.Burst = 0
+		return nil
+	}
+}
+
 func startTestServer(t *testing.T, ctx context.Context, policyD model.PolicyData, opts ...Option) (*tserver, error) {
 	t.Helper()
 
@@ -795,18 +805,15 @@ func Test_Agent_Enrollment_Id(t *testing.T) {
 // deduplication mechanism is racy: concurrent enrollments with the same
 // enrollment_id can all succeed and create duplicate agent records because
 // fleet-server's lookup uses an ES search query, which is subject to
-// near-real-time indexing latency (default 1s refresh interval). If retries
-// arrive before ES has indexed the first document, the search returns nothing
-// and a second (ghost) agent record is created.
+// near-real-time indexing latency. If retries arrive before ES has indexed
+// the first document, the search returns nothing and a second (ghost) agent
+// record is created.
 //
-// The test uses the default ES configuration (no refresh_interval override) to
-// replicate production conditions. A brief sleep after the first enrollment
-// ensures the document is committed to ES but not yet searchable, then
-// concurrent retries are fired into that window.
-//
-// This race is expected to be more pronounced in Serverless Elasticsearch,
-// where the write path goes through object storage (S3), making indexing
-// latency significantly higher than the standard 1s refresh interval.
+// The test sets refresh_interval=5s on .fleet-agents to replicate Serverless
+// Elasticsearch conditions (Serverless defaults to 5s, vs 1s for standard ES),
+// then waits exactly 5s before firing retries — matching Horde's first backoff
+// wait (EnrollBackoffInit=5s, attempt=0). The retry lands right at the edge of
+// the refresh window, making the race timing-dependent.
 func Test_Agent_Enrollment_Id_Race(t *testing.T) {
 	const (
 		enrollmentID = "race-test-enrollment-id"
@@ -824,7 +831,7 @@ func Test_Agent_Enrollment_Id_Race(t *testing.T) {
 	    }
 	}`, enrollmentID)
 
-	srv, err := startTestServer(t, t.Context(), policyData)
+	srv, err := startTestServer(t, t.Context(), policyData, WithNoEnrollRateLimit())
 	require.NoError(t, err)
 	ctx := testlog.SetLogger(t).WithContext(t.Context())
 
@@ -834,6 +841,20 @@ func Test_Agent_Enrollment_Id_Race(t *testing.T) {
 	}
 	esClient, err := elasticsearch.NewClient(esCfg)
 	require.NoError(t, err)
+
+	// Set refresh_interval=5s to match Serverless Elasticsearch defaults.
+	_, err = esClient.Indices.PutSettings(
+		strings.NewReader(`{"index":{"refresh_interval":"5s"}}`),
+		esClient.Indices.PutSettings.WithIndex(dl.FleetAgents),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// Restore default refresh interval.
+		_, _ = esClient.Indices.PutSettings(
+			strings.NewReader(`{"index":{"refresh_interval":null}}`),
+			esClient.Indices.PutSettings.WithIndex(dl.FleetAgents),
+		)
+	})
 
 	doEnroll := func() (string, error) {
 		req, err := http.NewRequestWithContext(ctx, "POST", srv.baseURL()+"/api/fleet/agents/enroll", strings.NewReader(enrollBodyWEnrollmentID))
@@ -860,18 +881,18 @@ func Test_Agent_Enrollment_Id_Race(t *testing.T) {
 		return response.Item.Id, nil
 	}
 
-	// Send the first enrollment and wait briefly — long enough for the document
-	// to be committed to ES primary storage but not yet searchable (i.e. within
-	// the 1s default refresh interval).
+	// Send the first enrollment, then wait exactly 5s — matching Horde's first
+	// backoff wait (EnrollBackoffInit=5s, attempt=0, jitter collapses to zero).
+	// With refresh_interval=5s, the retry lands right at the edge of the refresh
+	// window: whether the race triggers depends on where in the 5s cycle the
+	// first enrollment landed.
 	firstID, err := doEnroll()
 	require.NoError(t, err)
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(5 * time.Second)
 
-	// Now fire N concurrent retries with the same enrollment_id. These arrive
-	// while the first document is committed but not yet indexed, so the
-	// enrollment_id search returns nothing for each and each creates a new record.
-	// 503s are expected under concurrent load (rate limiter) and are not fatal —
-	// we only care about how many records were actually committed.
+	// Fire N concurrent retries with the same enrollment_id. These simulate
+	// multiple drones all firing their first retry at t=5s. The rate limiter is
+	// disabled so all requests reach the enrollment handler.
 	var (
 		mu       sync.Mutex
 		agentIDs = []string{firstID}

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -791,16 +791,22 @@ func Test_Agent_Enrollment_Id(t *testing.T) {
 	}
 }
 
-// Test_Agent_Enrollment_Id_Race demonstrates that the enrollment_id deduplication
-// mechanism is racy: concurrent enrollments with the same enrollment_id can all
-// succeed and create duplicate agent records because fleet-server's lookup uses an
-// ES search query, which is subject to near-real-time indexing latency (default 1s
-// refresh interval). If retries arrive before ES has indexed the first document,
-// the search returns nothing and a second (ghost) agent record is created.
+// Test_Agent_Enrollment_Id_Race tests the theory that the enrollment_id
+// deduplication mechanism is racy: concurrent enrollments with the same
+// enrollment_id can all succeed and create duplicate agent records because
+// fleet-server's lookup uses an ES search query, which is subject to
+// near-real-time indexing latency (default 1s refresh interval). If retries
+// arrive before ES has indexed the first document, the search returns nothing
+// and a second (ghost) agent record is created.
 //
-// This race is more pronounced in Serverless Elasticsearch, where the write path
-// goes through object storage (S3), making the indexing latency significantly
-// higher than the standard 1s refresh interval.
+// The test uses the default ES configuration (no refresh_interval override) to
+// replicate production conditions. A brief sleep after the first enrollment
+// ensures the document is committed to ES but not yet searchable, then
+// concurrent retries are fired into that window.
+//
+// This race is expected to be more pronounced in Serverless Elasticsearch,
+// where the write path goes through object storage (S3), making indexing
+// latency significantly higher than the standard 1s refresh interval.
 func Test_Agent_Enrollment_Id_Race(t *testing.T) {
 	const (
 		enrollmentID = "race-test-enrollment-id"
@@ -822,8 +828,6 @@ func Test_Agent_Enrollment_Id_Race(t *testing.T) {
 	require.NoError(t, err)
 	ctx := testlog.SetLogger(t).WithContext(t.Context())
 
-	// Disable auto-refresh on .fleet-agents so that concurrent enrollment
-	// requests cannot find each other's committed documents via ES search.
 	esCfg := elasticsearch.Config{
 		Username: "elastic",
 		Password: "changeme",
@@ -831,53 +835,55 @@ func Test_Agent_Enrollment_Id_Race(t *testing.T) {
 	esClient, err := elasticsearch.NewClient(esCfg)
 	require.NoError(t, err)
 
-	_, err = esClient.Indices.PutSettings(
-		bytes.NewBufferString(`{"index":{"refresh_interval":"-1"}}`),
-		esClient.Indices.PutSettings.WithIndex(dl.FleetAgents),
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		// Restore default refresh interval.
-		_, _ = esClient.Indices.PutSettings(
-			bytes.NewBufferString(`{"index":{"refresh_interval":"1s"}}`),
-			esClient.Indices.PutSettings.WithIndex(dl.FleetAgents),
-		)
-	})
+	doEnroll := func() (string, error) {
+		req, err := http.NewRequestWithContext(ctx, "POST", srv.baseURL()+"/api/fleet/agents/enroll", strings.NewReader(enrollBodyWEnrollmentID))
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("Authorization", "ApiKey "+srv.enrollKey)
+		req.Header.Set("User-Agent", "elastic agent "+serverVersion)
+		req.Header.Set("Content-Type", "application/json")
+		cli := cleanhttp.DefaultClient()
+		res, err := cli.Do(req)
+		if err != nil {
+			return "", err
+		}
+		defer res.Body.Close()
+		if res.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("unexpected status %d", res.StatusCode)
+		}
+		p, _ := io.ReadAll(res.Body)
+		var response api.EnrollResponse
+		if err := json.Unmarshal(p, &response); err != nil {
+			return "", err
+		}
+		return response.Item.Id, nil
+	}
 
-	// Send N concurrent enrollment requests with the same enrollment_id.
-	// With auto-refresh disabled, none of them can find the others' documents
-	// via the enrollment_id search, so each creates a new agent record.
+	// Send the first enrollment and wait briefly — long enough for the document
+	// to be committed to ES primary storage but not yet searchable (i.e. within
+	// the 1s default refresh interval).
+	firstID, err := doEnroll()
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+
+	// Now fire N concurrent retries with the same enrollment_id. These arrive
+	// while the first document is committed but not yet indexed, so the
+	// enrollment_id search returns nothing for each and each creates a new record.
 	var (
-		mu      sync.Mutex
-		agentIDs []string
+		mu       sync.Mutex
+		agentIDs = []string{firstID}
 	)
 	g, gCtx := errgroup.WithContext(ctx)
 	for i := 0; i < concurrency; i++ {
 		g.Go(func() error {
-			req, err := http.NewRequestWithContext(gCtx, "POST", srv.baseURL()+"/api/fleet/agents/enroll", strings.NewReader(enrollBodyWEnrollmentID))
+			_ = gCtx
+			id, err := doEnroll()
 			if err != nil {
-				return err
-			}
-			req.Header.Set("Authorization", "ApiKey "+srv.enrollKey)
-			req.Header.Set("User-Agent", "elastic agent "+serverVersion)
-			req.Header.Set("Content-Type", "application/json")
-
-			cli := cleanhttp.DefaultClient()
-			res, err := cli.Do(req)
-			if err != nil {
-				return err
-			}
-			defer res.Body.Close()
-			if res.StatusCode != http.StatusOK {
-				return fmt.Errorf("unexpected status %d", res.StatusCode)
-			}
-			p, _ := io.ReadAll(res.Body)
-			var response api.EnrollResponse
-			if err := json.Unmarshal(p, &response); err != nil {
 				return err
 			}
 			mu.Lock()
-			agentIDs = append(agentIDs, response.Item.Id)
+			agentIDs = append(agentIDs, id)
 			mu.Unlock()
 			return nil
 		})
@@ -894,9 +900,8 @@ func Test_Agent_Enrollment_Id_Race(t *testing.T) {
 		}
 	})
 
-	// Count how many agent records exist with this enrollment_id using the raw
-	// ES client (no search-result caching). If the race exists, count > 1.
-	// A correct implementation would have count == 1.
+	// Count how many agent records exist with this enrollment_id.
+	// If the theory is correct, count > 1. A correct implementation would have count == 1.
 	countRes, err := esClient.Count(
 		esClient.Count.WithContext(ctx),
 		esClient.Count.WithIndex(dl.FleetAgents),

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http/httptest"
 	"path"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -788,6 +789,129 @@ func Test_Agent_Enrollment_Id(t *testing.T) {
 	} else {
 		t.Fatal("duplicate agent found after enrolling with same enrollment id")
 	}
+}
+
+// Test_Agent_Enrollment_Id_Race demonstrates that the enrollment_id deduplication
+// mechanism is racy: concurrent enrollments with the same enrollment_id can all
+// succeed and create duplicate agent records because fleet-server's lookup uses an
+// ES search query, which is subject to near-real-time indexing latency (default 1s
+// refresh interval). If retries arrive before ES has indexed the first document,
+// the search returns nothing and a second (ghost) agent record is created.
+//
+// This race is more pronounced in Serverless Elasticsearch, where the write path
+// goes through object storage (S3), making the indexing latency significantly
+// higher than the standard 1s refresh interval.
+func Test_Agent_Enrollment_Id_Race(t *testing.T) {
+	const (
+		enrollmentID = "race-test-enrollment-id"
+		concurrency  = 5
+	)
+
+	enrollBodyWEnrollmentID := fmt.Sprintf(`{
+	    "type": "PERMANENT",
+	    "shared_id": "",
+	    "enrollment_id": %q,
+	    "metadata": {
+		"user_provided": {},
+		"local": {},
+		"tags": []
+	    }
+	}`, enrollmentID)
+
+	srv, err := startTestServer(t, t.Context(), policyData)
+	require.NoError(t, err)
+	ctx := testlog.SetLogger(t).WithContext(t.Context())
+
+	// Disable auto-refresh on .fleet-agents so that concurrent enrollment
+	// requests cannot find each other's committed documents via ES search.
+	esCfg := elasticsearch.Config{
+		Username: "elastic",
+		Password: "changeme",
+	}
+	esClient, err := elasticsearch.NewClient(esCfg)
+	require.NoError(t, err)
+
+	_, err = esClient.Indices.PutSettings(
+		bytes.NewBufferString(`{"index":{"refresh_interval":"-1"}}`),
+		esClient.Indices.PutSettings.WithIndex(dl.FleetAgents),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// Restore default refresh interval.
+		_, _ = esClient.Indices.PutSettings(
+			bytes.NewBufferString(`{"index":{"refresh_interval":"1s"}}`),
+			esClient.Indices.PutSettings.WithIndex(dl.FleetAgents),
+		)
+	})
+
+	// Send N concurrent enrollment requests with the same enrollment_id.
+	// With auto-refresh disabled, none of them can find the others' documents
+	// via the enrollment_id search, so each creates a new agent record.
+	var (
+		mu      sync.Mutex
+		agentIDs []string
+	)
+	g, gCtx := errgroup.WithContext(ctx)
+	for i := 0; i < concurrency; i++ {
+		g.Go(func() error {
+			req, err := http.NewRequestWithContext(gCtx, "POST", srv.baseURL()+"/api/fleet/agents/enroll", strings.NewReader(enrollBodyWEnrollmentID))
+			if err != nil {
+				return err
+			}
+			req.Header.Set("Authorization", "ApiKey "+srv.enrollKey)
+			req.Header.Set("User-Agent", "elastic agent "+serverVersion)
+			req.Header.Set("Content-Type", "application/json")
+
+			cli := cleanhttp.DefaultClient()
+			res, err := cli.Do(req)
+			if err != nil {
+				return err
+			}
+			defer res.Body.Close()
+			if res.StatusCode != http.StatusOK {
+				return fmt.Errorf("unexpected status %d", res.StatusCode)
+			}
+			p, _ := io.ReadAll(res.Body)
+			var response api.EnrollResponse
+			if err := json.Unmarshal(p, &response); err != nil {
+				return err
+			}
+			mu.Lock()
+			agentIDs = append(agentIDs, response.Item.Id)
+			mu.Unlock()
+			return nil
+		})
+	}
+	require.NoError(t, g.Wait())
+
+	// Trigger a manual refresh so all committed documents become searchable.
+	_, err = esClient.Indices.Refresh(esClient.Indices.Refresh.WithIndex(dl.FleetAgents))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		for _, id := range agentIDs {
+			_ = srv.bulker.Delete(ctx, dl.FleetAgents, id)
+		}
+	})
+
+	// Count how many agent records exist with this enrollment_id using the raw
+	// ES client (no search-result caching). If the race exists, count > 1.
+	// A correct implementation would have count == 1.
+	countRes, err := esClient.Count(
+		esClient.Count.WithContext(ctx),
+		esClient.Count.WithIndex(dl.FleetAgents),
+		esClient.Count.WithBody(bytes.NewBufferString(fmt.Sprintf(
+			`{"query":{"term":{"enrollment_id":%q}}}`, enrollmentID,
+		))),
+	)
+	require.NoError(t, err)
+	defer countRes.Body.Close()
+	var countBody struct {
+		Count int `json:"count"`
+	}
+	require.NoError(t, json.NewDecoder(countRes.Body).Decode(&countBody))
+	t.Logf("found %d agent record(s) with enrollment_id=%q (expected 1)", countBody.Count, enrollmentID)
+	require.Equal(t, 1, countBody.Count, "enrollment_id race: %d duplicate agent records created", countBody.Count)
 }
 
 func Test_Agent_Enrollment_Id_Invalidated_API_key(t *testing.T) {

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -870,6 +870,8 @@ func Test_Agent_Enrollment_Id_Race(t *testing.T) {
 	// Now fire N concurrent retries with the same enrollment_id. These arrive
 	// while the first document is committed but not yet indexed, so the
 	// enrollment_id search returns nothing for each and each creates a new record.
+	// 503s are expected under concurrent load (rate limiter) and are not fatal —
+	// we only care about how many records were actually committed.
 	var (
 		mu       sync.Mutex
 		agentIDs = []string{firstID}
@@ -880,7 +882,8 @@ func Test_Agent_Enrollment_Id_Race(t *testing.T) {
 			_ = gCtx
 			id, err := doEnroll()
 			if err != nil {
-				return err
+				t.Logf("concurrent enroll error (non-fatal): %v", err)
+				return nil
 			}
 			mu.Lock()
 			agentIDs = append(agentIDs, id)

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -898,7 +898,7 @@ func Test_Agent_Enrollment_Id_Race(t *testing.T) {
 		agentIDs = []string{firstID}
 	)
 	g, gCtx := errgroup.WithContext(ctx)
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		g.Go(func() error {
 			_ = gCtx
 			id, err := doEnroll()


### PR DESCRIPTION
## Theory

The `enrollment_id` deduplication mechanism in fleet-server may be racy. When multiple enrollment requests with the same `enrollment_id` arrive concurrently, the search-based lookup (`dl.FindAgent(..., QueryAgentByEnrollmentID, ...)`) issues an ES search query, which is subject to near-real-time indexing latency (default 1s refresh interval). If retries arrive before ES has indexed the first document, the search returns nothing for each request and each creates a new ghost agent record.

This would explain the 26 ghost agents observed in the [30k checkin scale test build #6778](https://buildkite.com/elastic/observability-perf/builds/6778) (see the "Remaining issue" section of [this comment](https://github.com/elastic/ingest-dev/issues/9167#issuecomment-5289394858)), even after the cache regression fix — despite Horde already sending `enrollment_id` on every retry.

If true, the race window would be even larger on Serverless Elasticsearch, where the write path goes through object storage (S3), making indexing latency significantly higher than the standard 1s refresh interval.

## The test

`Test_Agent_Enrollment_Id_Race` attempts to verify this theory using the **default ES configuration** (no `refresh_interval` override) to match production conditions:

1. Send the first enrollment request and sleep briefly (100ms) — long enough for the document to be committed to ES primary storage but not yet searchable (within the default 1s refresh window)
2. Fire `N=5` concurrent enrollment requests with the same `enrollment_id` into that window
3. Trigger a manual `_refresh`
4. Assert that exactly 1 agent record was created

If the theory is correct, the test will fail — demonstrating that the `enrollment_id` mechanism does not reliably prevent duplicates under concurrent retries against default ES configuration.

## Related

- elastic/fleet-server#2254 (original issue, closed as "fixed" but the fix may be incomplete)
- elastic/fleet-server#2655 (the `enrollment_id` mechanism — potentially racy as theorized here)
- elastic/fleet-server#4290 (`id` + `replace_token` — uses GET by document ID, not subject to this race)
- elastic/horde#532 (wires up `id` + `replace_token` in Horde)