### PR TITLE
Fix processPolicy using shared secret keys between agents

### DIFF
--- a/changelog/fragments/1788278234-fix-secret-keys-corruption.yaml
+++ b/changelog/fragments/1788278234-fix-secret-keys-corruption.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Fix secret keys corruption in policy processing
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: fleet-server
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -1084,6 +1084,7 @@ func processPolicy(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, a
 	}
 
 	data := model.ClonePolicyData(pp.Policy.Data)
+	secretKeys := slices.Clone(pp.SecretKeys)
 	for name, policyOutput := range data.Outputs {
 		// NOTE: Not sure if output secret keys collected here include new entries, but they are collected for completeness
 		ks, err := secret.ProcessOutputSecret(policyOutput, secretValues)
@@ -1091,7 +1092,7 @@ func processPolicy(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, a
 			return nil, fmt.Errorf("failed to process output secret for output %q: %w", name, err)
 		}
 		for _, key := range ks {
-			pp.SecretKeys = append(pp.SecretKeys, "outputs."+name+"."+key)
+			secretKeys = append(secretKeys, "outputs."+name+"."+key)
 		}
 	}
 	// Iterate through the policy outputs and prepare them
@@ -1111,7 +1112,7 @@ func processPolicy(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, a
 		}
 		if _, ok := data.Outputs[name][policy.FieldOutputServiceToken]; !ok {
 			prefixed := "outputs." + name + "." + policy.FieldOutputServiceToken
-			pp.SecretKeys = slices.DeleteFunc(pp.SecretKeys, func(key string) bool {
+			secretKeys = slices.DeleteFunc(secretKeys, func(key string) bool {
 				return key == prefixed
 			})
 		}
@@ -1135,8 +1136,8 @@ func processPolicy(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, a
 		return nil, err
 	}
 	// remove duplicates from secretkeys
-	slices.Sort(pp.SecretKeys)
-	keys := slices.Compact(pp.SecretKeys)
+	slices.Sort(secretKeys)
+	keys := slices.Compact(secretKeys)
 	d.SecretPaths = keys
 	ad := Action_Data{}
 	err = ad.FromActionPolicyChange(ActionPolicyChange{d})

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -18,7 +18,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1858,4 +1860,88 @@ func TestProcessPolicyRemoteESServiceTokenSecretPaths(t *testing.T) {
 	_, hasServiceToken := remotePolicy["service_token"]
 	assert.False(t, hasServiceToken, "service_token should be deleted by Prepare before delivery to agents")
 	assert.Equal(t, policy.OutputTypeElasticsearch, remotePolicy["type"])
+}
+
+// TestProcessPolicySecretPathsConcurrentDispatch ensures processPolicy does not
+// mutate the shared ParsedPolicy.SecretKeys when concurrent checkin goroutines
+// process the same policy fan-out.
+// Regression test for https://github.com/elastic/fleet-server/issues/7739
+func TestProcessPolicySecretPathsConcurrentDispatch(t *testing.T) {
+	logger := testlog.SetLogger(t)
+
+	const payload = `{
+		"outputs": {
+			"remote": {
+				"type": "remote_elasticsearch",
+				"secrets": {"service_token": {"id": "ST_ID"}}
+			}
+		},
+		"output_permissions": {
+			"remote": {
+				"_fallback": {
+					"indices": [{"names": ["logs-*"], "privileges": ["auto_configure", "create_doc"]}]
+				}
+			}
+		}
+	}`
+
+	const agents = 2
+
+	var d model.PolicyData
+	err := json.Unmarshal([]byte(payload), &d)
+	require.NoError(t, err)
+
+	bulker := ftesting.NewMockBulk()
+	pp, err := policy.NewParsedPolicy(t.Context(), bulker, model.Policy{
+		PolicyID:    "policy1",
+		RevisionIdx: 1,
+		Data:        &d,
+	})
+	require.NoError(t, err)
+
+	remoteOut := pp.Outputs["remote"]
+	require.NotNil(t, remoteOut.Role)
+
+	bulker.On("CreateAndGetBulker", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(ftesting.NewMockBulk(), false, nil)
+
+	baseline := slices.Clone(pp.SecretKeys)
+	remoteKey := bulk.APIKey{ID: "remote-id", Key: "remote-key"}
+
+	var wg sync.WaitGroup
+	secretPaths := make([][]string, agents)
+	errs := make([]error, agents)
+	for a := range agents {
+		agent := &model.Agent{
+			ESDocument: model.ESDocument{Id: fmt.Sprintf("agent%d", a)},
+			Outputs: map[string]*model.PolicyOutput{
+				"remote": {
+					APIKey:          remoteKey.Agent(),
+					APIKeyID:        remoteKey.ID,
+					PermissionsHash: remoteOut.Role.Sha2,
+					Type:            policy.OutputTypeRemoteElasticsearch,
+				},
+			},
+		}
+		wg.Go(func() {
+			action, err := processPolicy(t.Context(), logger, bulker, agent, pp, nil)
+			if err != nil {
+				errs[a] = err
+				return
+			}
+			pc, err := action.Data.AsActionPolicyChange()
+			if err != nil {
+				errs[a] = err
+				return
+			}
+			secretPaths[a] = pc.Policy.SecretPaths
+		})
+	}
+	wg.Wait()
+
+	for a := range agents {
+		require.NoError(t, errs[a])
+		assert.NotContains(t, secretPaths[a], "", "agent %d received a corrupt empty secret path", a)
+	}
+	assert.Equal(t, baseline, pp.SecretKeys, "shared ParsedPolicy.SecretKeys was mutated")
 }

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -1873,7 +1873,10 @@ func TestProcessPolicySecretPathsConcurrentDispatch(t *testing.T) {
 		"outputs": {
 			"remote": {
 				"type": "remote_elasticsearch",
-				"secrets": {"service_token": {"id": "ST_ID"}}
+				"secrets": {
+					"service_token": {"id": "ST_ID"},
+					"ssl": {"key": {"id": "SSL_KEY_ID"}}
+				}
 			}
 		},
 		"output_permissions": {
@@ -1941,7 +1944,7 @@ func TestProcessPolicySecretPathsConcurrentDispatch(t *testing.T) {
 
 	for a := range agents {
 		require.NoError(t, errs[a])
-		assert.NotContains(t, secretPaths[a], "", "agent %d received a corrupt empty secret path", a)
+		assert.Equal(t, []string{"outputs.remote.ssl.key"}, secretPaths[a], "agent %d received incorrect secret paths", a)
 	}
 	assert.Equal(t, baseline, pp.SecretKeys, "shared ParsedPolicy.SecretKeys was mutated")
 }


### PR DESCRIPTION
## What is the problem this PR solves?

Dispatch of a new policy revision sends a pointer to a single ParsedPolicy to every agent's checkin goroutine. Each processPolicy then mutates this ParsedPolicy's SecretKeys with no synchronization. This results in agents potentially receiving a [""] in secret paths, which causes them to crashloop.

## How does this PR solve the problem?

Fix processPolicy so that processPolicy for each agent doesn't mutate shared ParsedPolicy.SecretKeys.

## How to test this PR locally

`go test -race -count=1 -run TestProcessPolicySecretPathsConcurrentDispatch ./internal/pkg/api/`

## Design Checklist

- [X] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- ~~[ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~[ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)


## Related issues

- Closes #7739
- Relates https://github.com/elastic/sdh-beats/issues/7546
