### PR TITLE
[8.19] fix: prevent shared ParsedPolicy.SecretKeys mutation in processPolicy

### DIFF
--- a/changelog/fragments/1788278234-fix-secret-keys-corruption.yaml
+++ b/changelog/fragments/1788278234-fix-secret-keys-corruption.yaml
@@ -1,0 +1,7 @@
+kind: bug-fix
+
+summary: Fix secret keys corruption in policy processing
+
+component: fleet-server
+
+# pr: filled automatically by tooling

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -854,6 +854,9 @@ func processPolicy(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, a
 	}
 
 	data := model.ClonePolicyData(pp.Policy.Data)
+	// Clone pp.SecretKeys so concurrent processPolicy calls for the same policy
+	// revision do not race on the shared ParsedPolicy field.
+	secretKeys := slices.Clone(pp.SecretKeys)
 	for policyName, policyOutput := range data.Outputs {
 		// NOTE: Not sure if output secret keys collected here include new entries, but they are collected for completeness
 		ks, err := policy.ProcessOutputSecret(ctx, policyOutput, bulker) // makes a bulk request to get secret values
@@ -861,7 +864,7 @@ func processPolicy(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, a
 			return nil, fmt.Errorf("failed to process output secrets %q: %w",
 				policyName, err)
 		}
-		pp.SecretKeys = append(pp.SecretKeys, ks...)
+		secretKeys = append(secretKeys, ks...)
 	}
 	// Iterate through the policy outputs and prepare them
 	for _, policyOutput := range pp.Outputs {
@@ -884,8 +887,8 @@ func processPolicy(ctx context.Context, zlog zerolog.Logger, bulker bulk.Bulk, a
 		return nil, err
 	}
 	// remove duplicates from secretkeys
-	slices.Sort(pp.SecretKeys)
-	keys := slices.Compact(pp.SecretKeys)
+	slices.Sort(secretKeys)
+	keys := slices.Compact(secretKeys)
 	d.SecretPaths = &keys
 	ad := Action_Data{}
 	err = ad.FromActionPolicyChange(ActionPolicyChange{d})

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -13,10 +13,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1159,4 +1162,86 @@ func TestValidateCheckinRequest(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestProcessPolicySecretPathsConcurrentDispatch ensures processPolicy does not
+// mutate the shared ParsedPolicy.SecretKeys when concurrent checkin goroutines
+// process the same policy revision fan-out.
+// Regression test for https://github.com/elastic/fleet-server/issues/7739
+func TestProcessPolicySecretPathsConcurrentDispatch(t *testing.T) {
+	logger := testlog.SetLogger(t)
+
+	// Two input-level secrets so the sort in processPolicy has real work to do.
+	const payload = `{
+		"outputs": {
+			"default": {
+				"type": "logstash"
+			}
+		},
+		"inputs": [
+			{
+				"type": "logfile",
+				"vars": {
+					"username": "$co.elastic.secret{SEC_A}",
+					"password": "$co.elastic.secret{SEC_B}"
+				}
+			}
+		],
+		"secret_references": [
+			{"id": "SEC_A"},
+			{"id": "SEC_B"}
+		]
+	}`
+
+	const agents = 2
+
+	var d model.PolicyData
+	err := json.Unmarshal([]byte(payload), &d)
+	require.NoError(t, err)
+
+	bulker := ftesting.NewMockBulk()
+	pp, err := policy.NewParsedPolicy(t.Context(), bulker, model.Policy{
+		PolicyID:    "policy1",
+		RevisionIdx: 1,
+		Data:        &d,
+	})
+	require.NoError(t, err)
+
+	baseline := slices.Clone(pp.SecretKeys)
+	require.Len(t, baseline, 2, "expected two input secret keys from NewParsedPolicy")
+
+	var wg sync.WaitGroup
+	secretPaths := make([][]string, agents)
+	errs := make([]error, agents)
+	for a := range agents {
+		wg.Add(1)
+		a := a
+		go func() {
+			defer wg.Done()
+			agent := &model.Agent{
+				ESDocument: model.ESDocument{Id: fmt.Sprintf("agent%d", a)},
+			}
+			action, err := processPolicy(t.Context(), logger, bulker, agent, pp)
+			if err != nil {
+				errs[a] = err
+				return
+			}
+			pc, err := action.Data.AsActionPolicyChange()
+			if err != nil {
+				errs[a] = err
+				return
+			}
+			if pc.Policy.SecretPaths != nil {
+				secretPaths[a] = *pc.Policy.SecretPaths
+			}
+		}()
+	}
+	wg.Wait()
+
+	for a := range agents {
+		require.NoError(t, errs[a], "agent %d processPolicy failed", a)
+		assert.Equal(t, []string{"inputs.0.vars.password", "inputs.0.vars.username"}, secretPaths[a],
+			"agent %d received incorrect secret paths", a)
+	}
+	assert.Equal(t, baseline, pp.SecretKeys, "shared ParsedPolicy.SecretKeys was mutated")
 }


### PR DESCRIPTION
<!-- Type of change -->
<!-- Bug -->

## What is the problem this PR solves?

`processPolicy` is called concurrently — one goroutine per agent checkin — and all goroutines share the same `*ParsedPolicy` pointer for a given policy revision. The function mutated `pp.SecretKeys` directly via `append`, `slices.Sort`, and `slices.Compact`, all of which race on the shared backing array. Under concurrent execution this corrupts the `SecretPaths` slice delivered to agents (e.g. empty strings appear due to torn string reads during concurrent sort), causing agents to crash-loop in `addSecretMarkers` with:

```
panic: runtime error: index out of range [-1]
goroutine N [running]:
github.com/elastic/go-ucfg.idxField.GetValue(...)
...
github.com/elastic/elastic-agent/internal/pkg/diagnostics.addSecretMarkers(...)
```

The corrupted `SecretPaths` are persisted to the agent's local state, so the crash-loop continues across restarts. Only a full uninstall/reinstall (clearing local state) recovers the agent.

## How does this PR solve the problem?

This is a manual backport of #7740 to the 8.19 branch. The Mergify auto-backport #7744 was closed without merging because the cherry-pick produced unresolvable conflicts: main had diverged from 8.19 via a refactor of `ProcessOutputSecret` (different package and signature) and the addition of `slices.DeleteFunc` (from #7468), neither of which landed in 8.19. The conflict markers were committed as-is, breaking the build, and the PR was abandoned.

This PR re-applies the same logical fix — clone `pp.SecretKeys` into a local variable at the top of `processPolicy` so all subsequent appends, sort, and compact operate on a per-goroutine copy, leaving the shared `ParsedPolicy` field untouched — adapted cleanly to the 8.19 code.

## How to test this PR locally

```
go test -race -count=1 -run TestProcessPolicySecretPathsConcurrentDispatch ./internal/pkg/api/
```

## Design Checklist

- [X] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- ~~[ ] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.~~
- ~~[ ] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.~~

## Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/fleet-server#changelog)

## Related issues

- Closes #7739
- Supersedes #7744