### PR TITLE
fix: bypass expired Debian 11 security repo in Dockerfile.build

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -2,8 +2,12 @@ ARG GO_VERSION
 ARG SUFFIX # Should be main-debian11 or arm
 FROM docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-${SUFFIX}
 
+# TEMPORARY WORKAROUND: Debian 11 (Bullseye) reached EOL and its security
+# repo InRelease file has expired. check-valid-until=false bypasses the expiry
+# check so the build can proceed. Revert this once the upstream base image fix
+# is merged and published: https://github.com/elastic/golang-crossbuild/pull/754
 RUN \
-  apt-get update \
+  apt-get -o Acquire::Check-Valid-Until=false update \
   && apt-get install --no-install-recommends -y zip \
   && apt-get clean
 


### PR DESCRIPTION
## ⚠️ TEMPORARY WORKAROUND — Revert once elastic/golang-crossbuild#754 is merged and new images are published

## What is the problem this PR solves?

The Buildkite `Package x86_64` and `Package aarch64` jobs are failing (e.g. [build #16689](https://buildkite.com/elastic/fleet-server/builds/16689)) because Debian 11 (Bullseye) reached EOL and its security repository's `InRelease` file has expired. `apt-get update` in `Dockerfile.build` fails with:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease is expired
```

The **root cause fix** is in the upstream base image: [elastic/golang-crossbuild#754](https://github.com/elastic/golang-crossbuild/pull/754), which switches Debian 11 sources to the archive and snapshot mirrors. This PR should be reverted once that PR is merged and new `golang-crossbuild` images are published.

## How does this PR solve the problem?

Passes `-o Acquire::Check-Valid-Until=false` to `apt-get update` in `Dockerfile.build` to bypass the expiry check. This does not change the Debian version being built for — the base image remains `golang-crossbuild:*-debian11`. Since Debian 11 is EOL, the security repo has no new updates regardless, so bypassing the validity check has no practical security impact.

## How to test this PR locally

Trigger a packaging build or run locally:
```bash
docker build -t fleet-server-builder:test --build-arg GO_VERSION=$(cat .go-version) --build-arg SUFFIX=main-debian11 -f Dockerfile.build .
```

## Design Checklist

- [x] I have ensured my design is stateless and will work when multiple fleet-server instances are behind a load balancer.
- [x] I have or intend to scale test my changes, ensuring it will work reliably with 100K+ agents connected.
- [x] I have included fail safe mechanisms to limit the load on fleet-server: rate limiting, circuit breakers, caching, load shedding, etc.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues

- Relates to: https://github.com/elastic/golang-crossbuild/pull/754 (root cause fix — revert this PR once that lands)