### PR TITLE
feat(checkin): log per-item ES write failures from checkin bulk flush

### DIFF
--- a/internal/pkg/checkin/bulk.go
+++ b/internal/pkg/checkin/bulk.go
@@ -405,11 +405,13 @@ func (bc *Bulk) flush(ctx context.Context) error {
 func logCheckinBulkErrors(zlog *zerolog.Logger, items []bulk.BulkIndexerResponseItem) {
 	var totalErr, versionConflicts int
 	var sampleID string
+	var sampleStatus int
 	var sampleErr json.RawMessage
 	for _, item := range items {
 		if item.Status >= http.StatusBadRequest {
 			if totalErr == 0 {
 				sampleID = item.DocumentID
+				sampleStatus = item.Status
 				sampleErr = item.Error
 			}
 			totalErr++
@@ -423,7 +425,8 @@ func logCheckinBulkErrors(zlog *zerolog.Logger, items []bulk.BulkIndexerResponse
 			Int("failed", totalErr).
 			Int("version_conflicts", versionConflicts).
 			Int("total", len(items)).
-			Str("sample_agent_id", sampleID)
+			Str("sample_agent_id", sampleID).
+			Int("sample_status", sampleStatus)
 		if len(sampleErr) > 0 {
 			ev = ev.RawJSON("sample_error", sampleErr)
 		}

--- a/internal/pkg/checkin/bulk.go
+++ b/internal/pkg/checkin/bulk.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"sync"
 	"time"
 
@@ -385,7 +386,7 @@ func (bc *Bulk) flush(ctx context.Context) error {
 		opts = append(opts, bulk.WithRefresh())
 	}
 
-	_, err = bc.bulker.MUpdate(ctx, updates, opts...)
+	items, err := bc.bulker.MUpdate(ctx, updates, opts...)
 
 	zerolog.Ctx(ctx).Trace().
 		Err(err).
@@ -394,7 +395,40 @@ func (bc *Bulk) flush(ctx context.Context) error {
 		Bool("refresh", needRefresh).
 		Msg("Flush updates")
 
+	logCheckinBulkErrors(zerolog.Ctx(ctx), items)
+
 	return err
+}
+
+// logCheckinBulkErrors logs a summary when MUpdate returns per-item ES failures.
+// Version conflicts on updating→online transitions are otherwise silently dropped.
+func logCheckinBulkErrors(zlog *zerolog.Logger, items []bulk.BulkIndexerResponseItem) {
+	var totalErr, versionConflicts int
+	var sampleID string
+	var sampleErr json.RawMessage
+	for _, item := range items {
+		if item.Status >= http.StatusBadRequest {
+			if totalErr == 0 {
+				sampleID = item.DocumentID
+				sampleErr = item.Error
+			}
+			totalErr++
+			if item.Status == http.StatusConflict {
+				versionConflicts++
+			}
+		}
+	}
+	if totalErr > 0 {
+		ev := zlog.Warn().
+			Int("failed", totalErr).
+			Int("version_conflicts", versionConflicts).
+			Int("total", len(items)).
+			Str("sample_agent_id", sampleID)
+		if len(sampleErr) > 0 {
+			ev = ev.RawJSON("sample_error", sampleErr)
+		}
+		ev.Msg("checkin bulk: per-item ES write failures")
+	}
 }
 
 func toUpdateBody(now string, pending pendingT) ([]byte, error) {


### PR DESCRIPTION
## What is the problem this PR solves?

When fleet-server's checkin bulk flush writes agent status updates to ES via `MUpdate`, individual write failures (e.g. version conflicts on `updating→online` transitions during an upgrade) are silently dropped. The only signal is the batch-level `"Eat bulk checkin error; Keep on truckin'"` log, which gives no count, no agent IDs, and no error types. This makes it impossible to diagnose why agents stay stuck in `updating` after an upgrade completes.

## How does this PR solve the problem?

`MUpdate` already returns `[]BulkIndexerResponseItem` with per-agent document IDs, HTTP status codes, and ES error bodies — but the return value was always discarded (`_`).

This PR captures the items slice and passes it to a new `logCheckinBulkErrors` helper that emits a single `Warn` log per flush interval (every 10s) containing:
- `failed` / `total`: count of agents whose writes failed vs. batch size
- `version_conflicts`: count of 409s specifically (the signature of a stuck `updating→online` transition)
- `sample_agent_id` + `sample_error`: one concrete example for ES lookup

One log line per flush keeps noise low while making the failure visible during an upgrade-stuck scenario.

## How to test this PR locally

Run a local fleet-server against a staging ES. Trigger a version conflict on a bulk checkin update (e.g. by racing an external `_update` against the checkin flush with a mismatched `seq_no`). The `"checkin bulk: per-item ES write failures"` log should appear with `version_conflicts: 1`.

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [x] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected. (One Warn per 10s flush regardless of batch size — no per-agent log fan-out.)
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc. (N/A — read-only logging path.)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues

- Relates #7741