### PR TITLE
fix: wait for fleet server goroutines before test teardown to eliminate data race

### DIFF
--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -229,14 +229,24 @@ func startTestServer(t *testing.T, ctx context.Context, policyD model.PolicyData
 		return nil, fmt.Errorf("unable to create server: %w", err)
 	}
 
-	g, ctx := errgroup.WithContext(ctx)
+	// Derive a cancellable context so we can guarantee the fleet server goroutine
+	// exits before testing.T is torn down. Without this, loggedRunFunc can race
+	// with the test cleanup when it logs via the zerolog TestWriter after the test
+	// has already finished.
+	srvCtx, srvCancel := context.WithCancel(ctx)
+	g, srvCtx := errgroup.WithContext(srvCtx)
 
 	g.Go(func() error {
-		return srv.Run(ctx, cfg)
+		return srv.Run(srvCtx, cfg)
+	})
+
+	t.Cleanup(func() {
+		srvCancel()
+		g.Wait() //nolint:errcheck
 	})
 
 	tsrv := &tserver{cfg: cfg, g: g, srv: srv, enrollKey: key.Token(), bulker: bulker}
-	err = tsrv.waitServerUp(ctx, testWaitServerUp)
+	err = tsrv.waitServerUp(srvCtx, testWaitServerUp)
 	if err != nil {
 		return nil, fmt.Errorf("unable to start server: %w", err)
 	}

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -242,9 +242,12 @@ func startTestServer(t *testing.T, ctx context.Context, policyD model.PolicyData
 
 	tsrv := &tserver{cfg: cfg, g: g, srv: srv, enrollKey: key.Token(), bulker: bulker}
 
+	// serverUp gates whether cleanup reports exit errors: if startup failed, the
+	// exit error is a consequence of that failure and should not be reported separately.
+	serverUp := false
 	t.Cleanup(func() {
 		srvCancel()
-		if err := tsrv.waitExit(); err != nil {
+		if err := tsrv.waitExit(); err != nil && serverUp {
 			t.Errorf("fleet server exited with unexpected error: %v", err)
 		}
 	})
@@ -253,6 +256,7 @@ func startTestServer(t *testing.T, ctx context.Context, policyD model.PolicyData
 	if err != nil {
 		return nil, fmt.Errorf("unable to start server: %w", err)
 	}
+	serverUp = true
 	return tsrv, nil
 }
 

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -240,12 +240,15 @@ func startTestServer(t *testing.T, ctx context.Context, policyD model.PolicyData
 		return srv.Run(srvCtx, cfg)
 	})
 
+	tsrv := &tserver{cfg: cfg, g: g, srv: srv, enrollKey: key.Token(), bulker: bulker}
+
 	t.Cleanup(func() {
 		srvCancel()
-		g.Wait() //nolint:errcheck
+		if err := tsrv.waitExit(); err != nil {
+			t.Errorf("fleet server exited with unexpected error: %v", err)
+		}
 	})
 
-	tsrv := &tserver{cfg: cfg, g: g, srv: srv, enrollKey: key.Token(), bulker: bulker}
 	err = tsrv.waitServerUp(srvCtx, testWaitServerUp)
 	if err != nil {
 		return nil, fmt.Errorf("unable to start server: %w", err)


### PR DESCRIPTION
## What is the problem this PR solves?

The integration tests in `internal/pkg/server` intermittently fail the race detector with:

```
WARNING: DATA RACE
Read at ... by goroutine N:
  zerolog.TestWriter.Write()
  testing.(*common).Logf()
  ...
  fleet.go:310 loggedRunFunc.func1()

Previous write at ... by goroutine M:
  testing.tRunner.func1()
```

`loggedRunFunc` (called by subsystem goroutines inside `runSubsystems`) logs when each subsystem exits using the zerolog context logger. In tests, that logger has a `zerolog.TestWriter` that writes to `testing.T.Logf`. If a subsystem goroutine logs its exit message after the test's `testing.T` has been torn down, the race detector fires.

## How does this PR solve the problem?

`startTestServer` was starting `srv.Run` in an errgroup goroutine but never guaranteed that goroutine had fully exited before `testing.T` was invalidated.

The fix: derive `srvCtx` with its own cancel from the caller-supplied context, and register a `t.Cleanup` that:
1. Calls `srvCancel()` to signal the fleet server to stop.
2. Calls `tsrv.waitExit()` to block until all goroutines have exited, failing the test if the server exits with an unexpected error.

By the time `testing.T` is cleaned up, every fleet server goroutine — including `loggedRunFunc` — has already returned.

## Related issues

- Observed in elastic/fleet-server#7712 CI run (build #16516).