### PR TITLE
Skip renovate updates for internal cross-module imports

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -81,6 +81,16 @@
       "prConcurrentLimit": 10
     },
     {
+      "description": "Ignore internal fleet-server module references used in replace directives",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "/^github\\.com/elastic/fleet-server/"
+      ],
+      "enabled": false
+    },
+    {
       "description": "GitHub Actions: keep macOS runner updates manual",
       "matchManagers": [
         "github-actions"


### PR DESCRIPTION
Prevent renovate from updating internal cross-module imports of the root fleet-server module. See https://github.com/elastic/fleet-server/pull/7659 for an example.