### PR TITLE
Compare base policy IDs in replace-enrollment check

### DIFF
--- a/changelog/fragments/1787691869-replace-enroll-versioned-policy.yaml
+++ b/changelog/fragments/1787691869-replace-enroll-versioned-policy.yaml
@@ -1,0 +1,17 @@
+kind: bug-fix
+
+summary: Allow replace-enrollment of agents assigned to version-specific policy variants
+
+description: |
+  The enroll-with-replace path rejected any agent whose document had been
+  reassigned to a version-specific policy variant (e.g. "policy#9.6") by
+  Kibana's version-specific policy assignment task, because it compared the
+  raw stored policy ID against the enrollment key's policy ID, and enrollment
+  API keys are only ever bound to the base policy. Containerized (agentless)
+  agents hit this whenever their pod was recreated after such a reassignment:
+  every re-enrollment attempt failed with AgentNotReplaceable and the agent
+  stayed offline permanently. The check now compares base policy IDs, so a
+  version-suffixed assignment no longer blocks replacement while enrolling
+  into a genuinely different policy is still rejected.
+
+component: fleet-server

--- a/internal/pkg/api/handleEnroll.go
+++ b/internal/pkg/api/handleEnroll.go
@@ -306,7 +306,10 @@ func (et *EnrollerT) _enroll(
 
 			// confirm that its on the same policy
 			// it is not supported to have it the same ID enroll into different policies
-			if agent.PolicyID != policyID {
+			// compare base policy IDs: the agent may have been reassigned to a
+			// version-specific policy variant (e.g. "policy#9.6") while enrollment
+			// API keys are only ever bound to the base policy
+			if policyBaseID(agent.PolicyID) != policyBaseID(policyID) {
 				zlog.Warn().
 					Str("AgentId", agent.Id).
 					Str("PolicyId", policyID).

--- a/internal/pkg/api/handleEnroll_test.go
+++ b/internal/pkg/api/handleEnroll_test.go
@@ -423,6 +423,88 @@ func TestEnrollWithAgentIDExistingActive(t *testing.T) {
 	assert.Equal(t, "my-policy", updateDoc.Doc[dl.FieldPolicyBaseID])
 }
 
+// TestEnrollWithAgentIDExistingActive_VersionedPolicy covers replace-enrollment of an
+// agent that has been reassigned to a version-specific policy variant (e.g. "my-policy#9.6")
+// by Kibana's version-specific policy assignment task. Enrollment API keys are only ever
+// bound to the base policy, so the enrolling agent presents the base policy ID while the
+// stored agent document carries the versioned one. The replace must compare base policy
+// IDs, otherwise the agent can never re-enroll after its container/pod is recreated.
+func TestEnrollWithAgentIDExistingActive_VersionedPolicy(t *testing.T) {
+	ctx := t.Context()
+	rb := &rollback.Rollback{}
+	zlog := zerolog.Logger{}
+	agentID := "1234"
+	replaceToken := "replace_token"
+	var pbkdf2Cfg config.PBKDF2
+	pbkdf2Cfg.InitDefaults()
+	replaceHash, err := hashReplaceToken(replaceToken, pbkdf2Cfg)
+	if err != nil {
+		t.Fatalf("error generating bcrypt hash: %v", err)
+	}
+	req := &EnrollRequest{
+		Type: "PERMANENT",
+		Id:   &agentID,
+		Metadata: EnrollMetadata{
+			UserProvided: []byte("{}"),
+			Local:        []byte("{}"),
+		},
+		ReplaceToken: &replaceToken,
+	}
+	verCon := mustBuildConstraints("8.9.0")
+	cfg := &config.Server{}
+	cfg.InitDefaults()
+	c, _ := cache.New(config.Cache{NumCounters: 100, MaxCost: 100000})
+	bulker := ftesting.NewMockBulk()
+	et, _ := NewEnrollerT(verCon, cfg, bulker, c)
+
+	// Agent document carries the version-specific policy ID; the enrollment key is
+	// bound to the base policy.
+	source := fmt.Sprintf(`{"active":true,"agent":{"id":"1234","version":"8.9.0"},"type":"PERMANENT","policy_id":"my-policy#9.6","replace_token":"%s"}`, replaceHash)
+	bulker.On("Search", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&es.ResultT{
+		HitsT: es.HitsT{
+			Hits: []es.HitT{{
+				ID:     "1234",
+				Index:  dl.FleetAgents,
+				Source: []byte(source),
+			}},
+		},
+	}, nil)
+	bulker.On("APIKeyRead", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		&apikey.APIKeyMetadata{ID: "1234"}, nil)
+	bulker.On("APIKeyInvalidate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	bulker.On("APIKeyCreate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		&apikey.APIKey{
+			ID:  "1234",
+			Key: "1234",
+		}, nil)
+	bulker.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		nil)
+	resp, err := et._enroll(ctx, rb, zlog, req, "my-policy", []string{}, "8.9.0")
+	if err != nil {
+		t.Fatalf("enroll should have succeeded for versioned policy with base enrollment key, got: %v", err)
+	}
+
+	if resp.Action != "created" {
+		t.Fatal("enroll failed")
+	}
+	if resp.Item.Id != agentID {
+		t.Fatalf("agent ID should have been %s (not %s)", agentID, resp.Item.Id)
+	}
+
+	var updateBody []byte
+	for _, c := range bulker.Calls {
+		if c.Method == "Update" {
+			updateBody = c.Arguments.Get(3).([]byte)
+			break
+		}
+	}
+	var updateDoc struct {
+		Doc map[string]any `json:"doc"`
+	}
+	assert.NoError(t, json.Unmarshal(updateBody, &updateDoc))
+	assert.Equal(t, "my-policy", updateDoc.Doc[dl.FieldPolicyBaseID])
+}
+
 func TestEnrollerT_retrieveStaticTokenEnrollmentToken(t *testing.T) {
 	bulkerBuilder := func(policies ...model.Policy) func() bulk.Bulk {
 		return func() bulk.Bulk {


### PR DESCRIPTION
## What is the problem this PR solves?

An agent that has been reassigned to a version-specific policy variant (e.g. `my-policy#9.6`) by Kibana's version-specific policy assignment task can never re-enroll via the enroll-with-replace flow. Enrollment API keys are only ever bound to the **base** policy, so the enrolling agent presents the base policy ID while the stored agent document carries the versioned one. The replace check compares the two raw IDs, sees a mismatch, and returns `AgentNotReplaceable` (403) on every attempt.

Containerized (agentless) agents hit this whenever their pod is recreated after such a reassignment — e.g. after any policy edit rolls the pod. The agent stays offline permanently and the pod crash-loops on enrollment. Observed in production (elastic/sdh-beats#7493) and reproduced in elastic/ingest-dev#9238: all 8 offline agents in the repro environment had `#9.6`-suffixed `policy_id`s with still-active agent docs, while 0 of 15 enrollment keys were bound to a versioned policy.

## How does this PR solve the problem?

The replace check now compares **base** policy IDs using the existing `policyBaseID()` helper (already used in the same file when writing `policy_base_id` on agent documents):

```go
if policyBaseID(agent.PolicyID) != policyBaseID(policyID) {
```

A version-suffixed assignment no longer blocks replacement, while enrolling into a genuinely different policy is still rejected. The replace path already leaves the agent document's `policy_id` untouched (it only resets `policy_revision_idx` and updates `policy_base_id`), so the agent keeps its version-specific assignment and receives the latest policy on next checkin.

## How to test this PR locally

Unit test `TestEnrollWithAgentIDExistingActive_VersionedPolicy` covers the exact production scenario: an existing active agent with `policy_id: "my-policy#9.6"` and a valid replace token, re-enrolling with an enrollment key bound to `"my-policy"`. It fails with `AgentNotReplaceable` before this change and passes after. `TestEnrollWithAgentIDExistingActive_WrongPolicy` verifies genuinely different policies are still rejected.

Manual reproduction (before the fix): create an agentless/containerized agent on a policy whose package declares `conditions.agent.version` (e.g. aws ≥ 7.0.0), wait for the version-specific policy assignment task to reassign the agent to `<policy>#<minor>`, then recreate the container so it re-enrolls with its replace token — enrollment loops on `AgentNotReplaceable`.

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc. (no new load paths; one string comparison changed)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Closes elastic/ingest-dev#9238
- Relates elastic/sdh-beats#7493
- Relates elastic/kibana#281074


🤖 Generated with [Claude Code](https://claude.com/claude-code)
