### PR TITLE
Add support for multiple upgrade artifact source URIs

### DIFF
--- a/changelog/fragments/1787356110-support-multiple-upgrade-source-uris.yaml
+++ b/changelog/fragments/1787356110-support-multiple-upgrade-source-uris.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: feature
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Add support for multiple upgrade artifact source URIs.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+description: Adds an ordered sources field to upgrade actions for multiple upgrade artifact source URIs. The existing source_uri setting is deprecated but remains supported for backward compatibility.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: fleet-server
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -1023,9 +1023,13 @@ func convertActionData(aType ActionType, raw json.RawMessage) (ad Action_Data, e
 		if err != nil {
 			return
 		}
-		if d.Sources != nil && len(*d.Sources) > 0 {
-			sourceURI := (*d.Sources)[0]
-			d.SourceUri = &sourceURI
+		if d.Sources != nil {
+			if len(*d.Sources) > 0 {
+				sourceURI := (*d.Sources)[0]
+				d.SourceUri = &sourceURI
+			} else {
+				d.SourceUri = nil
+			}
 		} else if d.SourceUri != nil {
 			sources := []string{*d.SourceUri}
 			d.Sources = &sources

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -1031,7 +1031,10 @@ func convertActionData(aType ActionType, raw json.RawMessage) (ad Action_Data, e
 				d.SourceUri = nil
 			}
 		} else if d.SourceUri != nil {
-			sources := []string{*d.SourceUri}
+			sources := []string{}
+			if *d.SourceUri != "" {
+				sources = append(sources, *d.SourceUri)
+			}
 			d.Sources = &sources
 		}
 		err = ad.FromActionUpgrade(d)

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -1023,6 +1023,13 @@ func convertActionData(aType ActionType, raw json.RawMessage) (ad Action_Data, e
 		if err != nil {
 			return
 		}
+		if d.Sources != nil && len(*d.Sources) > 0 {
+			sourceURI := (*d.Sources)[0]
+			d.SourceUri = &sourceURI
+		} else if d.SourceUri != nil {
+			sources := []string{*d.SourceUri}
+			d.Sources = &sources
+		}
 		err = ad.FromActionUpgrade(d)
 		return
 	case REQUESTDIAGNOSTICS:

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -52,6 +52,7 @@ var (
 	ErrNoPolicyOutput         = errors.New("output section not found")
 	ErrFailInjectAPIKey       = errors.New("failure to inject api key")
 	ErrInvalidUpgradeMetadata = errors.New("invalid upgrade metadata")
+	ErrTooManyUpgradeSources  = errors.New("too many upgrade sources")
 )
 
 const (
@@ -63,6 +64,8 @@ const (
 	invalidKeyStateCleanInterval = 5 * time.Minute
 
 	invalidKeyLRUEntryBytes = 250
+
+	maxUpgradeSources = 20
 )
 
 // validActionTypes is a map of action.type and if they are valid
@@ -1024,6 +1027,10 @@ func convertActionData(aType ActionType, raw json.RawMessage) (ad Action_Data, e
 			return
 		}
 		if d.Sources != nil {
+			if len(*d.Sources) > maxUpgradeSources {
+				err = fmt.Errorf("%w: %d exceeds limit of %d", ErrTooManyUpgradeSources, len(*d.Sources), maxUpgradeSources)
+				return
+			}
 			if len(*d.Sources) > 0 {
 				sourceURI := (*d.Sources)[0]
 				d.SourceUri = &sourceURI

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -143,6 +143,12 @@ func TestConvertActionData(t *testing.T) {
 		expect: Action_Data{json.RawMessage(`{"source_uri":"https://legacy.example.com","sources":["https://legacy.example.com"],"version":"1.2.3"}`)},
 		hasErr: false,
 	}, {
+		name:   "upgrade action uses sources over source uri",
+		aType:  UPGRADE,
+		raw:    json.RawMessage(`{"source_uri":"https://legacy.example.com","sources":["https://new.example.com"],"version":"1.2.3"}`),
+		expect: Action_Data{json.RawMessage(`{"source_uri":"https://new.example.com","sources":["https://new.example.com"],"version":"1.2.3"}`)},
+		hasErr: false,
+	}, {
 		name:   "request diagnostics action",
 		aType:  REQUESTDIAGNOSTICS,
 		expect: Action_Data{},

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -161,6 +161,12 @@ func TestConvertActionData(t *testing.T) {
 		expect: Action_Data{json.RawMessage(`{"source_uri":"","sources":[],"version":"1.2.3"}`)},
 		hasErr: false,
 	}, {
+		name:   "upgrade action handles empty source_uri and sources",
+		aType:  UPGRADE,
+		raw:    json.RawMessage(`{"version":"1.2.3"}`),
+		expect: Action_Data{json.RawMessage(`{"version":"1.2.3"}`)},
+		hasErr: false,
+	}, {
 		name:   "upgrade action fails with too many sources",
 		aType:  UPGRADE,
 		raw:    json.RawMessage(`{"sources":["https://s1","https://s2","https://s3","https://s4","https://s5","https://s6","https://s7","https://s8","https://s9","https://s10","https://s11","https://s12","https://s13","https://s14","https://s15","https://s16","https://s17","https://s18","https://s19","https://s20","https://s21"],"version":"1.2.3"}`),

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -149,6 +149,18 @@ func TestConvertActionData(t *testing.T) {
 		expect: Action_Data{json.RawMessage(`{"source_uri":"https://new.example.com","sources":["https://new.example.com"],"version":"1.2.3"}`)},
 		hasErr: false,
 	}, {
+		name:   "upgrade action uses empty sources over source uri",
+		aType:  UPGRADE,
+		raw:    json.RawMessage(`{"source_uri":"https://legacy.example.com","sources":[],"version":"1.2.3"}`),
+		expect: Action_Data{json.RawMessage(`{"sources":[],"version":"1.2.3"}`)},
+		hasErr: false,
+	}, {
+		name:   "upgrade action does not populate sources from empty source uri",
+		aType:  UPGRADE,
+		raw:    json.RawMessage(`{"source_uri":"","version":"1.2.3"}`),
+		expect: Action_Data{json.RawMessage(`{"source_uri":"","sources":[],"version":"1.2.3"}`)},
+		hasErr: false,
+	}, {
 		name:   "request diagnostics action",
 		aType:  REQUESTDIAGNOSTICS,
 		expect: Action_Data{},

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -127,8 +127,20 @@ func TestConvertActionData(t *testing.T) {
 	}, {
 		name:   "upgrade action",
 		aType:  UPGRADE,
-		raw:    json.RawMessage(`{"source_uri":"https://localhost:8080","version":"1.2.3"}`),
-		expect: Action_Data{json.RawMessage(`{"source_uri":"https://localhost:8080","version":"1.2.3"}`)},
+		raw:    json.RawMessage(`{"sources":["https://localhost:8080"],"version":"1.2.3"}`),
+		expect: Action_Data{json.RawMessage(`{"source_uri":"https://localhost:8080","sources":["https://localhost:8080"],"version":"1.2.3"}`)},
+		hasErr: false,
+	}, {
+		name:   "upgrade action populates source uri from sources",
+		aType:  UPGRADE,
+		raw:    json.RawMessage(`{"sources":["https://first.example.com","https://second.example.com"],"version":"1.2.3"}`),
+		expect: Action_Data{json.RawMessage(`{"source_uri":"https://first.example.com","sources":["https://first.example.com","https://second.example.com"],"version":"1.2.3"}`)},
+		hasErr: false,
+	}, {
+		name:   "upgrade action populates sources from source uri",
+		aType:  UPGRADE,
+		raw:    json.RawMessage(`{"source_uri":"https://legacy.example.com","version":"1.2.3"}`),
+		expect: Action_Data{json.RawMessage(`{"source_uri":"https://legacy.example.com","sources":["https://legacy.example.com"],"version":"1.2.3"}`)},
 		hasErr: false,
 	}, {
 		name:   "request diagnostics action",
@@ -231,6 +243,16 @@ func TestConvertActions(t *testing.T) {
 			Type:    REQUESTDIAGNOSTICS,
 			Signed:  &ActionSignature{Data: "eyJAdGltZXN0YW==", Signature: "U6NOg4ssxpFV="},
 			Data:    Action_Data{json.RawMessage(`{}`)},
+		}},
+		token: "",
+	}, {
+		name:    "upgrade action",
+		actions: []model.Action{{ActionID: "1234", Type: "UPGRADE", Data: json.RawMessage(`{"sources":["https://first.example.com","https://second.example.com"],"version":"9.6.0"}`)}},
+		resp: []Action{{
+			AgentId: "agent-id",
+			Id:      "1234",
+			Type:    UPGRADE,
+			Data:    Action_Data{json.RawMessage(`{"source_uri":"https://first.example.com","sources":["https://first.example.com","https://second.example.com"],"version":"9.6.0"}`)},
 		}},
 		token: "",
 	}, {name: "multiple actions",

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -161,6 +161,12 @@ func TestConvertActionData(t *testing.T) {
 		expect: Action_Data{json.RawMessage(`{"source_uri":"","sources":[],"version":"1.2.3"}`)},
 		hasErr: false,
 	}, {
+		name:   "upgrade action fails with too many sources",
+		aType:  UPGRADE,
+		raw:    json.RawMessage(`{"sources":["https://s1","https://s2","https://s3","https://s4","https://s5","https://s6","https://s7","https://s8","https://s9","https://s10","https://s11","https://s12","https://s13","https://s14","https://s15","https://s16","https://s17","https://s18","https://s19","https://s20","https://s21"],"version":"1.2.3"}`),
+		expect: Action_Data{},
+		hasErr: true,
+	}, {
 		name:   "request diagnostics action",
 		aType:  REQUESTDIAGNOSTICS,
 		expect: Action_Data{},

--- a/internal/pkg/api/openapi.gen.go
+++ b/internal/pkg/api/openapi.gen.go
@@ -299,7 +299,11 @@ type ActionUpgrade struct {
 	Rollback *bool `json:"rollback,omitempty"`
 
 	// SourceUri The source of the upgrade artifact.
+	// Deprecated: Replaced by sources.
 	SourceUri *string `json:"source_uri,omitempty"`
+
+	// Sources An ordered list of sources for the upgrade artifact.
+	Sources *[]string `json:"sources,omitempty"`
 
 	// Version The version number that the agent should upgrade to.
 	Version string `json:"version"`

--- a/model/openapi.yml
+++ b/model/openapi.yml
@@ -743,6 +743,13 @@ components:
         source_uri:
           description: The source of the upgrade artifact.
           type: string
+          deprecated: true
+          x-deprecated-reason: Replaced by sources.
+        sources:
+          description: An ordered list of sources for the upgrade artifact.
+          type: array
+          items:
+            type: string
         rollback:
           description: Indicates if this version change should be performed as a rollback to a previous version.
           type: boolean

--- a/pkg/api/types.gen.go
+++ b/pkg/api/types.gen.go
@@ -296,7 +296,11 @@ type ActionUpgrade struct {
 	Rollback *bool `json:"rollback,omitempty"`
 
 	// SourceUri The source of the upgrade artifact.
+	// Deprecated: Replaced by sources.
 	SourceUri *string `json:"source_uri,omitempty"`
+
+	// Sources An ordered list of sources for the upgrade artifact.
+	Sources *[]string `json:"sources,omitempty"`
 
 	// Version The version number that the agent should upgrade to.
 	Version string `json:"version"`


### PR DESCRIPTION
## What is the problem this PR solves?

Currently, only one source for upgrade artifacts can be specified, meaning upgrades fail if that source is down.

## How does this PR solve the problem?

Adds support for sending multiple upgrade artifact source URIs in an upgrade action with a new sources that deprecates source_uri. Backwards compatibility is maintained.

## Design Checklist

- [ ] ~~I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.~~
- [ ] ~~I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- [ ] ~~I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

- Closes https://github.com/elastic/fleet-server/issues/2586
- Relates https://github.com/elastic/elastic-agent/issues/4752
- Relates https://github.com/elastic/elastic-agent/pull/16097