### PR TITLE
feat: log enrollment_id on successful enrollment

### DIFF
--- a/internal/pkg/api/handleEnroll.go
+++ b/internal/pkg/api/handleEnroll.go
@@ -597,7 +597,7 @@ func writeResponse(ctx context.Context, zlog zerolog.Logger, w http.ResponseWrit
 		Str(LogPolicyID, resp.Item.PolicyId).
 		Str(LogAccessAPIKeyID, resp.Item.AccessApiKeyId)
 	if enrollmentID != "" {
-		logEvent = logEvent.Str("enrollment_id", enrollmentID)
+		logEvent = logEvent.Str(dl.FieldEnrollmentID, enrollmentID)
 	}
 	logEvent.
 		Int(ECSHTTPResponseBodyBytes, numWritten).

--- a/internal/pkg/api/handleEnroll.go
+++ b/internal/pkg/api/handleEnroll.go
@@ -100,28 +100,28 @@ func (et *EnrollerT) handleEnroll(zlog zerolog.Logger, w http.ResponseWriter, r 
 		return err
 	}
 
-	resp, err := et.processRequest(zlog, w, r, rb, key, ver)
+	resp, enrollmentID, err := et.processRequest(zlog, w, r, rb, key, ver)
 	if err != nil {
 		return err
 	}
 
 	ts, _ := logger.CtxStartTime(r.Context())
-	return writeResponse(r.Context(), zlog, w, resp, ts)
+	return writeResponse(r.Context(), zlog, w, resp, enrollmentID, ts)
 }
 
-func (et *EnrollerT) processRequest(zlog zerolog.Logger, w http.ResponseWriter, r *http.Request, rb *rollback.Rollback, enrollmentAPIKey *apikey.APIKey, ver string) (*EnrollResponse, error) {
+func (et *EnrollerT) processRequest(zlog zerolog.Logger, w http.ResponseWriter, r *http.Request, rb *rollback.Rollback, enrollmentAPIKey *apikey.APIKey, ver string) (*EnrollResponse, string, error) {
 	// Validate that an enrollment record exists for a key with this id.
 	var enrollAPI *model.EnrollmentAPIKey
 	enrollAPI, err := et.retrieveStaticTokenEnrollmentToken(r.Context(), zlog, enrollmentAPIKey)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	if enrollAPI == nil {
 		zlog.Debug().Msgf("Checking enrollment key from database %s", enrollmentAPIKey.ID)
 		key, err := et.fetchEnrollmentKeyRecord(r.Context(), enrollmentAPIKey.ID)
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		zlog.Debug().Msgf("Found enrollment key %s", key.APIKeyID)
 		enrollAPI = key
@@ -138,12 +138,18 @@ func (et *EnrollerT) processRequest(zlog zerolog.Logger, w http.ResponseWriter, 
 	// Parse the request body
 	req, err := validateRequest(r.Context(), readCounter)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	cntEnroll.bodyIn.Add(readCounter.Count())
 
-	return et._enroll(r.Context(), rb, zlog, req, enrollAPI.PolicyID, enrollAPI.Namespaces, ver)
+	var enrollmentID string
+	if req.EnrollmentId != nil {
+		enrollmentID = *req.EnrollmentId
+	}
+
+	resp, err := et._enroll(r.Context(), rb, zlog, req, enrollAPI.PolicyID, enrollAPI.Namespaces, ver)
+	return resp, enrollmentID, err
 }
 
 // retrieveStaticTokenEnrollmentToken fetches the enrollment key record from the config static tokens.
@@ -570,7 +576,7 @@ LOOP:
 	return nil
 }
 
-func writeResponse(ctx context.Context, zlog zerolog.Logger, w http.ResponseWriter, resp *EnrollResponse, start time.Time) error {
+func writeResponse(ctx context.Context, zlog zerolog.Logger, w http.ResponseWriter, resp *EnrollResponse, enrollmentID string, start time.Time) error {
 	span, _ := apm.StartSpan(ctx, "response", "write")
 	defer span.End()
 
@@ -590,6 +596,7 @@ func writeResponse(ctx context.Context, zlog zerolog.Logger, w http.ResponseWrit
 		Str(LogAgentID, resp.Item.Id).
 		Str(LogPolicyID, resp.Item.PolicyId).
 		Str(LogAccessAPIKeyID, resp.Item.AccessApiKeyId).
+		Str("enrollment_id", enrollmentID).
 		Int(ECSHTTPResponseBodyBytes, numWritten).
 		Int64(ECSEventDuration, time.Since(start).Nanoseconds()).
 		Msg("Elastic Agent successfully enrolled")

--- a/internal/pkg/api/handleEnroll.go
+++ b/internal/pkg/api/handleEnroll.go
@@ -592,11 +592,14 @@ func writeResponse(ctx context.Context, zlog zerolog.Logger, w http.ResponseWrit
 		return fmt.Errorf("fail send enroll response: %w", err)
 	}
 
-	zlog.Info().
+	logEvent := zlog.Info().
 		Str(LogAgentID, resp.Item.Id).
 		Str(LogPolicyID, resp.Item.PolicyId).
-		Str(LogAccessAPIKeyID, resp.Item.AccessApiKeyId).
-		Str("enrollment_id", enrollmentID).
+		Str(LogAccessAPIKeyID, resp.Item.AccessApiKeyId)
+	if enrollmentID != "" {
+		logEvent = logEvent.Str("enrollment_id", enrollmentID)
+	}
+	logEvent.
 		Int(ECSHTTPResponseBodyBytes, numWritten).
 		Int64(ECSEventDuration, time.Since(start).Nanoseconds()).
 		Msg("Elastic Agent successfully enrolled")

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -229,14 +229,24 @@ func startTestServer(t *testing.T, ctx context.Context, policyD model.PolicyData
 		return nil, fmt.Errorf("unable to create server: %w", err)
 	}
 
-	g, ctx := errgroup.WithContext(ctx)
+	// Derive a cancellable context so we can guarantee the fleet server goroutine
+	// exits before testing.T is torn down. Without this, loggedRunFunc can race
+	// with the test cleanup when it logs via the zerolog TestWriter after the test
+	// has already finished.
+	srvCtx, srvCancel := context.WithCancel(ctx)
+	g, srvCtx := errgroup.WithContext(srvCtx)
 
 	g.Go(func() error {
-		return srv.Run(ctx, cfg)
+		return srv.Run(srvCtx, cfg)
+	})
+
+	t.Cleanup(func() {
+		srvCancel()
+		g.Wait() //nolint:errcheck
 	})
 
 	tsrv := &tserver{cfg: cfg, g: g, srv: srv, enrollKey: key.Token(), bulker: bulker}
-	err = tsrv.waitServerUp(ctx, testWaitServerUp)
+	err = tsrv.waitServerUp(srvCtx, testWaitServerUp)
 	if err != nil {
 		return nil, fmt.Errorf("unable to start server: %w", err)
 	}

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -242,9 +242,12 @@ func startTestServer(t *testing.T, ctx context.Context, policyD model.PolicyData
 
 	tsrv := &tserver{cfg: cfg, g: g, srv: srv, enrollKey: key.Token(), bulker: bulker}
 
+	// serverUp gates whether cleanup reports exit errors: if startup failed, the
+	// exit error is a consequence of that failure and should not be reported separately.
+	serverUp := false
 	t.Cleanup(func() {
 		srvCancel()
-		if err := tsrv.waitExit(); err != nil {
+		if err := tsrv.waitExit(); err != nil && serverUp {
 			t.Errorf("fleet server exited with unexpected error: %v", err)
 		}
 	})
@@ -253,6 +256,7 @@ func startTestServer(t *testing.T, ctx context.Context, policyD model.PolicyData
 	if err != nil {
 		return nil, fmt.Errorf("unable to start server: %w", err)
 	}
+	serverUp = true
 	return tsrv, nil
 }
 

--- a/internal/pkg/server/fleet_integration_test.go
+++ b/internal/pkg/server/fleet_integration_test.go
@@ -240,12 +240,15 @@ func startTestServer(t *testing.T, ctx context.Context, policyD model.PolicyData
 		return srv.Run(srvCtx, cfg)
 	})
 
+	tsrv := &tserver{cfg: cfg, g: g, srv: srv, enrollKey: key.Token(), bulker: bulker}
+
 	t.Cleanup(func() {
 		srvCancel()
-		g.Wait() //nolint:errcheck
+		if err := tsrv.waitExit(); err != nil {
+			t.Errorf("fleet server exited with unexpected error: %v", err)
+		}
 	})
 
-	tsrv := &tserver{cfg: cfg, g: g, srv: srv, enrollKey: key.Token(), bulker: bulker}
 	err = tsrv.waitServerUp(srvCtx, testWaitServerUp)
 	if err != nil {
 		return nil, fmt.Errorf("unable to start server: %w", err)


### PR DESCRIPTION
<!-- Type of change: Enhancement -->

## What is the problem this PR solves?

When ghost agents appear in `.fleet-agents` (documents with `enrolled_at` but no `last_checkin`), we cannot determine from fleet-server logs whether the ghost write was one that fleet-server considered successful. The "Elastic Agent successfully enrolled" log entry records `agent_id` but not `enrollment_id`, so there is no way to correlate a ghost document (identified by `enrollment_id` via aggregation) back to a fleet-server log entry.

This gap was discovered during ghost agent investigation ([elastic/fleet-server#7741](https://github.com/elastic/fleet-server/issues/7741)): in [observability-perf build #6943](https://buildkite.com/elastic/observability-perf/builds/6943), 3 ghost documents had enrollment_ids that appeared in neither fleet-server write-error logs nor ES error logs, making the root cause unclear.

## How does this PR solve the problem?

Adds `enrollment_id` to the "Elastic Agent successfully enrolled" log entry. With this field present, the next run with ghost agents can confirm whether ghost enrollment_ids appear in the success log, distinguishing between:
- Ghost write succeeded from FS perspective (enrollment_id IS in success log)
- Ghost write failed silently without reaching the success log path

The change threads `enrollmentID` from `processRequest` (where the request body is parsed) through `handleEnroll` to `writeResponse`. `EnrollResponse` is auto-generated from OpenAPI spec and is not modified.

## How to test this PR locally

```bash
# Start fleet-server and enroll an agent. Verify the log entry:
# {"message":"Elastic Agent successfully enrolled","fleet.agent.id":"...","enrollment_id":"..."}
```

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [x] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc. *(logging-only change; no load impact)*

## Checklist

- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Relates #7741