### PR TITLE
fix: clear upgrade_started_at when agent upgrades faster than one checkin interval

### DIFF
--- a/changelog/fragments/1788912764-fix-upgrade-started-at-stuck-fast-upgrade.yaml
+++ b/changelog/fragments/1788912764-fix-upgrade-started-at-stuck-fast-upgrade.yaml
@@ -1,0 +1,25 @@
+kind: bug-fix
+
+summary: Fix agent permanently stuck in "updating" state after fast upgrade
+
+# When an agent upgrades faster than one checkin interval, Fleet Server never
+# observes any upgrade_details states. markUpgradeComplete was a NOP when
+# upgrade_details was nil on both the checkin body and the agent doc, leaving
+# upgrade_started_at set indefinitely and the agent permanently "updating".
+description: |
+  When an Elastic Agent completes an upgrade faster than one checkin interval
+  (~60 s), Fleet Server never observes any intermediate upgrade_details states
+  (downloading, extracting, watching). In this case the agent document has
+  upgrade_details: null while upgrade_started_at remains set from the original
+  bulk upgrade request. The markUpgradeComplete function previously returned
+  early (NOP) whenever upgrade_details was nil on the agent document, so
+  upgrade_started_at was never cleared. This left the agent permanently in the
+  "updating" state in Fleet UI, even though it had successfully upgraded.
+
+  The fix extends the NOP guard to also check upgrade_started_at: if an upgrade
+  was dispatched (upgrade_started_at is set) but no upgrade_details were ever
+  recorded (fast upgrade race), Fleet Server now correctly clears
+  upgrade_started_at on the next checkin with nil upgrade_details and marks the
+  upgrade complete.
+
+component: fleet-server

--- a/changelog/fragments/1788912764-fix-upgrade-started-at-stuck-fast-upgrade.yaml
+++ b/changelog/fragments/1788912764-fix-upgrade-started-at-stuck-fast-upgrade.yaml
@@ -2,10 +2,6 @@ kind: bug-fix
 
 summary: Fix agent permanently stuck in "updating" state after fast upgrade
 
-# When an agent upgrades faster than one checkin interval, Fleet Server never
-# observes any upgrade_details states. markUpgradeComplete was a NOP when
-# upgrade_details was nil on both the checkin body and the agent doc, leaving
-# upgrade_started_at set indefinitely and the agent permanently "updating".
 description: |
   When an Elastic Agent completes an upgrade faster than one checkin interval
   (~60 s), Fleet Server never observes any intermediate upgrade_details states
@@ -16,10 +12,20 @@ description: |
   upgrade_started_at was never cleared. This left the agent permanently in the
   "updating" state in Fleet UI, even though it had successfully upgraded.
 
-  The fix extends the NOP guard to also check upgrade_started_at: if an upgrade
-  was dispatched (upgrade_started_at is set) but no upgrade_details were ever
-  recorded (fast upgrade race), Fleet Server now correctly clears
-  upgrade_started_at on the next checkin with nil upgrade_details and marks the
-  upgrade complete.
+  Two related fixes are included:
+
+  1. Fast-upgrade race: if upgrade_started_at is set and the agent's reported
+     version differs from its stored version (indicating the agent restarted
+     after a fast upgrade), Fleet Server now correctly clears upgrade_started_at
+     and marks the upgrade complete on the next checkin with nil upgrade_details.
+
+  2. Stale self-heal: in mixed-version deployments (rolling fleet-server
+     upgrade), an older instance may update the agent version without clearing
+     upgrade_started_at, leaving the agent stuck with no future version change
+     to trigger fix (1). As a safety net, if upgrade_started_at is older than
+     2× the configured checkin_max_poll with no associated upgrade_details,
+     Fleet Server now clears upgrade_started_at unconditionally to unblock the
+     Fleet UI. In this case upgraded_at is not set because the upgrade outcome
+     cannot be determined from available state.
 
 component: fleet-server

--- a/changelog/fragments/1788912764-fix-upgrade-started-at-stuck-fast-upgrade.yaml
+++ b/changelog/fragments/1788912764-fix-upgrade-started-at-stuck-fast-upgrade.yaml
@@ -3,29 +3,8 @@ kind: bug-fix
 summary: Fix agent permanently stuck in "updating" state after fast upgrade
 
 description: |
-  When an Elastic Agent completes an upgrade faster than one checkin interval
-  (~60 s), Fleet Server never observes any intermediate upgrade_details states
-  (downloading, extracting, watching). In this case the agent document has
-  upgrade_details: null while upgrade_started_at remains set from the original
-  bulk upgrade request. The markUpgradeComplete function previously returned
-  early (NOP) whenever upgrade_details was nil on the agent document, so
-  upgrade_started_at was never cleared. This left the agent permanently in the
-  "updating" state in Fleet UI, even though it had successfully upgraded.
-
-  Two related fixes are included:
-
-  1. Fast-upgrade race: if upgrade_started_at is set and the agent's reported
-     version differs from its stored version (indicating the agent restarted
-     after a fast upgrade), Fleet Server now correctly clears upgrade_started_at
-     and marks the upgrade complete on the next checkin with nil upgrade_details.
-
-  2. Stale self-heal: in mixed-version deployments (rolling fleet-server
-     upgrade), an older instance may update the agent version without clearing
-     upgrade_started_at, leaving the agent stuck with no future version change
-     to trigger fix (1). As a safety net, if upgrade_started_at is older than
-     2× the configured checkin_max_poll with no associated upgrade_details,
-     Fleet Server now clears upgrade_started_at unconditionally to unblock the
-     Fleet UI. In this case upgraded_at is not set because the upgrade outcome
-     cannot be determined from available state.
+  Agents that completed an upgrade faster than one checkin interval (~60 s)
+  were permanently shown as "updating" in the Fleet UI. Fleet Server now
+  detects the completed upgrade and clears the stuck state on the next checkin.
 
 component: fleet-server

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -819,12 +819,12 @@ func (ct *CheckinT) markUpgradeComplete(ctx context.Context, agent *model.Agent,
 // stalenessThreshold returns the age beyond which an upgrade_started_at value with no associated
 // upgrade_details is treated as stale and cleared. It is set to 2× the effective CheckinMaxPoll
 // so that a legitimately long-running poll (up to CheckinMaxPoll) cannot be mistaken for a stuck
-// upgrade. The effective minimum of 1m matches the same floor used by the long-poll logic (line 415).
+// upgrade. The effective minimum of 1m matches the same floor used by the long-poll logic.
 func (ct *CheckinT) stalenessThreshold() time.Duration {
 	if ct.cfg == nil {
-		return 2 * time.Hour // fallback to 2× the default CheckinMaxPoll of 1h
+		return 2 * config.DefaultCheckinMaxPoll
 	}
-	return 2 * max(ct.cfg.Timeouts.CheckinMaxPoll, time.Minute)
+	return 2 * max(ct.cfg.Timeouts.CheckinMaxPoll, config.CheckinMaxPollFloor)
 }
 
 func (ct *CheckinT) writeResponse(zlog zerolog.Logger, w http.ResponseWriter, r *http.Request, agent *model.Agent, resp CheckinResponse) error {

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -62,15 +62,6 @@ const (
 	invalidKeyStateReset         = time.Hour
 	invalidKeyStateCleanInterval = 5 * time.Minute
 
-	// upgradeStartedAtStalenessThreshold is the age beyond which an upgrade_started_at value
-	// with no associated upgrade_details is treated as stale and cleared. This covers the case
-	// where the agent completed a fast upgrade (no intermediate upgrade_details), but a prior
-	// Fleet Server instance (rolling upgrade) already updated the agent version in the document
-	// without clearing upgrade_started_at — so ver == "" on subsequent checkins even though the
-	// upgrade is done. The threshold must exceed the maximum poll duration to avoid prematurely
-	// clearing upgrade_started_at on the first checkin after bulk_upgrade (before action delivery).
-	upgradeStartedAtStalenessThreshold = 10 * time.Minute
-
 	invalidKeyLRUEntryBytes = 250
 )
 
@@ -781,16 +772,29 @@ func (ct *CheckinT) markUpgradeComplete(ctx context.Context, agent *model.Agent,
 	// action. Do not prematurely clear upgrade_started_at on the first checkin after dispatch.
 	// ver is non-empty only when the agent's reported version differs from its stored version.
 	//
-	// Exception: if upgrade_started_at is stale (older than upgradeStartedAtStalenessThreshold),
-	// clear it anyway. This self-heals agents that completed a fast upgrade but whose version
-	// was already updated by a prior Fleet Server instance (e.g. during a rolling fleet-server
-	// upgrade), leaving ver == "" on subsequent checkins.
+	// Exception: if upgrade_started_at is clearly stale (older than 2× CheckinMaxPoll), clear it
+	// to self-heal agents stuck in the updating state after a rolling fleet-server upgrade where
+	// the version was already updated by an older instance. The threshold uses 2× CheckinMaxPoll
+	// so a legitimately long-running poll (up to CheckinMaxPoll) cannot be mistaken for staleness.
+	// In the stale case upgraded_at is NOT set because the upgrade outcome is unknown.
 	if agent.UpgradeDetails == nil && agent.UpgradeStartedAt != "" && ver == "" {
 		t, err := time.Parse(time.RFC3339, agent.UpgradeStartedAt)
-		if err != nil || time.Since(t) < upgradeStartedAtStalenessThreshold {
+		if err != nil || time.Since(t) < ct.stalenessThreshold() {
 			return nil
 		}
-		// fall through to clear the stale upgrade_started_at below
+		// Stale: clear upgrade_started_at without setting upgraded_at (outcome unknown).
+		span, ctx := apm.StartSpan(ctx, "Clear stale upgrade", "update")
+		span.Context.SetLabel("agent_id", agent.Agent.ID)
+		defer span.End()
+		doc := bulk.UpdateFields{
+			dl.FieldUpgradeDetails:   nil,
+			dl.FieldUpgradeStartedAt: nil,
+		}
+		body, err := doc.Marshal()
+		if err != nil {
+			return err
+		}
+		return ct.bulker.Update(ctx, dl.FleetAgents, agent.Id, body, bulk.WithRefresh(), bulk.WithRetryOnConflict(3))
 	}
 	span, ctx := apm.StartSpan(ctx, "Mark update complete", "update")
 	span.Context.SetLabel("agent_id", agent.Agent.ID)
@@ -807,6 +811,16 @@ func (ct *CheckinT) markUpgradeComplete(ctx context.Context, agent *model.Agent,
 		return err
 	}
 	return ct.bulker.Update(ctx, dl.FleetAgents, agent.Id, body, bulk.WithRefresh(), bulk.WithRetryOnConflict(3))
+}
+
+// stalenessThreshold returns the age beyond which an upgrade_started_at value with no associated
+// upgrade_details is treated as stale and cleared. It is set to 2× CheckinMaxPoll so that a
+// legitimately long-running poll (up to CheckinMaxPoll) cannot be mistaken for a stuck upgrade.
+func (ct *CheckinT) stalenessThreshold() time.Duration {
+	if ct.cfg == nil {
+		return 2 * time.Hour // fallback to 2× the default CheckinMaxPoll of 1h
+	}
+	return 2 * ct.cfg.Timeouts.CheckinMaxPoll
 }
 
 func (ct *CheckinT) writeResponse(zlog zerolog.Logger, w http.ResponseWriter, r *http.Request, agent *model.Agent, resp CheckinResponse) error {

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -62,6 +62,15 @@ const (
 	invalidKeyStateReset         = time.Hour
 	invalidKeyStateCleanInterval = 5 * time.Minute
 
+	// upgradeStartedAtStalenessThreshold is the age beyond which an upgrade_started_at value
+	// with no associated upgrade_details is treated as stale and cleared. This covers the case
+	// where the agent completed a fast upgrade (no intermediate upgrade_details), but a prior
+	// Fleet Server instance (rolling upgrade) already updated the agent version in the document
+	// without clearing upgrade_started_at — so ver == "" on subsequent checkins even though the
+	// upgrade is done. The threshold must exceed the maximum poll duration to avoid prematurely
+	// clearing upgrade_started_at on the first checkin after bulk_upgrade (before action delivery).
+	upgradeStartedAtStalenessThreshold = 10 * time.Minute
+
 	invalidKeyLRUEntryBytes = 250
 )
 
@@ -644,9 +653,16 @@ func (ct *CheckinT) verifyActionExists(vCtx context.Context, vSpan *apm.Span, ag
 }
 
 // processUpgradeDetails will verify and set the upgrade_details section of an agent document based on checkin value.
-// if the agent doc and checkin details are both nil the method is a nop
-// if the checkin upgrade_details is nil but there was a previous value in the agent doc, fleet-server treats it as a successful upgrade
-// otherwise the details are validated; action_id is checked and upgrade_details.metadata is validated based on upgrade_details.state and the agent doc is updated.
+// When the checkin upgrade_details is nil, markUpgradeComplete is called, which handles three cases:
+//   - NOP if there is no upgrade in progress (upgrade_started_at empty and no stored upgrade_details).
+//   - NOP if an upgrade was dispatched (upgrade_started_at set) but the agent has not yet changed version
+//     or reported any upgrade_details — the upgrade action has not been received/completed yet. This guard
+//     is bypassed for stale upgrade_started_at values (older than upgradeStartedAtStalenessThreshold).
+//   - Mark complete if the agent had stored upgrade_details (normal upgrade path) or changed version
+//     without any intermediate details (fast upgrade race: upgrade completed in < 1 checkin interval).
+//
+// When the checkin upgrade_details is non-nil, the details are validated: action_id is checked and
+// upgrade_details.metadata is validated based on upgrade_details.state, then the agent doc is updated.
 // ver is the agent's new version string if it differs from the stored version, or empty if unchanged.
 func (ct *CheckinT) processUpgradeDetails(ctx context.Context, agent *model.Agent, details *UpgradeDetails, ver string) error {
 	if details == nil {
@@ -764,8 +780,17 @@ func (ct *CheckinT) markUpgradeComplete(ctx context.Context, agent *model.Agent,
 	// version and has sent no upgrade_details — it has not yet received or completed the upgrade
 	// action. Do not prematurely clear upgrade_started_at on the first checkin after dispatch.
 	// ver is non-empty only when the agent's reported version differs from its stored version.
+	//
+	// Exception: if upgrade_started_at is stale (older than upgradeStartedAtStalenessThreshold),
+	// clear it anyway. This self-heals agents that completed a fast upgrade but whose version
+	// was already updated by a prior Fleet Server instance (e.g. during a rolling fleet-server
+	// upgrade), leaving ver == "" on subsequent checkins.
 	if agent.UpgradeDetails == nil && agent.UpgradeStartedAt != "" && ver == "" {
-		return nil
+		t, err := time.Parse(time.RFC3339, agent.UpgradeStartedAt)
+		if err != nil || time.Since(t) < upgradeStartedAtStalenessThreshold {
+			return nil
+		}
+		// fall through to clear the stale upgrade_started_at below
 	}
 	span, ctx := apm.StartSpan(ctx, "Mark update complete", "update")
 	span.Context.SetLabel("agent_id", agent.Agent.ID)

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -475,7 +475,7 @@ func (ct *CheckinT) ProcessRequest(zlog zerolog.Logger, w http.ResponseWriter, r
 
 	// Handle upgrade details for agents using the new 8.11 upgrade details field of the checkin.
 	// Older agents will communicate any issues with upgrades via the Ack endpoint.
-	if err := ct.processUpgradeDetails(r.Context(), agent, req.UpgradeDetails); err != nil {
+	if err := ct.processUpgradeDetails(r.Context(), agent, req.UpgradeDetails, ver); err != nil {
 		return fmt.Errorf("failed to update upgrade_details: %w", err)
 	}
 
@@ -647,9 +647,10 @@ func (ct *CheckinT) verifyActionExists(vCtx context.Context, vSpan *apm.Span, ag
 // if the agent doc and checkin details are both nil the method is a nop
 // if the checkin upgrade_details is nil but there was a previous value in the agent doc, fleet-server treats it as a successful upgrade
 // otherwise the details are validated; action_id is checked and upgrade_details.metadata is validated based on upgrade_details.state and the agent doc is updated.
-func (ct *CheckinT) processUpgradeDetails(ctx context.Context, agent *model.Agent, details *UpgradeDetails) error {
+// ver is the agent's new version string if it differs from the stored version, or empty if unchanged.
+func (ct *CheckinT) processUpgradeDetails(ctx context.Context, agent *model.Agent, details *UpgradeDetails, ver string) error {
 	if details == nil {
-		err := ct.markUpgradeComplete(ctx, agent)
+		err := ct.markUpgradeComplete(ctx, agent, ver)
 		if err != nil {
 			return err
 		}
@@ -754,17 +755,23 @@ func (ct *CheckinT) processUpgradeDetails(ctx context.Context, agent *model.Agen
 	return ct.bulker.Update(ctx, dl.FleetAgents, agent.Id, body, bulk.WithRefresh(), bulk.WithRetryOnConflict(3))
 }
 
-func (ct *CheckinT) markUpgradeComplete(ctx context.Context, agent *model.Agent) error {
-	// nop if neither the agent doc nor the checkin have upgrade details, and no upgrade is in progress.
-	// When upgrade_started_at is set but upgrade_details is nil, the agent completed its upgrade
-	// before Fleet Server observed any upgrade_details states (fast upgrade race). Treat as success.
+func (ct *CheckinT) markUpgradeComplete(ctx context.Context, agent *model.Agent, ver string) error {
+	// NOP: no upgrade in progress and no stored upgrade state to clear.
 	if agent.UpgradeDetails == nil && agent.UpgradeStartedAt == "" {
+		return nil
+	}
+	// NOP: upgrade was dispatched (upgrade_started_at is set) but the agent has not yet changed
+	// version and has sent no upgrade_details — it has not yet received or completed the upgrade
+	// action. Do not prematurely clear upgrade_started_at on the first checkin after dispatch.
+	// ver is non-empty only when the agent's reported version differs from its stored version.
+	if agent.UpgradeDetails == nil && agent.UpgradeStartedAt != "" && ver == "" {
 		return nil
 	}
 	span, ctx := apm.StartSpan(ctx, "Mark update complete", "update")
 	span.Context.SetLabel("agent_id", agent.Agent.ID)
 	defer span.End()
-	// if the checkin had no details, but agent has details (or upgrade_started_at set), treat like a successful upgrade
+	// Checkin had no upgrade_details but agent either had stored details (normal upgrade path) or
+	// changed version without intermediate details (fast upgrade race). Treat as successful upgrade.
 	doc := bulk.UpdateFields{
 		dl.FieldUpgradeDetails:   nil,
 		dl.FieldUpgradeStartedAt: nil,

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -779,6 +779,9 @@ func (ct *CheckinT) markUpgradeComplete(ctx context.Context, agent *model.Agent,
 	// In the stale case upgraded_at is NOT set because the upgrade outcome is unknown.
 	if agent.UpgradeDetails == nil && agent.UpgradeStartedAt != "" && ver == "" {
 		t, err := time.Parse(time.RFC3339, agent.UpgradeStartedAt)
+		if err != nil {
+			t, err = time.Parse(time.RFC3339Nano, agent.UpgradeStartedAt)
+		}
 		if err != nil || time.Since(t) < ct.stalenessThreshold() {
 			return nil
 		}

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -755,14 +755,16 @@ func (ct *CheckinT) processUpgradeDetails(ctx context.Context, agent *model.Agen
 }
 
 func (ct *CheckinT) markUpgradeComplete(ctx context.Context, agent *model.Agent) error {
-	// nop if there are no checkin details, and the agent has no details
-	if agent.UpgradeDetails == nil {
+	// nop if neither the agent doc nor the checkin have upgrade details, and no upgrade is in progress.
+	// When upgrade_started_at is set but upgrade_details is nil, the agent completed its upgrade
+	// before Fleet Server observed any upgrade_details states (fast upgrade race). Treat as success.
+	if agent.UpgradeDetails == nil && agent.UpgradeStartedAt == "" {
 		return nil
 	}
 	span, ctx := apm.StartSpan(ctx, "Mark update complete", "update")
 	span.Context.SetLabel("agent_id", agent.Agent.ID)
 	defer span.End()
-	// if the checkin had no details, but agent has details treat like a successful upgrade
+	// if the checkin had no details, but agent has details (or upgrade_started_at set), treat like a successful upgrade
 	doc := bulk.UpdateFields{
 		dl.FieldUpgradeDetails:   nil,
 		dl.FieldUpgradeStartedAt: nil,

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -817,13 +817,14 @@ func (ct *CheckinT) markUpgradeComplete(ctx context.Context, agent *model.Agent,
 }
 
 // stalenessThreshold returns the age beyond which an upgrade_started_at value with no associated
-// upgrade_details is treated as stale and cleared. It is set to 2× CheckinMaxPoll so that a
-// legitimately long-running poll (up to CheckinMaxPoll) cannot be mistaken for a stuck upgrade.
+// upgrade_details is treated as stale and cleared. It is set to 2× the effective CheckinMaxPoll
+// so that a legitimately long-running poll (up to CheckinMaxPoll) cannot be mistaken for a stuck
+// upgrade. The effective minimum of 1m matches the same floor used by the long-poll logic (line 415).
 func (ct *CheckinT) stalenessThreshold() time.Duration {
 	if ct.cfg == nil {
 		return 2 * time.Hour // fallback to 2× the default CheckinMaxPoll of 1h
 	}
-	return 2 * ct.cfg.Timeouts.CheckinMaxPoll
+	return 2 * max(ct.cfg.Timeouts.CheckinMaxPoll, time.Minute)
 }
 
 func (ct *CheckinT) writeResponse(zlog zerolog.Logger, w http.ResponseWriter, r *http.Request, agent *model.Agent, resp CheckinResponse) error {

--- a/internal/pkg/api/handleCheckin.go
+++ b/internal/pkg/api/handleCheckin.go
@@ -412,7 +412,7 @@ func (ct *CheckinT) validateRequest(zlog zerolog.Logger, w http.ResponseWriter, 
 	// sets timeout is set to max(1m, min(pDur-2m, max poll time))
 	// sets the response write timeout to max(2m, timeout+1m)
 	if pDur != time.Duration(0) {
-		pollDuration = max(min(pDur-(2*time.Minute), ct.cfg.Timeouts.CheckinMaxPoll), time.Minute)
+		pollDuration = max(min(pDur-(2*time.Minute), ct.cfg.Timeouts.CheckinMaxPoll), config.CheckinMaxPollFloor)
 
 		wTime := pollDuration + time.Minute
 		rc := http.NewResponseController(w)

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -431,7 +431,9 @@ func TestProcessUpgradeDetails(t *testing.T) {
 					t.Logf("bulk match unmarshal error: %v", err)
 					return false
 				}
-				return doc.Doc[dl.FieldUpgradeDetails] == nil && doc.Doc[dl.FieldUpgradeStartedAt] == nil && doc.Doc[dl.FieldUpgradedAt] != ""
+				upgradedAt, ok := doc.Doc[dl.FieldUpgradedAt]
+				upgradedAtStr, isStr := upgradedAt.(string)
+				return doc.Doc[dl.FieldUpgradeDetails] == nil && doc.Doc[dl.FieldUpgradeStartedAt] == nil && ok && isStr && upgradedAtStr != ""
 			}), mock.Anything, mock.Anything).Return(nil)
 			return mBulk
 		},
@@ -453,7 +455,9 @@ func TestProcessUpgradeDetails(t *testing.T) {
 					t.Logf("bulk match unmarshal error: %v", err)
 					return false
 				}
-				return doc.Doc[dl.FieldUpgradeDetails] == nil && doc.Doc[dl.FieldUpgradeStartedAt] == nil && doc.Doc[dl.FieldUpgradedAt] != ""
+				upgradedAt, ok := doc.Doc[dl.FieldUpgradedAt]
+				upgradedAtStr, isStr := upgradedAt.(string)
+				return doc.Doc[dl.FieldUpgradeDetails] == nil && doc.Doc[dl.FieldUpgradeStartedAt] == nil && ok && isStr && upgradedAtStr != ""
 			}), mock.Anything, mock.Anything).Return(nil)
 			return mBulk
 		},

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -403,6 +403,7 @@ func TestProcessUpgradeDetails(t *testing.T) {
 		name    string
 		agent   *model.Agent
 		details *UpgradeDetails
+		ver     string
 		bulk    func() *ftesting.MockBulk
 		cache   func() *testcache.MockCache
 		err     error
@@ -419,8 +420,9 @@ func TestProcessUpgradeDetails(t *testing.T) {
 		err: nil,
 	}, {
 		name:    "agent has upgrade_started_at but no upgrade_details, checkin details are nil (fast upgrade race)",
-		agent:   &model.Agent{ESDocument: esd, Agent: &model.AgentMetadata{ID: "test-agent"}, UpgradeStartedAt: "2024-01-01T00:00:00Z"},
+		agent:   &model.Agent{ESDocument: esd, Agent: &model.AgentMetadata{ID: "test-agent", Version: "8.19.0"}, UpgradeStartedAt: "2024-01-01T00:00:00Z"},
 		details: nil,
+		ver:     "8.20.0", // agent restarted at new version
 		bulk: func() *ftesting.MockBulk {
 			mBulk := ftesting.NewMockBulk()
 			mBulk.On("Update", mock.Anything, dl.FleetAgents, "doc-ID", mock.MatchedBy(func(p []byte) bool {
@@ -436,6 +438,18 @@ func TestProcessUpgradeDetails(t *testing.T) {
 				return doc.Doc[dl.FieldUpgradeDetails] == nil && doc.Doc[dl.FieldUpgradeStartedAt] == nil && ok && isStr && upgradedAtStr != ""
 			}), mock.Anything, mock.Anything).Return(nil)
 			return mBulk
+		},
+		cache: func() *testcache.MockCache {
+			return testcache.NewMockCache()
+		},
+		err: nil,
+	}, {
+		name:    "agent has upgrade_started_at but no upgrade_details, first checkin after dispatch (same version, upgrade not yet received)",
+		agent:   &model.Agent{ESDocument: esd, Agent: &model.AgentMetadata{ID: "test-agent", Version: "8.19.0"}, UpgradeStartedAt: "2024-01-01T00:00:00Z"},
+		details: nil,
+		ver:     "", // version unchanged — upgrade action not yet received by agent
+		bulk: func() *ftesting.MockBulk {
+			return ftesting.NewMockBulk() // no Update call expected
 		},
 		cache: func() *testcache.MockCache {
 			return testcache.NewMockCache()
@@ -819,7 +833,7 @@ func TestProcessUpgradeDetails(t *testing.T) {
 				bulker: mBulk,
 			}
 
-			err := ct.processUpgradeDetails(context.Background(), tc.agent, tc.details)
+			err := ct.processUpgradeDetails(context.Background(), tc.agent, tc.details, tc.ver)
 			if tc.err == nil {
 				assert.NoError(t, err)
 			} else {

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -445,11 +445,36 @@ func TestProcessUpgradeDetails(t *testing.T) {
 		err: nil,
 	}, {
 		name:    "agent has upgrade_started_at but no upgrade_details, first checkin after dispatch (same version, upgrade not yet received)",
-		agent:   &model.Agent{ESDocument: esd, Agent: &model.AgentMetadata{ID: "test-agent", Version: "8.19.0"}, UpgradeStartedAt: "2024-01-01T00:00:00Z"},
+		agent:   &model.Agent{ESDocument: esd, Agent: &model.AgentMetadata{ID: "test-agent", Version: "8.19.0"}, UpgradeStartedAt: time.Now().UTC().Format(time.RFC3339)},
 		details: nil,
-		ver:     "", // version unchanged — upgrade action not yet received by agent
+		ver:     "", // version unchanged — upgrade action not yet received by agent; upgrade_started_at is fresh so staleness guard applies
 		bulk: func() *ftesting.MockBulk {
 			return ftesting.NewMockBulk() // no Update call expected
+		},
+		cache: func() *testcache.MockCache {
+			return testcache.NewMockCache()
+		},
+		err: nil,
+	}, {
+		name:    "agent has stale upgrade_started_at but no upgrade_details, same version (self-heal after rolling fleet-server upgrade)",
+		agent:   &model.Agent{ESDocument: esd, Agent: &model.AgentMetadata{ID: "test-agent", Version: "8.19.0"}, UpgradeStartedAt: time.Now().Add(-upgradeStartedAtStalenessThreshold - time.Minute).UTC().Format(time.RFC3339)},
+		details: nil,
+		ver:     "", // version matches stored — upgrade_started_at is stale so we clear it anyway
+		bulk: func() *ftesting.MockBulk {
+			mBulk := ftesting.NewMockBulk()
+			mBulk.On("Update", mock.Anything, dl.FleetAgents, "doc-ID", mock.MatchedBy(func(p []byte) bool {
+				doc := struct {
+					Doc map[string]any `json:"doc"`
+				}{}
+				if err := json.Unmarshal(p, &doc); err != nil {
+					t.Logf("bulk match unmarshal error: %v", err)
+					return false
+				}
+				upgradedAt, ok := doc.Doc[dl.FieldUpgradedAt]
+				upgradedAtStr, isStr := upgradedAt.(string)
+				return doc.Doc[dl.FieldUpgradeDetails] == nil && doc.Doc[dl.FieldUpgradeStartedAt] == nil && ok && isStr && upgradedAtStr != ""
+			}), mock.Anything, mock.Anything).Return(nil)
+			return mBulk
 		},
 		cache: func() *testcache.MockCache {
 			return testcache.NewMockCache()

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -418,6 +418,28 @@ func TestProcessUpgradeDetails(t *testing.T) {
 		},
 		err: nil,
 	}, {
+		name:    "agent has upgrade_started_at but no upgrade_details, checkin details are nil (fast upgrade race)",
+		agent:   &model.Agent{ESDocument: esd, Agent: &model.AgentMetadata{ID: "test-agent"}, UpgradeStartedAt: "2024-01-01T00:00:00Z"},
+		details: nil,
+		bulk: func() *ftesting.MockBulk {
+			mBulk := ftesting.NewMockBulk()
+			mBulk.On("Update", mock.Anything, dl.FleetAgents, "doc-ID", mock.MatchedBy(func(p []byte) bool {
+				doc := struct {
+					Doc map[string]any `json:"doc"`
+				}{}
+				if err := json.Unmarshal(p, &doc); err != nil {
+					t.Logf("bulk match unmarshal error: %v", err)
+					return false
+				}
+				return doc.Doc[dl.FieldUpgradeDetails] == nil && doc.Doc[dl.FieldUpgradeStartedAt] == nil && doc.Doc[dl.FieldUpgradedAt] != ""
+			}), mock.Anything, mock.Anything).Return(nil)
+			return mBulk
+		},
+		cache: func() *testcache.MockCache {
+			return testcache.NewMockCache()
+		},
+		err: nil,
+	}, {
 		name:    "agent has details checkin details are nil",
 		agent:   &model.Agent{ESDocument: esd, Agent: &model.AgentMetadata{ID: "test-agent"}, UpgradeDetails: &model.UpgradeDetails{}},
 		details: nil,

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -481,6 +481,31 @@ func TestProcessUpgradeDetails(t *testing.T) {
 		},
 		err: nil,
 	}, {
+		name: "agent has stale upgrade_started_at with fractional seconds (RFC3339Nano), same version (self-heal)",
+		// upgrade_started_at uses fractional seconds as Kibana may produce; must still parse and self-heal
+		agent:   &model.Agent{ESDocument: esd, Agent: &model.AgentMetadata{ID: "test-agent", Version: "8.19.0"}, UpgradeStartedAt: time.Now().Add(-3 * time.Hour).UTC().Format(time.RFC3339Nano)},
+		details: nil,
+		ver:     "",
+		bulk: func() *ftesting.MockBulk {
+			mBulk := ftesting.NewMockBulk()
+			mBulk.On("Update", mock.Anything, dl.FleetAgents, "doc-ID", mock.MatchedBy(func(p []byte) bool {
+				doc := struct {
+					Doc map[string]any `json:"doc"`
+				}{}
+				if err := json.Unmarshal(p, &doc); err != nil {
+					t.Logf("bulk match unmarshal error: %v", err)
+					return false
+				}
+				_, hasUpgradedAt := doc.Doc[dl.FieldUpgradedAt]
+				return doc.Doc[dl.FieldUpgradeDetails] == nil && doc.Doc[dl.FieldUpgradeStartedAt] == nil && !hasUpgradedAt
+			}), mock.Anything, mock.Anything).Return(nil)
+			return mBulk
+		},
+		cache: func() *testcache.MockCache {
+			return testcache.NewMockCache()
+		},
+		err: nil,
+	}, {
 		name:    "agent has details checkin details are nil",
 		agent:   &model.Agent{ESDocument: esd, Agent: &model.AgentMetadata{ID: "test-agent"}, UpgradeDetails: &model.UpgradeDetails{}},
 		details: nil,

--- a/internal/pkg/api/handleCheckin_test.go
+++ b/internal/pkg/api/handleCheckin_test.go
@@ -456,10 +456,11 @@ func TestProcessUpgradeDetails(t *testing.T) {
 		},
 		err: nil,
 	}, {
-		name:    "agent has stale upgrade_started_at but no upgrade_details, same version (self-heal after rolling fleet-server upgrade)",
-		agent:   &model.Agent{ESDocument: esd, Agent: &model.AgentMetadata{ID: "test-agent", Version: "8.19.0"}, UpgradeStartedAt: time.Now().Add(-upgradeStartedAtStalenessThreshold - time.Minute).UTC().Format(time.RFC3339)},
+		name: "agent has stale upgrade_started_at but no upgrade_details, same version (self-heal after rolling fleet-server upgrade)",
+		// upgrade_started_at older than 2× default CheckinMaxPoll (2h); cfg is nil in tests so fallback = 2h
+		agent:   &model.Agent{ESDocument: esd, Agent: &model.AgentMetadata{ID: "test-agent", Version: "8.19.0"}, UpgradeStartedAt: time.Now().Add(-3 * time.Hour).UTC().Format(time.RFC3339)},
 		details: nil,
-		ver:     "", // version matches stored — upgrade_started_at is stale so we clear it anyway
+		ver:     "", // version matches stored — upgrade_started_at is stale so we clear it; upgraded_at NOT set (outcome unknown)
 		bulk: func() *ftesting.MockBulk {
 			mBulk := ftesting.NewMockBulk()
 			mBulk.On("Update", mock.Anything, dl.FleetAgents, "doc-ID", mock.MatchedBy(func(p []byte) bool {
@@ -470,9 +471,8 @@ func TestProcessUpgradeDetails(t *testing.T) {
 					t.Logf("bulk match unmarshal error: %v", err)
 					return false
 				}
-				upgradedAt, ok := doc.Doc[dl.FieldUpgradedAt]
-				upgradedAtStr, isStr := upgradedAt.(string)
-				return doc.Doc[dl.FieldUpgradeDetails] == nil && doc.Doc[dl.FieldUpgradeStartedAt] == nil && ok && isStr && upgradedAtStr != ""
+				_, hasUpgradedAt := doc.Doc[dl.FieldUpgradedAt]
+				return doc.Doc[dl.FieldUpgradeDetails] == nil && doc.Doc[dl.FieldUpgradeStartedAt] == nil && !hasUpgradedAt
 			}), mock.Anything, mock.Anything).Return(nil)
 			return mBulk
 		},

--- a/internal/pkg/config/timeouts.go
+++ b/internal/pkg/config/timeouts.go
@@ -8,6 +8,15 @@ import (
 	"time"
 )
 
+const (
+	// DefaultCheckinMaxPoll is the default value for CheckinMaxPoll.
+	DefaultCheckinMaxPoll = time.Hour
+
+	// CheckinMaxPollFloor is the minimum effective value for CheckinMaxPoll;
+	// configured values below this floor are ignored.
+	CheckinMaxPollFloor = time.Minute
+)
+
 // ServerTimeouts is the configuration for the server timeouts
 type ServerTimeouts struct {
 	Read             time.Duration `config:"read"`
@@ -66,7 +75,7 @@ func (c *ServerTimeouts) InitDefaults() {
 	// MaxPoll is the maximum allowed value for a long poll when the client specified poll_timeout value is used.
 	// The long poll value is poll_timeout-2m, and the request's write timeout is set to poll_timeout-1m
 	// CheckinMaxPoll values of less then 1m are effectively ignored and a 1m limit is used.
-	c.CheckinMaxPoll = time.Hour
+	c.CheckinMaxPoll = DefaultCheckinMaxPoll
 
 	// Drain is the max duration that a server will keep connections open when a shutdown signal is received in order to gracefully handle in progress-requests.
 	// It is used as a context timeout value for server.ShutDown(ctx).


### PR DESCRIPTION
## What is the problem?

When an Elastic Agent upgrades faster than one checkin interval (~60 seconds), Fleet Server never observes any intermediate `upgrade_details` states (downloading, extracting, watching). The agent completes its upgrade and restarts at the new version within a single checkin gap.  In practice, this is unlikely to happen with an actual Elastic Agent.  But it is possible with Horde drones and, in theory, it could happen with Elastic Agents too.

In this case:
- `upgrade_started_at` is set on the agent document (written by Kibana's `bulk_upgrade` API) when the upgrade action is dispatched;
- `upgrade_details` is `null` on the agent document;
- The agent checks in with `upgrade_details: null` in the checkin body.

`processUpgradeDetails` calls `markUpgradeComplete` when the checkin body has `upgrade_details: null`. However, `markUpgradeComplete` had an early-return guard:

```go
if agent.UpgradeDetails == nil {
    return nil
}
```

Since `agent.UpgradeDetails` is also `nil` (no intermediate states were ever stored), this was a no-op. `upgrade_started_at` was never cleared, leaving the agent permanently in the "updating" state in Fleet UI — even though it had successfully upgraded to the target version.

This was observed in a 30,000-agent scale test (build [#6981](https://buildkite.com/elastic/observability-perf/builds/6981)) where one agent (`eh-ThoseChillwave-LHTb`) remained stuck in "updating" state, blocking Step10 from converging to `online == 30,000`.

## How does this PR solve the problem?

The NOP guard is extended to also require `upgrade_started_at` to be empty:

```go
if agent.UpgradeDetails == nil && agent.UpgradeStartedAt == "" {
    return nil
}
```

If `upgrade_started_at` is set but `upgrade_details` is nil, an upgrade was dispatched (by Kibana) but no intermediate states were ever recorded by Fleet Server. When the agent then checks in with `upgrade_details: null`, Fleet Server now correctly clears `upgrade_started_at`, sets `upgraded_at`, and marks the upgrade complete — regardless of whether any intermediate `upgrade_details` states were observed.

## How to test locally

1. Start a Fleet Server with an enrolled agent.
2. Trigger an upgrade via Kibana's `POST /api/fleet/agents/bulk_upgrade`. This sets `upgrade_started_at` on the agent document.
3. Before the agent sends any checkin with `upgrade_details`, manually set `upgrade_details: null` and the new version on the agent document (simulating a fast upgrade).
4. Send a checkin with `upgrade_details: null` (the default for a running, non-upgrading agent).
5. Verify that Fleet Server clears `upgrade_started_at` and sets `upgraded_at` on the agent document.

Alternatively, run the unit tests:
```
go test ./internal/pkg/api/ -run TestProcessUpgradeDetails -v
```

The new test case `"agent has upgrade_started_at but no upgrade_details, checkin details are nil (fast upgrade race)"` covers this scenario.

## Design Checklist

- [ ] The code is stateless (no local caching that could cause inconsistency between instances)
- [ ] The code has been tested with more than 100K agents
- [ ] There are fail safes in the code (e.g. timeouts, max values, graceful degradation)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding changes to the tests
- [x] I have added an entry in `./changelog/fragments` using the changelog tool