### PR TITLE
fix: log ES 429 rejections at warn level, not error

### DIFF
--- a/changelog/fragments/1787844912-es-429-warn-level.yaml
+++ b/changelog/fragments/1787844912-es-429-warn-level.yaml
@@ -5,7 +5,6 @@ summary: Log Elasticsearch 429 rejections at warn level instead of error
 description: |
   When Elasticsearch returns a 429 (es_rejected_execution_exception), fleet-server
   was logging it at ERROR level. A 429 is transient backpressure — the agent retries
-  on its next check-in — so WARN is the appropriate level. Logging at ERROR inflated
-  the error-log rate measured by the serverless quality gate.
+  on its next check-in — so WARN is the appropriate level.
 
 component: fleet-server

--- a/changelog/fragments/1787844912-es-429-warn-level.yaml
+++ b/changelog/fragments/1787844912-es-429-warn-level.yaml
@@ -1,0 +1,11 @@
+kind: bug-fix
+
+summary: Log Elasticsearch 429 rejections at warn level instead of error
+
+description: |
+  When Elasticsearch returns a 429 (es_rejected_execution_exception), fleet-server
+  was logging it at ERROR level. A 429 is transient backpressure — the agent retries
+  on its next check-in — so WARN is the appropriate level. Logging at ERROR inflated
+  the error-log rate measured by the serverless quality gate.
+
+component: fleet-server

--- a/internal/pkg/api/error.go
+++ b/internal/pkg/api/error.go
@@ -629,11 +629,16 @@ func NewHTTPErrResp(err error) HTTPErrResp {
 
 	var esErr *es.ErrElastic
 	if errors.As(err, &esErr) {
+		level := zerolog.ErrorLevel
+		if esErr.Status == http.StatusTooManyRequests {
+			// 429 from ES is transient backpressure; the agent will retry on its next checkin.
+			level = zerolog.WarnLevel
+		}
 		return HTTPErrResp{
 			http.StatusServiceUnavailable,
 			esErr.Error(),
 			"elasticsearch error",
-			zerolog.ErrorLevel,
+			level,
 		}
 	}
 

--- a/internal/pkg/api/error_test.go
+++ b/internal/pkg/api/error_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/elastic/fleet-server/v7/internal/pkg/es"
 	testlog "github.com/elastic/fleet-server/v7/internal/pkg/testing/log"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"go.elastic.co/apm/v2"
 	"go.elastic.co/apm/v2/apmtest"
@@ -93,6 +94,28 @@ func Test_ErrorResp_NoTransaction(t *testing.T) {
 	require.Len(t, payloads.Errors, 0)
 }
 
+func Test_ErrResp_Level(t *testing.T) {
+	tests := []struct {
+		name  string
+		err   error
+		level zerolog.Level
+	}{{
+		name:  "es 429 is warn",
+		err:   &es.ErrElastic{Status: http.StatusTooManyRequests},
+		level: zerolog.WarnLevel,
+	}, {
+		name:  "es 500 is error",
+		err:   &es.ErrElastic{Status: http.StatusInternalServerError},
+		level: zerolog.ErrorLevel,
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewHTTPErrResp(tc.err)
+			require.Equal(t, tc.level, r.Level)
+		})
+	}
+}
+
 func Test_ErrResp_Status(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -110,6 +133,12 @@ func Test_ErrResp_Status(t *testing.T) {
 		name: "es error",
 		err: &es.ErrElastic{
 			Status: 500,
+		},
+		status: 503,
+	}, {
+		name: "es 429 error",
+		err: &es.ErrElastic{
+			Status: 429,
 		},
 		status: 503,
 	}, {


### PR DESCRIPTION
## What is the problem this PR solves?

When Elasticsearch returns a 429 (`es_rejected_execution_exception`) for a search on a system index (e.g. `.fleet-actions`), fleet-server logs it at **ERROR** level with message `"HTTP request error"`. This inflates the error-log rate measured by the serverless quality gate, causing gate failures even though the 429 is transient — the agent retries on its next check-in.

The specific scenario: the `endpoint.metadata_united` transform was cycling ~67×/hour in QA, saturating the `system_read` thread pool. This produced ~153k 429s from `fetchAgentPendingActions`, pushing the error rate to 5.1% (gate threshold: 1%).

## How does this PR solve the problem?

In `NewHTTPErrResp`, the `*es.ErrElastic` catch-all now checks the ES status code. If it is 429, it uses `zerolog.WarnLevel` instead of `zerolog.ErrorLevel`. All other ES errors remain at ERROR.

The ES client's built-in retry-on-status logic does **not** apply here — the 429 appears as a per-item status inside an `_msearch` response body (outer HTTP is 200), so only the per-item error is visible to fleet-server. Fleet-server returns 503 to the agent, and the agent retries on its own schedule. Logging this at ERROR is incorrect.

## How to test this PR locally

```
go test ./internal/pkg/api/ -run Test_ErrResp
```

New `Test_ErrResp_Level` asserts:
- `*es.ErrElastic{Status: 429}` → `WarnLevel`
- `*es.ErrElastic{Status: 500}` → `ErrorLevel`

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [x] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Relates https://github.com/elastic/security-team/issues/19111