### PR TITLE
fix: add detailed logging for sync enrollment write failures

### DIFF
--- a/internal/pkg/api/api.go
+++ b/internal/pkg/api/api.go
@@ -114,7 +114,7 @@ func (a *apiServer) AgentEnroll(w http.ResponseWriter, r *http.Request, params A
 	rb := rollback.New(zlog)
 	defer func() {
 		if err != nil {
-			zlog.Info().Err(err).Msg("perform rollback on enrollment failure")
+			zlog.Warn().Err(err).Msg("perform rollback on enrollment failure")
 			err = rb.Rollback(r.Context())
 			if err != nil {
 				zlog.Error().Err(err).Msg("rollback error on enrollment failure")

--- a/internal/pkg/api/handleEnroll.go
+++ b/internal/pkg/api/handleEnroll.go
@@ -672,17 +672,21 @@ func createFleetAgent(ctx context.Context, bulker bulk.Bulk, id string, agent mo
 			OpType:     "create",
 			Refresh:    "wait_for",
 		}
-		res, err := req.Do(ctx, bulker.Client())
-		if err != nil {
-			return err
+		zlog := zerolog.Ctx(ctx)
+		res, doErr := req.Do(ctx, bulker.Client())
+		if doErr != nil {
+			zlog.Warn().Str("agent_id", id).Err(doErr).Msg("enrollment write transport error")
+			return doErr
 		}
 		defer res.Body.Close()
 		if res.StatusCode == http.StatusConflict {
-			zerolog.Ctx(ctx).Debug().Str("agent_id", id).Msg("agent document already exists on enrollment create, treating as success")
+			zlog.Debug().Str("agent_id", id).Msg("agent document already exists on enrollment create, treating as success")
 			return nil
 		}
 		if res.IsError() {
-			return fmt.Errorf("createFleetAgent: %s", res.String())
+			esResp := res.String()
+			zlog.Warn().Str("agent_id", id).Int("status_code", res.StatusCode).Str("es_response", esResp).Msg("enrollment write ES error")
+			return fmt.Errorf("createFleetAgent: %s", esResp)
 		}
 		return nil
 	}

--- a/internal/pkg/rollback/rollback.go
+++ b/internal/pkg/rollback/rollback.go
@@ -41,7 +41,7 @@ func (r *Rollback) Register(name string, fn RollbackFunc) {
 func (r *Rollback) Rollback(ctx context.Context) (err error) {
 	for _, rb := range r.rbi {
 		log := r.log.With().Str("rollback_fn_name", rb.name).Logger()
-		log.Debug().Msg("rollback function called")
+		log.Info().Msg("rollback function called")
 		if rerr := rb.fn(ctx); rerr != nil {
 			log.Error().Err(rerr).Msgf("rollback function %q failed", rb.name)
 			if err == nil {


### PR DESCRIPTION
## Summary

- Log transport errors from the \`refresh=wait_for\` enrollment write as \`Warn\` so the cause of failures is visible in production (previously the error was only surfaced at rollback time with no indication it came from the ES write).
- Log ES error responses as \`Warn\` with \`status_code\` and \`es_response\` (full response body) as structured fields, making the ES-side reason for failure searchable.
- Promote the "perform rollback on enrollment failure" log from \`Info\` → \`Warn\` — this event correlates with potential ghost agent creation.
- Promote the per-function rollback execution log in \`rollback.go\` from \`Debug\` → \`Info\` so it is visible in production, making it legible which cleanup actions ran (and that "delete agent" is absent when the write itself failed).

## References

Relates #7741