### PR TITLE
fix: retry enrollment write on transient refresh-wait failure to prevent ghost agents

### DIFF
--- a/changelog/fragments/1788232734-enrollment-create-retry.yaml
+++ b/changelog/fragments/1788232734-enrollment-create-retry.yaml
@@ -1,0 +1,19 @@
+kind: bug-fix
+
+summary: Retry enrollment write on transient refresh-wait failure to prevent ghost agents
+
+description: |
+  In stateless Elasticsearch, a synchronous enrollment write (op_type=create +
+  refresh=wait_for) can commit the agent document to blob storage and then time out
+  while waiting for a search shard to acknowledge the refresh — for example when the
+  search shard is bootstrapping onto a new node after cluster scale-out. Fleet-server
+  received an error and returned 500, causing the agent to retry enrollment and create
+  a second document for the same agent. The first, now-orphaned document became a
+  "ghost" agent visible in Fleet.
+
+  fleet-server now retries the same op_type=create write once before surfacing the
+  error. If the original write committed, the retry gets 409 Conflict, which is treated
+  as success — the caller receives a valid enrollment response and no ghost is created.
+  The retry is skipped when the outer HTTP request context has expired.
+
+component: fleet-server

--- a/internal/pkg/api/handleEnroll.go
+++ b/internal/pkg/api/handleEnroll.go
@@ -663,28 +663,7 @@ func createFleetAgent(ctx context.Context, bulker bulk.Bulk, id string, agent mo
 	}
 
 	if syncWrite {
-		// Sync path: write directly with refresh=wait_for so the document is immediately
-		// visible to any retry pod's FindAgent search, preventing ghost agents.
-		req := esapi.IndexRequest{
-			Index:      dl.FleetAgents,
-			DocumentID: id,
-			Body:       bytes.NewReader(data),
-			OpType:     "create",
-			Refresh:    "wait_for",
-		}
-		res, err := req.Do(ctx, bulker.Client())
-		if err != nil {
-			return err
-		}
-		defer res.Body.Close()
-		if res.StatusCode == http.StatusConflict {
-			zerolog.Ctx(ctx).Debug().Str("agent_id", id).Msg("agent document already exists on enrollment create, treating as success")
-			return nil
-		}
-		if res.IsError() {
-			return fmt.Errorf("createFleetAgent: %s", res.String())
-		}
-		return nil
+		return createFleetAgentSync(ctx, bulker, id, data)
 	}
 
 	_, err = bulker.Create(ctx, dl.FleetAgents, id, data, bulk.WithRefresh())
@@ -694,6 +673,55 @@ func createFleetAgent(ctx context.Context, bulker bulk.Bulk, id string, agent mo
 		return nil
 	}
 	return err
+}
+
+// createFleetAgentSync writes the agent document using op_type=create + refresh=wait_for.
+// It retries once on failure because in stateless ES the primary shard can commit the
+// write and upload it to blob storage before the search-shard refresh notification
+// times out (e.g. when the search shard is bootstrapping onto a new node after cluster
+// scale-out). In that window the client receives an error even though the document IS
+// durable; a retry with op_type=create on the same document ID gets 409 Conflict, which
+// this function treats as success — preventing the caller from creating a second
+// document for the same agent (a ghost).
+func createFleetAgentSync(ctx context.Context, bulker bulk.Bulk, id string, data []byte) error {
+	zlog := zerolog.Ctx(ctx)
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		if attempt > 0 {
+			// Before retrying, confirm the outer request context is still alive.
+			// If it has expired there is no point issuing another ES request.
+			if ctx.Err() != nil {
+				return lastErr
+			}
+			zlog.Warn().Str("agent_id", id).Err(lastErr).Msg("retrying enrollment write after transient failure")
+		}
+
+		req := esapi.IndexRequest{
+			Index:      dl.FleetAgents,
+			DocumentID: id,
+			Body:       bytes.NewReader(data),
+			OpType:     "create",
+			Refresh:    "wait_for",
+		}
+		res, doErr := req.Do(ctx, bulker.Client())
+		if doErr != nil {
+			lastErr = doErr
+			continue
+		}
+		if res.StatusCode == http.StatusConflict {
+			_ = res.Body.Close()
+			zlog.Debug().Str("agent_id", id).Msg("agent document already exists on enrollment create, treating as success")
+			return nil
+		}
+		if res.IsError() {
+			lastErr = fmt.Errorf("createFleetAgent: %s", res.String())
+			_ = res.Body.Close()
+			continue
+		}
+		_ = res.Body.Close()
+		return nil
+	}
+	return lastErr
 }
 
 func generateAccessAPIKey(ctx context.Context, bulk bulk.Bulk, agentID string) (*apikey.APIKey, error) {

--- a/internal/pkg/api/handleEnroll_test.go
+++ b/internal/pkg/api/handleEnroll_test.go
@@ -654,6 +654,100 @@ func TestCreateFleetAgentSyncWriteErrorSurfaces(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestCreateFleetAgentSyncWriteRetry covers the ghost-agent prevention retry path:
+// when the primary shard commits the enrollment write but the search-shard
+// refresh notification times out (a known stateless-ES failure mode during shard
+// bootstrapping), fleet-server retries the same op_type=create. If ES returns 409
+// Conflict the original write is confirmed durable and we treat it as success.
+func TestCreateFleetAgentSyncWriteRetry(t *testing.T) {
+	syncResponse := func(code int) *http.Response {
+		return &http.Response{
+			StatusCode: code,
+			Body:       io.NopCloser(strings.NewReader(`{}`)),
+			Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+		}
+	}
+	// DisableRetry prevents the go-elasticsearch transport from adding its own
+	// retry loop on top of the retry loop we're testing here.
+	noRetryClient := func(t *testing.T, mt *MockTransport) *elasticsearch.Client {
+		t.Helper()
+		cli, err := elasticsearch.NewClient(elasticsearch.Config{Transport: mt, DisableRetry: true})
+		require.NoError(t, err)
+		return cli
+	}
+
+	t.Run("transient error then 409 succeeds", func(t *testing.T) {
+		attempt := 0
+		mt := &MockTransport{}
+		mt.RoundTripFn = func(req *http.Request) (*http.Response, error) {
+			assertSyncEnrollParams(t, req)
+			attempt++
+			if attempt == 1 {
+				return nil, errors.New("context deadline exceeded")
+			}
+			return syncResponse(http.StatusConflict), nil
+		}
+		bulker := ftesting.NewMockBulk()
+		bulker.On("Client").Return(noRetryClient(t, mt))
+
+		err := createFleetAgent(t.Context(), bulker, "test-agent-id", model.Agent{}, true)
+		require.NoError(t, err)
+		require.Equal(t, 2, attempt)
+	})
+
+	t.Run("transient error then 201 succeeds", func(t *testing.T) {
+		attempt := 0
+		mt := &MockTransport{}
+		mt.RoundTripFn = func(req *http.Request) (*http.Response, error) {
+			assertSyncEnrollParams(t, req)
+			attempt++
+			if attempt == 1 {
+				return nil, errors.New("context deadline exceeded")
+			}
+			return syncResponse(http.StatusCreated), nil
+		}
+		bulker := ftesting.NewMockBulk()
+		bulker.On("Client").Return(noRetryClient(t, mt))
+
+		err := createFleetAgent(t.Context(), bulker, "test-agent-id", model.Agent{}, true)
+		require.NoError(t, err)
+		require.Equal(t, 2, attempt)
+	})
+
+	t.Run("persistent error on both attempts surfaces error", func(t *testing.T) {
+		attempt := 0
+		mt := &MockTransport{}
+		mt.RoundTripFn = func(req *http.Request) (*http.Response, error) {
+			assertSyncEnrollParams(t, req)
+			attempt++
+			return nil, errors.New("persistent error")
+		}
+		bulker := ftesting.NewMockBulk()
+		bulker.On("Client").Return(noRetryClient(t, mt))
+
+		err := createFleetAgent(t.Context(), bulker, "test-agent-id", model.Agent{}, true)
+		require.Error(t, err)
+		require.Equal(t, 2, attempt)
+	})
+
+	t.Run("context cancelled before retry aborts with last error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		attempt := 0
+		mt := &MockTransport{}
+		mt.RoundTripFn = func(req *http.Request) (*http.Response, error) {
+			attempt++
+			cancel() // cancel context so the retry guard sees an expired ctx
+			return nil, errors.New("transient error")
+		}
+		bulker := ftesting.NewMockBulk()
+		bulker.On("Client").Return(noRetryClient(t, mt))
+
+		err := createFleetAgent(ctx, bulker, "test-agent-id", model.Agent{}, true)
+		require.Error(t, err)
+		require.Equal(t, 1, attempt) // only one attempt; retry aborted due to cancelled ctx
+	})
+}
+
 func TestValidateEnrollRequest(t *testing.T) {
 	t.Run("invalid json", func(t *testing.T) {
 		req, err := validateRequest(context.Background(), strings.NewReader("not a json"))


### PR DESCRIPTION
⚠️ _I would like someone from the Elasticsearch team to confirm the root cause mentioned below before putting this PR into review._

## What is the problem this PR solves?

In stateless Elasticsearch, the primary (index) shard is not searchable — search queries are handled by separate `SEARCH_ONLY` shard nodes. In stateless, the primary has role `INDEX_ONLY` (`promotable=true, searchable=false`) and search replicas have role `SEARCH_ONLY` (`promotable=false, searchable=true`) ([`ShardRouting.java:937`](https://github.com/elastic/elasticsearch/blob/71e50fce48adb6239e2b22f2aa8897f8c6b426f6/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java#L937-L939), [`StatelessShardRoutingRoleStrategy.java:17`](https://github.com/elastic/elasticsearch/blob/71e50fce48adb6239e2b22f2aa8897f8c6b426f6/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/allocation/StatelessShardRoutingRoleStrategy.java#L17)). Fleet-server uses `refresh=wait_for` so enrollment blocks until those `SEARCH_ONLY` shards have loaded the new agent document, at which point credentials are returned and Horde can immediately verify them.

When `refresh=wait_for` is used on a non-searchable (`INDEX_ONLY`) primary, `PostWriteRefresh.refreshUnpromotables` ([`PostWriteRefresh.java:104`](https://github.com/elastic/elasticsearch/blob/71e50fce48adb6239e2b22f2aa8897f8c6b426f6/server/src/main/java/org/elasticsearch/action/support/replication/PostWriteRefresh.java#L104)) registers a flush listener that, once the Lucene commit completes, sends an `UnpromotableShardRefreshRequest` to each `SEARCH_ONLY` shard node. Each `SEARCH_ONLY` shard must call `waitForPrimaryTermAndGeneration` ([`TransportUnpromotableShardRefreshAction.java:181`](https://github.com/elastic/elasticsearch/blob/71e50fce48adb6239e2b22f2aa8897f8c6b426f6/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportUnpromotableShardRefreshAction.java#L181)) to confirm it has loaded the new generation from blob storage before the write response is returned to the caller.

A `SEARCH_ONLY` shard that is bootstrapping onto a new node cannot respond to that notification. This happens in (at least) two observed scenarios:

1. **ES cluster scale-out** — the autoscaler adds nodes and shard rebalancing migrates `.fleet-agents` to a new node. Observed in [build #6895](https://buildkite.com/elastic/observability-perf/builds/6895): EPA over-provisioned fleet-server to 113 pods, causing ES to autoscale 3 new nodes (00:17:53–00:18:11 UTC). Shard bootstrapping windows at 00:22:25, 00:22:39, 00:24:55, 00:26:44 UTC produced 232 ghost agents.

2. **ES index-node rolling update** — a Kubernetes rolling restart of the `es-es-index` deployment terminates old pods one by one, each handoff migrating the `.fleet-agents` `INDEX_ONLY` shard via peer recovery to a new pod, triggering a fresh `SEARCH_ONLY` bootstrapping window on each migration. Observed in [build #6897](https://buildkite.com/elastic/observability-perf/builds/6897): 10+ ES index pods received SIGTERM between 06:48–06:56 UTC; the `.fleet-agents-7[0]` shard migrated across 4 distinct node replicasets; 42 `"failed to notify search shards after create commit"` events ([`StatelessCommitService.java:2370`](https://github.com/elastic/elasticsearch/blob/71e50fce48adb6239e2b22f2aa8897f8c6b426f6/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitService.java#L2370)) in two windows (06:52:27 and 06:55:50 UTC) produced 13 ghost agents. This run used only ~52 fleet-server pods — the same count as the passing run — confirming the failure is not bounded by EPA tuning.

In both cases the notification timeout causes fleet-server to return HTTP 500 — but the underlying Lucene commit is not rolled back. As `InternalEngine.addFlushListener` documents ([`InternalEngine.java:4163`](https://github.com/elastic/elasticsearch/blob/71e50fce48adb6239e2b22f2aa8897f8c6b426f6/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java#L4163)): *"flush does not imply commit durability"* — durability (blob storage upload) is handled separately by `IndexEngine.waitForCommitDurability` ([`IndexEngine.java:855`](https://github.com/elastic/elasticsearch/blob/71e50fce48adb6239e2b22f2aa8897f8c6b426f6/x-pack/plugin/stateless/src/main/java/org/elasticsearch/xpack/stateless/engine/IndexEngine.java#L855)) and proceeds independently of the refresh notification. The document will eventually become visible once the `SEARCH_ONLY` shard finishes bootstrapping.

Fleet-server returned 500 to Horde. Horde retried enrollment with the same enrollment ID. At retry time, `FindAgent` searched the still-bootstrapping shard, got "not found", and fleet-server created a second agent document under a new UUID. When the original document later became visible, it appeared as a "ghost" agent in Fleet — counted in the total agent count but never having checked in.

## How does this PR solve the problem?

Fleet-server retries the `op_type=create` enrollment write once before surfacing the error. Because `op_type=create` is idempotent on the document ID, a retry that finds the original write already committed receives `409 Conflict`, which is treated as success — the caller gets a valid enrollment response and no ghost is created. The retry is skipped when the outer HTTP request context has expired.

## How to test this PR locally

Run the `api` package tests:
```
go test ./internal/pkg/api/...
```

`TestCreateFleetAgentSyncWriteRetry` covers four cases: transient error → 409 success, transient error → 201 success, persistent error on both attempts, and context cancellation before retry.

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [x] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)
