### PR TITLE
[8.19] fix: bypass expired Debian 11 security repo in Dockerfile.build

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -2,8 +2,11 @@ ARG GO_VERSION
 ARG SUFFIX # Should be main-debian11 or arm
 FROM docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-${SUFFIX}
 
+# TEMPORARY: Debian 11 (Bullseye) reached EOL and its security repo InRelease
+# has expired. Check-Valid-Until=false bypasses the expiry check so the build
+# can proceed. Revert once golang-crossbuild base image is updated.
 RUN \
-  apt-get update \
+  apt-get -o Acquire::Check-Valid-Until=false update \
   && apt-get install --no-install-recommends -y zip \
   && apt-get clean
 


### PR DESCRIPTION
## Summary

- Debian 11 (Bullseye) reached EOL and its security repository `InRelease` file has expired, causing all Buildkite package builds for the `8.19` branch to fail at the `apt-get update` step.
- Passes `-o Acquire::Check-Valid-Until=false` to `apt-get` as a temporary workaround to bypass the expiry check.
- The permanent fix is upstream in [elastic/golang-crossbuild#754](https://github.com/elastic/golang-crossbuild/pull/754) (updating the base image to Debian 12). This commit should be reverted once that is merged and published.

## Impact

Without this fix, _all_ open PRs against `8.19` fail Buildkite — including unrelated updatecli bumps like #7780.

## Test plan

- [ ] Buildkite build passes for this PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)