### PR TITLE
feat: batch enrollment FindAgent searches with pre-refresh dedup

### DIFF
--- a/changelog/fragments/1787137647-enroll-search-bulker-queue.yaml
+++ b/changelog/fragments/1787137647-enroll-search-bulker-queue.yaml
@@ -1,21 +1,20 @@
 kind: enhancement
 
-summary: Batch enrollment FindAgent searches with pre-refresh dedup to prevent ghost agents
+summary: Prevent ghost agent documents caused by concurrent enrollment retries
 
 description: |
-  Adds a new kQueueEnrollSearch bulker queue that batches enrollment duplicate-check
-  searches (FindAgent by enrollment_id) and fires a single POST .fleet-agents/_refresh
-  before executing the msearch for the batch. This prevents ghost agent documents that
-  were caused by concurrent enrollment retries searching the index before a previous
-  write was visible due to Elasticsearch's refresh latency.
+  At large scale, concurrent enrollment retries could create duplicate (ghost) agent
+  documents in Elasticsearch. This occurred when an agent retried enrollment before
+  its previous write was visible to search, causing multiple retries to each believe
+  no agent existed and each create a new document.
 
-  Within each batch, requests sharing the same enrollment_id are de-duplicated: only
-  one search is sent to ES per unique enrollment_id; duplicates receive a 429 and retry.
-  The batch flushes after N requests (default: 50) or M seconds (default: 1s), whichever
-  comes first, capping refresh calls at one per fleet-server instance per flush window.
+  Fleet Server now batches enrollment lookups and ensures index visibility before
+  searching, so retries consistently find an existing agent document rather than
+  creating a new one. Duplicate requests within a batch are handled efficiently
+  and prompted to retry, keeping the number of Elasticsearch operations low.
 
-  Both the flush interval and threshold count are configurable via
-  inputs[].server.bulk.enroll_bulker.flush_interval and
-  inputs[].server.bulk.enroll_bulker.flush_threshold_cnt.
+  The batching behaviour is configurable via
+  inputs[].server.bulk.enroll.flush_interval (default: 1s) and
+  inputs[].server.bulk.enroll.flush_threshold_cnt (default: 50).
 
 component: fleet-server

--- a/changelog/fragments/1787137647-enroll-search-bulker-queue.yaml
+++ b/changelog/fragments/1787137647-enroll-search-bulker-queue.yaml
@@ -15,7 +15,7 @@ description: |
   comes first, capping refresh calls at one per fleet-server instance per flush window.
 
   Both the flush interval and threshold count are configurable via
-  inputs[].server.bulk.enroll_batcher.flush_interval and
-  inputs[].server.bulk.enroll_batcher.flush_threshold_cnt.
+  inputs[].server.bulk.enroll_bulker.flush_interval and
+  inputs[].server.bulk.enroll_bulker.flush_threshold_cnt.
 
 component: fleet-server

--- a/changelog/fragments/1787137647-enroll-search-bulker-queue.yaml
+++ b/changelog/fragments/1787137647-enroll-search-bulker-queue.yaml
@@ -1,0 +1,21 @@
+kind: enhancement
+
+summary: Batch enrollment FindAgent searches with pre-refresh dedup to prevent ghost agents
+
+description: |
+  Adds a new kQueueEnrollSearch bulker queue that batches enrollment duplicate-check
+  searches (FindAgent by enrollment_id) and fires a single POST .fleet-agents/_refresh
+  before executing the msearch for the batch. This prevents ghost agent documents that
+  were caused by concurrent enrollment retries searching the index before a previous
+  write was visible due to Elasticsearch's refresh latency.
+
+  Within each batch, requests sharing the same enrollment_id are de-duplicated: only
+  one search is sent to ES per unique enrollment_id; duplicates receive a 429 and retry.
+  The batch flushes after N requests (default: 50) or M seconds (default: 1s), whichever
+  comes first, capping refresh calls at one per fleet-server instance per flush window.
+
+  Both the flush interval and threshold count are configurable via
+  inputs[].server.bulk.enroll_batcher.flush_interval and
+  inputs[].server.bulk.enroll_batcher.flush_threshold_cnt.
+
+component: fleet-server

--- a/internal/pkg/api/error.go
+++ b/internal/pkg/api/error.go
@@ -206,6 +206,15 @@ func NewHTTPErrResp(err error) HTTPErrResp {
 			},
 		},
 		{
+			bulk.ErrEnrollDuplicate,
+			HTTPErrResp{
+				http.StatusTooManyRequests,
+				"EnrollDuplicate",
+				"concurrent enrollment for same id: retry",
+				zerolog.DebugLevel,
+			},
+		},
+		{
 			os.ErrDeadlineExceeded,
 			HTTPErrResp{
 				http.StatusRequestTimeout,

--- a/internal/pkg/api/handleEnroll.go
+++ b/internal/pkg/api/handleEnroll.go
@@ -215,8 +215,13 @@ func (et *EnrollerT) _enroll(
 		vSpan, vCtx := apm.StartSpan(ctx, "checkEnrollmentID", "validate")
 		enrollmentID = *req.EnrollmentId
 		var err error
-		agent, err = dl.FindAgent(vCtx, et.bulker, dl.QueryAgentByEnrollmentID, dl.FieldEnrollmentID, enrollmentID)
+		agent, err = dl.FindAgent(vCtx, et.bulker, dl.QueryAgentByEnrollmentID, dl.FieldEnrollmentID, enrollmentID,
+			dl.WithBulkOpts(bulk.WithDedupeKey(enrollmentID, dl.FleetAgents)))
 		if err != nil {
+			if errors.Is(err, bulk.ErrEnrollDuplicate) {
+				vSpan.End()
+				return nil, err
+			}
 			zlog.Debug().Err(err).
 				Str("EnrollmentId", enrollmentID).
 				Msg("Agent with EnrollmentId not found")

--- a/internal/pkg/bulk/block.go
+++ b/internal/pkg/bulk/block.go
@@ -16,14 +16,16 @@ type Buf = danger.Buf
 // However, the multiOp API's will allocate directly in large blocks.
 
 type bulkT struct {
-	action      actionT    // requested actions
-	flags       flagsT     // execution flags
-	idx         int32      // idx of originating request, used in mulitOp
-	ch          chan respT // response channel, caller is waiting synchronously
-	buf         Buf        // json payload to be sent to elastic
-	next        *bulkT     // pointer to next bulkT, used for fast internal queueing
-	spanLink    apm.SpanLink
-	hasSpanLink bool
+	action       actionT    // requested actions
+	flags        flagsT     // execution flags
+	idx          int32      // idx of originating request, used in mulitOp
+	ch           chan respT // response channel, caller is waiting synchronously
+	buf          Buf        // json payload to be sent to elastic
+	next         *bulkT     // pointer to next bulkT, used for fast internal queueing
+	spanLink     apm.SpanLink
+	hasSpanLink  bool
+	dedupeKey    string // enrollment dedup key (enrollment_id); routes to kQueueEnrollSearch when set
+	refreshIndex string // index to refresh before msearch in kQueueEnrollSearch
 }
 
 type flagsT int8
@@ -79,6 +81,8 @@ func (blk *bulkT) reset() {
 	blk.next = nil
 	blk.spanLink = apm.SpanLink{}
 	blk.hasSpanLink = false
+	blk.dedupeKey = ""
+	blk.refreshIndex = ""
 }
 
 type respT struct {

--- a/internal/pkg/bulk/engine.go
+++ b/internal/pkg/bulk/engine.go
@@ -40,6 +40,7 @@ type APIKeyMetadata = apikey.APIKeyMetadata
 var (
 	ErrNoQuotes              = errors.New("quoted literal not supported")
 	ErrTooManyBulkDispatches = errors.New("too many pending bulk dispatches")
+	ErrEnrollDuplicate       = errors.New("enrollment deduplicated: retry")
 )
 
 type MultiOp struct {
@@ -379,6 +380,10 @@ func stopTimer(t *time.Timer) {
 func blkToQueueType(blk *bulkT) queueType {
 	queueIdx := kQueueBulk
 
+	if blk.action == ActionSearch && blk.dedupeKey != "" {
+		return kQueueEnrollSearch
+	}
+
 	forceRefresh := blk.flags.Has(flagRefresh)
 
 	switch blk.action {
@@ -413,6 +418,12 @@ func (b *Bulker) Run(ctx context.Context) error {
 	stopTimer(timer)
 	defer timer.Stop()
 
+	// Separate timer and counter for the enrollment search queue so it can flush
+	// independently at a shorter interval without affecting other queues.
+	enrollTimer := time.NewTimer(b.opts.enrollFlushInterval)
+	stopTimer(enrollTimer)
+	defer enrollTimer.Stop()
+
 	w := semaphore.NewWeighted(int64(b.opts.maxPending))
 
 	var queues [kNumQueues]queueT
@@ -424,29 +435,42 @@ func (b *Bulker) Run(ctx context.Context) error {
 
 	var itemCnt int
 	var byteCnt int
+	var enrollItemCnt int
 
 	doFlush := func() error {
-
 		for i := range queues {
+			if queueType(i) == kQueueEnrollSearch {
+				continue // flushed independently by doFlushEnroll
+			}
 			q := &queues[i]
 			if q.pending > 0 {
-
 				// Pass queue structure by value
 				if err := b.flushQueue(ctx, w, *q); err != nil {
 					return err
 				}
-
 				// Reset local queue stored in array
 				q.cnt = 0
 				q.head = nil
 				q.pending = 0
 			}
 		}
-
 		// Reset threshold counters
 		itemCnt = 0
 		byteCnt = 0
+		return nil
+	}
 
+	doFlushEnroll := func() error {
+		q := &queues[kQueueEnrollSearch]
+		if q.pending > 0 {
+			if err := b.flushQueue(ctx, w, *q); err != nil {
+				return err
+			}
+			q.cnt = 0
+			q.head = nil
+			q.pending = 0
+		}
+		enrollItemCnt = 0
 		return nil
 	}
 
@@ -467,27 +491,49 @@ func (b *Bulker) Run(ctx context.Context) error {
 			q.cnt += 1
 			q.pending += blk.buf.Len()
 
-			// Update threshold counters
-			itemCnt += 1
-			byteCnt += blk.buf.Len()
+			if queueIdx == kQueueEnrollSearch {
+				enrollItemCnt++
+				if enrollItemCnt == 1 {
+					enrollTimer.Reset(b.opts.enrollFlushInterval)
+				}
+				if enrollItemCnt >= b.opts.enrollFlushThresholdCnt {
+					zerolog.Ctx(ctx).Trace().
+						Str("mod", kModBulk).
+						Int("enrollItemCnt", enrollItemCnt).
+						Msg("Flush enroll search on threshold")
+					err = doFlushEnroll()
+					stopTimer(enrollTimer)
+				}
+			} else {
+				// Update threshold counters
+				itemCnt += 1
+				byteCnt += blk.buf.Len()
 
-			// Start timer on first queued item
-			if itemCnt == 1 {
-				timer.Reset(b.opts.flushInterval)
+				// Start timer on first queued item
+				if itemCnt == 1 {
+					timer.Reset(b.opts.flushInterval)
+				}
+
+				// Threshold test, short circuit timer on pending count
+				if itemCnt >= b.opts.flushThresholdCnt || byteCnt >= b.opts.flushThresholdSz {
+					zerolog.Ctx(ctx).Trace().
+						Str("mod", kModBulk).
+						Int("itemCnt", itemCnt).
+						Int("byteCnt", byteCnt).
+						Msg("Flush on threshold")
+
+					err = doFlush()
+
+					stopTimer(timer)
+				}
 			}
 
-			// Threshold test, short circuit timer on pending count
-			if itemCnt >= b.opts.flushThresholdCnt || byteCnt >= b.opts.flushThresholdSz {
-				zerolog.Ctx(ctx).Trace().
-					Str("mod", kModBulk).
-					Int("itemCnt", itemCnt).
-					Int("byteCnt", byteCnt).
-					Msg("Flush on threshold")
-
-				err = doFlush()
-
-				stopTimer(timer)
-			}
+		case <-enrollTimer.C:
+			zerolog.Ctx(ctx).Trace().
+				Str("mod", kModBulk).
+				Int("enrollItemCnt", enrollItemCnt).
+				Msg("Flush enroll search on timer")
+			err = doFlushEnroll()
 
 		case <-timer.C:
 			zerolog.Ctx(ctx).Trace().
@@ -564,6 +610,8 @@ func (b *Bulker) flushQueue(ctx context.Context, w *semaphore.Weighted, queue qu
 			err = b.flushRead(flushCtx, queue)
 		case kQueueSearch, kQueueFleetSearch:
 			err = b.flushSearch(flushCtx, queue)
+		case kQueueEnrollSearch:
+			err = b.flushEnrollSearch(flushCtx, queue)
 		case kQueueAPIKeyUpdate:
 			err = b.flushUpdateAPIKey(flushCtx, queue)
 		default:
@@ -619,6 +667,8 @@ func (b *Bulker) newBlk(action actionT, opts optionsT) *bulkT {
 	}
 	blk.spanLink = opts.spanLink
 	blk.hasSpanLink = opts.hasSpanLink
+	blk.dedupeKey = opts.DedupeKey
+	blk.refreshIndex = opts.RefreshIndex
 
 	return blk
 }

--- a/internal/pkg/bulk/enroll_search_integration_test.go
+++ b/internal/pkg/bulk/enroll_search_integration_test.go
@@ -1,0 +1,74 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+//go:build integration
+
+package bulk
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	testlog "github.com/elastic/fleet-server/v7/internal/pkg/testing/log"
+)
+
+// TestEnrollSearchDedup verifies that concurrent FindAgent searches sharing the
+// same enrollment_id are de-duplicated within a single flush batch: exactly one
+// request (the oldest, FIFO) is executed against ES and the rest receive
+// ErrEnrollDuplicate so the agent handlers know to retry.
+func TestEnrollSearchDedup(t *testing.T) {
+	const (
+		numConcurrent = 10
+		// Set threshold high enough that the timer drives the flush, not item count.
+		enrollThreshold = numConcurrent + 1
+		enrollInterval  = 300 * time.Millisecond
+	)
+
+	ctx := t.Context()
+	ctx = testlog.SetLogger(t).WithContext(ctx)
+
+	// enrollThreshold > numConcurrent ensures all goroutines land in one batch.
+	index, bulker := SetupIndexWithBulk(ctx, t, testPolicy,
+		WithEnrollFlushThresholdCount(enrollThreshold),
+		WithEnrollFlushInterval(enrollInterval),
+	)
+
+	// Write a doc so the canonical search has something to find.
+	sample := NewRandomSample()
+	_, err := bulker.Create(ctx, index, "", sample.marshal(t), WithRefresh())
+	require.NoError(t, err)
+
+	dsl := []byte(`{"query":{"match_all":{}}}`)
+	dedupeKey := "test-enrollment-id-dedup"
+
+	errs := make([]error, numConcurrent)
+	var wg sync.WaitGroup
+	wg.Add(numConcurrent)
+	for i := range numConcurrent {
+		go func(i int) {
+			defer wg.Done()
+			_, searchErr := bulker.Search(ctx, index, dsl, WithDedupeKey(dedupeKey, index))
+			errs[i] = searchErr
+		}(i)
+	}
+	wg.Wait()
+
+	var dupes, successes int
+	for _, e := range errs {
+		if errors.Is(e, ErrEnrollDuplicate) {
+			dupes++
+		} else {
+			assert.NoError(t, e, "canonical request should not error")
+			successes++
+		}
+	}
+
+	assert.Equal(t, 1, successes, "exactly one canonical request should succeed")
+	assert.Equal(t, numConcurrent-1, dupes, "all other requests should receive ErrEnrollDuplicate")
+}

--- a/internal/pkg/bulk/opSearch.go
+++ b/internal/pkg/bulk/opSearch.go
@@ -308,7 +308,7 @@ func (b *Bulker) flushEnrollSearch(ctx context.Context, queue queueT) error {
 	// Build msearch body from canonical items only.
 	const kRoughEstimatePerItem = 256
 	bufSz := max(len(canonicals)*kRoughEstimatePerItem, queue.pending)
-	buf := b.flushBufPool.Get().(*bytes.Buffer) //nolint:errcheck
+	buf := b.flushBufPool.Get().(*bytes.Buffer) //nolint:errcheck // we control what is placed in the pool
 	buf.Reset()
 	buf.Grow(bufSz)
 	defer b.flushBufPool.Put(buf)

--- a/internal/pkg/bulk/opSearch.go
+++ b/internal/pkg/bulk/opSearch.go
@@ -243,3 +243,110 @@ func (b *Bulker) flushSearch(ctx context.Context, queue queueT) error {
 
 	return nil
 }
+
+// flushEnrollSearch handles the kQueueEnrollSearch queue. It:
+//  1. Groups items by dedupeKey — first occurrence is canonical, the rest are duplicates.
+//  2. Refreshes the index named by the first item's refreshIndex.
+//  3. Sends an msearch containing only the canonical items.
+//  4. Dispatches results to canonical items; sends ErrEnrollDuplicate to duplicates.
+func (b *Bulker) flushEnrollSearch(ctx context.Context, queue queueT) error {
+	// Group items: first occurrence of each dedupeKey is canonical, rest are dupes.
+	dupesByKey := make(map[string][]*bulkT)
+	var canonicals []*bulkT
+
+	for n := queue.head; n != nil; n = n.next {
+		key := n.dedupeKey
+		if _, seen := dupesByKey[key]; !seen {
+			dupesByKey[key] = nil // mark key as seen; nil slice = no dupes yet
+			canonicals = append(canonicals, n)
+		} else {
+			dupesByKey[key] = append(dupesByKey[key], n)
+		}
+	}
+
+	// Refresh the index before searching so retries see the most recent writes.
+	if len(canonicals) > 0 && canonicals[0].refreshIndex != "" {
+		refreshReq := esapi.IndicesRefreshRequest{
+			Index: []string{canonicals[0].refreshIndex},
+		}
+		refreshResp, err := refreshReq.Do(ctx, b.es)
+		if err != nil {
+			failQueue(queue, err)
+			return nil
+		}
+		if refreshResp.Body != nil {
+			refreshResp.Body.Close()
+		}
+		if refreshResp.IsError() {
+			err = fmt.Errorf("enroll search refresh failed: %s", refreshResp.String())
+			failQueue(queue, err)
+			return nil
+		}
+	}
+
+	if len(canonicals) == 0 {
+		return nil
+	}
+
+	// Build msearch body from canonical items only.
+	const kRoughEstimatePerItem = 256
+	bufSz := max(len(canonicals)*kRoughEstimatePerItem, queue.pending)
+	buf := b.flushBufPool.Get().(*bytes.Buffer) //nolint:errcheck
+	buf.Reset()
+	buf.Grow(bufSz)
+	defer b.flushBufPool.Put(buf)
+
+	for _, n := range canonicals {
+		buf.Write(n.buf.Bytes())
+	}
+
+	span, ctx := apm.StartSpanOptions(ctx, flushSpanNames[queue.ty], queue.Type(), apm.SpanOptions{})
+	defer span.End()
+
+	msearchReq := esapi.MsearchRequest{Body: bytes.NewReader(buf.Bytes())}
+	res, err := msearchReq.Do(ctx, b.es)
+	if err != nil {
+		failQueue(queue, err)
+		return nil
+	}
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+	if res.IsError() {
+		err = parseError(res, zerolog.Ctx(ctx))
+		failQueue(queue, err)
+		return nil
+	}
+
+	buf.Reset()
+	if _, err = buf.ReadFrom(res.Body); err != nil {
+		return err
+	}
+
+	var blk MsearchResponse
+	blk.Responses = make([]MsearchResponseItem, 0, len(canonicals))
+	if err = easyjson.Unmarshal(buf.Bytes(), &blk); err != nil {
+		return err
+	}
+	if len(blk.Responses) != len(canonicals) {
+		return fmt.Errorf("enroll search queue length mismatch: got %d, want %d", len(blk.Responses), len(canonicals))
+	}
+
+	// WARNING: Once we start pushing items to the queue, the node pointers are invalid.
+	for i, n := range canonicals {
+		response := &blk.Responses[i]
+		select {
+		case n.ch <- respT{err: response.deriveError(), idx: n.idx, data: response}:
+		default:
+			panic("Unexpected blocked response channel on flushEnrollSearch canonical")
+		}
+		for _, dupe := range dupesByKey[n.dedupeKey] {
+			select {
+			case dupe.ch <- respT{err: ErrEnrollDuplicate}:
+			default:
+				panic("Unexpected blocked response channel on flushEnrollSearch dupe")
+			}
+		}
+	}
+	return nil
+}

--- a/internal/pkg/bulk/opSearch.go
+++ b/internal/pkg/bulk/opSearch.go
@@ -352,14 +352,21 @@ func (b *Bulker) flushEnrollSearch(ctx context.Context, queue queueT) error {
 	// WARNING: Once we start pushing items to the queue, the node pointers are invalid.
 	for i, n := range canonicals {
 		response := &blk.Responses[i]
+		respErr := response.deriveError()
 		select {
-		case n.ch <- respT{err: response.deriveError(), idx: n.idx, data: response}:
+		case n.ch <- respT{err: respErr, idx: n.idx, data: response}:
 		default:
 			panic("Unexpected blocked response channel on flushEnrollSearch canonical")
 		}
+		// If the canonical's search itself failed, propagate that error to duplicates
+		// instead of ErrEnrollDuplicate so callers don't suppress real failures.
+		dupeErr := ErrEnrollDuplicate
+		if respErr != nil {
+			dupeErr = respErr
+		}
 		for _, dupe := range dupesByKey[n.dedupeKey] {
 			select {
-			case dupe.ch <- respT{err: ErrEnrollDuplicate}:
+			case dupe.ch <- respT{err: dupeErr}:
 			default:
 				panic("Unexpected blocked response channel on flushEnrollSearch dupe")
 			}

--- a/internal/pkg/bulk/opSearch.go
+++ b/internal/pkg/bulk/opSearch.go
@@ -245,16 +245,26 @@ func (b *Bulker) flushSearch(ctx context.Context, queue queueT) error {
 }
 
 // flushEnrollSearch handles the kQueueEnrollSearch queue. It:
-//  1. Groups items by dedupeKey — first occurrence is canonical, the rest are duplicates.
-//  2. Refreshes the index named by the first item's refreshIndex.
+//  1. Groups items by dedupeKey — oldest (FIFO) occurrence is canonical, the rest are duplicates.
+//  2. Refreshes all unique refreshIndex values in the batch.
 //  3. Sends an msearch containing only the canonical items.
-//  4. Dispatches results to canonical items; sends ErrEnrollDuplicate to duplicates.
+//  4. Dispatches results to canonical items; sends ErrEnrollDuplicate to duplicates (or the
+//     canonical's error if the search itself failed, to avoid hiding operational failures).
 func (b *Bulker) flushEnrollSearch(ctx context.Context, queue queueT) error {
-	// Group items: first occurrence of each dedupeKey is canonical, rest are dupes.
+	// Collect items in LIFO order from the queue (queue.head is newest), then reverse to FIFO
+	// so the oldest request becomes canonical for each dedupeKey.
+	var all []*bulkT
+	for n := queue.head; n != nil; n = n.next {
+		all = append(all, n)
+	}
+	for i, j := 0, len(all)-1; i < j; i, j = i+1, j-1 {
+		all[i], all[j] = all[j], all[i]
+	}
+
+	// Group items: oldest occurrence of each dedupeKey is canonical, rest are dupes.
 	dupesByKey := make(map[string][]*bulkT)
 	var canonicals []*bulkT
-
-	for n := queue.head; n != nil; n = n.next {
+	for _, n := range all {
 		key := n.dedupeKey
 		if _, seen := dupesByKey[key]; !seen {
 			dupesByKey[key] = nil // mark key as seen; nil slice = no dupes yet
@@ -264,12 +274,23 @@ func (b *Bulker) flushEnrollSearch(ctx context.Context, queue queueT) error {
 		}
 	}
 
-	// Refresh the index before searching so retries see the most recent writes.
-	if len(canonicals) > 0 && canonicals[0].refreshIndex != "" {
-		refreshReq := esapi.IndicesRefreshRequest{
-			Index: []string{canonicals[0].refreshIndex},
+	if len(canonicals) == 0 {
+		return nil
+	}
+
+	// Refresh all unique indices in the batch before searching so retries see the most recent writes.
+	refreshIndices := make(map[string]struct{})
+	for _, n := range canonicals {
+		if n.refreshIndex != "" {
+			refreshIndices[n.refreshIndex] = struct{}{}
 		}
-		refreshResp, err := refreshReq.Do(ctx, b.es)
+	}
+	if len(refreshIndices) > 0 {
+		idxSlice := make([]string, 0, len(refreshIndices))
+		for idx := range refreshIndices {
+			idxSlice = append(idxSlice, idx)
+		}
+		refreshResp, err := esapi.IndicesRefreshRequest{Index: idxSlice}.Do(ctx, b.es)
 		if err != nil {
 			failQueue(queue, err)
 			return nil
@@ -282,10 +303,6 @@ func (b *Bulker) flushEnrollSearch(ctx context.Context, queue queueT) error {
 			failQueue(queue, err)
 			return nil
 		}
-	}
-
-	if len(canonicals) == 0 {
-		return nil
 	}
 
 	// Build msearch body from canonical items only.

--- a/internal/pkg/bulk/opSearch.go
+++ b/internal/pkg/bulk/opSearch.go
@@ -350,9 +350,12 @@ func (b *Bulker) flushEnrollSearch(ctx context.Context, queue queueT) error {
 	}
 
 	// WARNING: Once we start pushing items to the queue, the node pointers are invalid.
+	// Save any fields we need after the channel send before sending — the receiver
+	// calls freeBlk immediately on receipt, which races with any subsequent read of n.
 	for i, n := range canonicals {
 		response := &blk.Responses[i]
 		respErr := response.deriveError()
+		key := n.dedupeKey // must be captured before n.ch send
 		select {
 		case n.ch <- respT{err: respErr, idx: n.idx, data: response}:
 		default:
@@ -364,7 +367,7 @@ func (b *Bulker) flushEnrollSearch(ctx context.Context, queue queueT) error {
 		if respErr != nil {
 			dupeErr = respErr
 		}
-		for _, dupe := range dupesByKey[n.dedupeKey] {
+		for _, dupe := range dupesByKey[key] {
 			select {
 			case dupe.ch <- respT{err: dupeErr}:
 			default:

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -26,6 +26,8 @@ type optionsT struct {
 	IgnoreUnavailable  bool
 	spanLink           apm.SpanLink
 	hasSpanLink        bool
+	DedupeKey          string
+	RefreshIndex       string
 }
 
 type Opt func(*optionsT)
@@ -63,6 +65,16 @@ func WithWaitForCheckpoints(checkpoints []int64) Opt {
 	}
 }
 
+// WithDedupeKey routes a search through kQueueEnrollSearch, which refreshes
+// refreshIndex before executing the msearch and de-dupes concurrent requests
+// with the same key, returning ErrEnrollDuplicate to all but the first.
+func WithDedupeKey(key, refreshIndex string) Opt {
+	return func(opt *optionsT) {
+		opt.DedupeKey = key
+		opt.RefreshIndex = refreshIndex
+	}
+}
+
 //-----
 // Bulk API options
 
@@ -78,6 +90,8 @@ type bulkOptT struct {
 	maxConcurrentSecretReads int
 	policyTokens             []config.PolicyToken
 	bi                       build.Info
+	enrollFlushInterval      time.Duration
+	enrollFlushThresholdCnt  int
 }
 
 type BulkOpt func(*bulkOptT)
@@ -162,6 +176,17 @@ func WithBi(bi build.Info) BulkOpt {
 	}
 }
 
+// WithEnrollFlushInterval sets the flush interval for the kQueueEnrollSearch queue.
+func WithEnrollFlushInterval(d time.Duration) BulkOpt {
+	return func(opt *bulkOptT) { opt.enrollFlushInterval = d }
+}
+
+// WithEnrollFlushThresholdCount sets the item count that triggers an early flush
+// of the kQueueEnrollSearch queue.
+func WithEnrollFlushThresholdCount(cnt int) BulkOpt {
+	return func(opt *bulkOptT) { opt.enrollFlushThresholdCnt = cnt }
+}
+
 func parseBulkOpts(opts ...BulkOpt) bulkOptT {
 	bopt := bulkOptT{
 		flushInterval:            defaultFlushInterval,
@@ -174,6 +199,8 @@ func parseBulkOpts(opts ...BulkOpt) bulkOptT {
 		maxPendingBulkDispatches: defaultMaxPendingBulkDispatches,
 		maxConcurrentSecretReads: defaultMaxConcurrentSecretReads,
 		policyTokens:             []config.PolicyToken{}, // default is empty
+		enrollFlushInterval:      time.Second,
+		enrollFlushThresholdCnt:  50,
 	}
 
 	for _, f := range opts {
@@ -193,6 +220,8 @@ func (o *bulkOptT) MarshalZerologObject(e *zerolog.Event) {
 	e.Int("apikeyMaxReqSize", o.apikeyMaxReqSize)
 	e.Int64("maxPendingBulkDispatches", o.maxPendingBulkDispatches)
 	e.Int("maxConcurrentSecretReads", o.maxConcurrentSecretReads)
+	e.Dur("enrollFlushInterval", o.enrollFlushInterval)
+	e.Int("enrollFlushThresholdCnt", o.enrollFlushThresholdCnt)
 }
 
 // BulkOptsFromCfg transforms config to a slize of BulkOpt
@@ -218,5 +247,7 @@ func BulkOptsFromCfg(cfg *config.Config) []BulkOpt {
 		WithAPIKeyMaxRequestSize(cfg.Output.Elasticsearch.MaxContentLength),
 		WithMaxPendingBulkDispatches(bulkCfg.MaxPendingBulkDispatches),
 		WithPolicyTokens(policyTokens),
+		WithEnrollFlushInterval(bulkCfg.EnrollBatcher.FlushInterval),
+		WithEnrollFlushThresholdCount(bulkCfg.EnrollBatcher.FlushThresholdCount),
 	}
 }

--- a/internal/pkg/bulk/opt.go
+++ b/internal/pkg/bulk/opt.go
@@ -247,7 +247,7 @@ func BulkOptsFromCfg(cfg *config.Config) []BulkOpt {
 		WithAPIKeyMaxRequestSize(cfg.Output.Elasticsearch.MaxContentLength),
 		WithMaxPendingBulkDispatches(bulkCfg.MaxPendingBulkDispatches),
 		WithPolicyTokens(policyTokens),
-		WithEnrollFlushInterval(bulkCfg.EnrollBatcher.FlushInterval),
-		WithEnrollFlushThresholdCount(bulkCfg.EnrollBatcher.FlushThresholdCount),
+		WithEnrollFlushInterval(bulkCfg.EnrollBulker.FlushInterval),
+		WithEnrollFlushThresholdCount(bulkCfg.EnrollBulker.FlushThresholdCount),
 	}
 }

--- a/internal/pkg/bulk/queue.go
+++ b/internal/pkg/bulk/queue.go
@@ -18,6 +18,7 @@ const (
 	kQueueRead
 	kQueueSearch
 	kQueueFleetSearch
+	kQueueEnrollSearch
 	kQueueRefreshBulk
 	kQueueRefreshRead
 	kQueueAPIKeyUpdate
@@ -34,6 +35,8 @@ func (q queueT) Type() string {
 		return "search"
 	case kQueueFleetSearch:
 		return "fleetSearch"
+	case kQueueEnrollSearch:
+		return "enrollSearch"
 	case kQueueRefreshBulk:
 		return "refreshBulk"
 	case kQueueRefreshRead:

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -49,12 +49,12 @@ type ServerTLS struct {
 	Cert string `config:"cert"`
 }
 
-type ServerBulkEnrollBatcher struct {
+type ServerBulkEnrollBulker struct {
 	FlushInterval       time.Duration `config:"flush_interval"`
 	FlushThresholdCount int           `config:"flush_threshold_cnt"`
 }
 
-func (c *ServerBulkEnrollBatcher) InitDefaults() {
+func (c *ServerBulkEnrollBulker) InitDefaults() {
 	c.FlushInterval = time.Second
 	c.FlushThresholdCount = 50
 }
@@ -65,7 +65,7 @@ type ServerBulk struct {
 	FlushThresholdSize       int                  `config:"flush_threshold_size"`
 	FlushMaxPending          int                  `config:"flush_max_pending"`
 	MaxPendingBulkDispatches int64                `config:"max_pending_bulk_dispatches"`
-	EnrollBatcher            ServerBulkEnrollBatcher `config:"enroll_batcher"`
+	EnrollBulker             ServerBulkEnrollBulker  `config:"enroll_bulker"`
 }
 
 func (c *ServerBulk) InitDefaults() {

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -60,12 +60,12 @@ func (c *ServerBulkEnrollBulker) InitDefaults() {
 }
 
 type ServerBulk struct {
-	FlushInterval            time.Duration        `config:"flush_interval"`
-	FlushThresholdCount      int                  `config:"flush_threshold_cnt"`
-	FlushThresholdSize       int                  `config:"flush_threshold_size"`
-	FlushMaxPending          int                  `config:"flush_max_pending"`
-	MaxPendingBulkDispatches int64                `config:"max_pending_bulk_dispatches"`
-	EnrollBulker             ServerBulkEnrollBulker  `config:"enroll_bulker"`
+	FlushInterval            time.Duration          `config:"flush_interval"`
+	FlushThresholdCount      int                    `config:"flush_threshold_cnt"`
+	FlushThresholdSize       int                    `config:"flush_threshold_size"`
+	FlushMaxPending          int                    `config:"flush_max_pending"`
+	MaxPendingBulkDispatches int64                  `config:"max_pending_bulk_dispatches"`
+	EnrollBulker             ServerBulkEnrollBulker `config:"enroll_bulker"`
 }
 
 func (c *ServerBulk) InitDefaults() {

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -49,12 +49,23 @@ type ServerTLS struct {
 	Cert string `config:"cert"`
 }
 
+type ServerBulkEnrollBatcher struct {
+	FlushInterval       time.Duration `config:"flush_interval"`
+	FlushThresholdCount int           `config:"flush_threshold_cnt"`
+}
+
+func (c *ServerBulkEnrollBatcher) InitDefaults() {
+	c.FlushInterval = time.Second
+	c.FlushThresholdCount = 50
+}
+
 type ServerBulk struct {
-	FlushInterval            time.Duration `config:"flush_interval"`
-	FlushThresholdCount      int           `config:"flush_threshold_cnt"`
-	FlushThresholdSize       int           `config:"flush_threshold_size"`
-	FlushMaxPending          int           `config:"flush_max_pending"`
-	MaxPendingBulkDispatches int64         `config:"max_pending_bulk_dispatches"`
+	FlushInterval            time.Duration        `config:"flush_interval"`
+	FlushThresholdCount      int                  `config:"flush_threshold_cnt"`
+	FlushThresholdSize       int                  `config:"flush_threshold_size"`
+	FlushMaxPending          int                  `config:"flush_max_pending"`
+	MaxPendingBulkDispatches int64                `config:"max_pending_bulk_dispatches"`
+	EnrollBatcher            ServerBulkEnrollBatcher `config:"enroll_batcher"`
 }
 
 func (c *ServerBulk) InitDefaults() {

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -65,7 +65,7 @@ type ServerBulk struct {
 	FlushThresholdSize       int                    `config:"flush_threshold_size"`
 	FlushMaxPending          int                    `config:"flush_max_pending"`
 	MaxPendingBulkDispatches int64                  `config:"max_pending_bulk_dispatches"`
-	EnrollBulker             ServerBulkEnrollBulker `config:"enroll_bulker"`
+	EnrollBulker             ServerBulkEnrollBulker `config:"enroll"`
 }
 
 func (c *ServerBulk) InitDefaults() {

--- a/internal/pkg/config/input.go
+++ b/internal/pkg/config/input.go
@@ -73,6 +73,7 @@ func (c *ServerBulk) InitDefaults() {
 	c.FlushThresholdCount = 2048
 	c.FlushThresholdSize = 1024 * 1024
 	c.FlushMaxPending = 8
+	c.EnrollBulker.InitDefaults()
 }
 
 // Server is the configuration for the server

--- a/internal/pkg/dl/agent.go
+++ b/internal/pkg/dl/agent.go
@@ -67,7 +67,7 @@ func GetAgent(ctx context.Context, bulker bulk.Bulk, agentID string, opt ...Opti
 
 func FindAgent(ctx context.Context, bulker bulk.Bulk, tmpl *dsl.Tmpl, name string, v any, opt ...Option) (model.Agent, error) {
 	o := newOption(FleetAgents, opt...)
-	res, err := SearchWithOneParam(ctx, bulker, tmpl, o.indexName, name, v)
+	res, err := SearchWithOneParam(ctx, bulker, tmpl, o.indexName, name, v, o.bulkOpts...)
 	if err != nil {
 		return model.Agent{}, fmt.Errorf("failed searching for agent: %w", err)
 	}

--- a/internal/pkg/dl/common.go
+++ b/internal/pkg/dl/common.go
@@ -4,8 +4,11 @@
 
 package dl
 
+import "github.com/elastic/fleet-server/v7/internal/pkg/bulk"
+
 type queryOption struct {
 	indexName string
+	bulkOpts  []bulk.Opt
 }
 
 // Option for the operation being made
@@ -17,6 +20,13 @@ type Option func(opt *queryOption)
 func WithIndexName(name string) Option {
 	return func(opt *queryOption) {
 		opt.indexName = name
+	}
+}
+
+// WithBulkOpts passes additional bulk.Opt values to the underlying bulker call.
+func WithBulkOpts(opts ...bulk.Opt) Option {
+	return func(o *queryOption) {
+		o.bulkOpts = append(o.bulkOpts, opts...)
 	}
 }
 

--- a/internal/pkg/dl/search.go
+++ b/internal/pkg/dl/search.go
@@ -26,12 +26,12 @@ func Search(ctx context.Context, bulker bulk.Bulk, tmpl *dsl.Tmpl, index string,
 	return &res.HitsT, nil
 }
 
-func SearchWithOneParam(ctx context.Context, bulker bulk.Bulk, tmpl *dsl.Tmpl, index string, name string, v any) (*es.HitsT, error) {
+func SearchWithOneParam(ctx context.Context, bulker bulk.Bulk, tmpl *dsl.Tmpl, index string, name string, v any, opts ...bulk.Opt) (*es.HitsT, error) {
 	query, err := tmpl.RenderOne(name, v)
 	if err != nil {
 		return nil, err
 	}
-	res, err := bulker.Search(ctx, index, query)
+	res, err := bulker.Search(ctx, index, query, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Enhancement -->

## What is the problem this PR solves?

At 30k+ agent scale, enrollment retries can create duplicate (ghost) agent documents in `.fleet-agents`. The root cause is ES near-real-time search latency: when an agent retries enrollment before the previous write is visible to search (default refresh interval: 1s on ES, 5s on Serverless), a concurrent retry also finds "no existing agent" and writes a second document with the same `enrollment_id`.

## How does this PR solve the problem?

Adds a new `kQueueEnrollSearch` bulker queue that batches enrollment `FindAgent` searches and, before executing them, fires a single `POST .fleet-agents/_refresh` to make all recent writes visible. Within each batch:

1. **Pre-refresh**: all unique `refreshIndex` values in the batch are refreshed so retries see the most recent writes.
2. **De-duplication**: requests sharing the same `enrollment_id` (passed via `WithDedupeKey`) are grouped by FIFO order — the oldest (first) request is canonical and is included in the msearch; duplicates receive HTTP 429 (`ErrEnrollDuplicate`) and retry after backoff.
3. **Error propagation**: if the canonical search itself returns an ES error, that error is forwarded to duplicates instead of `ErrEnrollDuplicate`, so operational failures are not silently hidden.

The queue flushes when N requests accumulate (default: 50) or after M seconds (default: 1s), whichever comes first — capping refresh calls at one per fleet-server instance per flush window. Both thresholds are configurable via `inputs[].server.bulk.enroll.flush_interval` and `inputs[].server.bulk.enroll.flush_threshold_cnt`.

## How to test this PR locally

Run the integration test added in this PR:

```
ELASTICSEARCH_HOSTS=localhost:9200 ELASTICSEARCH_SERVICE_TOKEN=<token> \
  go test -tags integration ./internal/pkg/bulk/... -run TestEnrollSearchDedup -v
```

For manual testing, set a low `flush_threshold_cnt` (e.g. 2) in config and fire concurrent enrollment requests with the same `enrollment_id`. Only one agent document should be created.

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer. _(Each instance maintains its own bulker queue; the pre-refresh + `op_type: create` write guarantees in ES ensure correctness across instances.)_
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding. _(Flush interval and threshold count cap the refresh rate; duplicates shed load via 429.)_

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the changelog tool

## Related issues

- Relates elastic/horde#532