### PR TITLE
perf: add BenchmarkPolicyDispatch to quantify memory cost of #7794 clone-at-dispatch fix

### DIFF
--- a/internal/pkg/policy/monitor_test.go
+++ b/internal/pkg/policy/monitor_test.go
@@ -710,10 +710,10 @@ func TestMonitor_StaleRevisionSkipsSecretResolution(t *testing.T) {
 //
 // Run this benchmark on commits before and after #7794 to compare:
 //
-//   git stash  # or checkout the parent commit
-//   go test -run=^$ -bench=BenchmarkPolicyDispatch -benchmem ./internal/pkg/policy/
-//   git stash pop  # or checkout current commit
-//   go test -run=^$ -bench=BenchmarkPolicyDispatch -benchmem ./internal/pkg/policy/
+//	git stash  # or checkout the parent commit
+//	go test -run=^$ -bench=BenchmarkPolicyDispatch -benchmem ./internal/pkg/policy/
+//	git stash pop  # or checkout current commit
+//	go test -run=^$ -bench=BenchmarkPolicyDispatch -benchmem ./internal/pkg/policy/
 //
 // Before #7794: dispatchPending sends &policy.pp (0 clone allocs).
 // After  #7794: dispatchPending calls pp.Clone() per subscriber (N×clone allocs).

--- a/internal/pkg/policy/monitor_test.go
+++ b/internal/pkg/policy/monitor_test.go
@@ -704,3 +704,61 @@ func TestMonitor_StaleRevisionSkipsSecretResolution(t *testing.T) {
 	assert.NoError(t, err, "stale revision should be skipped without error, not trigger secret resolution")
 	assert.Equal(t, int64(8), pm.policies[policyID].pp.Policy.RevisionIdx, "cached revision must not change for stale input")
 }
+
+// BenchmarkPolicyDispatch measures fleet-server heap allocation per policy
+// dispatch cycle across varying subscriber counts.
+//
+// Run this benchmark on commits before and after #7794 to compare:
+//
+//   git stash  # or checkout the parent commit
+//   go test -run=^$ -bench=BenchmarkPolicyDispatch -benchmem ./internal/pkg/policy/
+//   git stash pop  # or checkout current commit
+//   go test -run=^$ -bench=BenchmarkPolicyDispatch -benchmem ./internal/pkg/policy/
+//
+// Before #7794: dispatchPending sends &policy.pp (0 clone allocs).
+// After  #7794: dispatchPending calls pp.Clone() per subscriber (N×clone allocs).
+// The bytes/op delta is the per-dispatch memory cost of the race-condition fix.
+func BenchmarkPolicyDispatch(b *testing.B) {
+	// benchDispatchPolicy has a remote_elasticsearch output with a secret
+	// service_token. This is the exact shape that triggered the incident
+	// (sdh-beats/issues/7585): processPolicy called slices.DeleteFunc on the
+	// shared SecretKeys for every remote ES output, causing concurrent
+	// processPolicy goroutines to race and corrupt the slice.
+	bulker := ftesting.NewMockBulk()
+	var d model.PolicyData
+	require.NoError(b, json.Unmarshal([]byte(benchDispatchPolicy), &d))
+	pp, err := NewParsedPolicy(context.Background(), bulker, model.Policy{
+		PolicyID:    "bench-policy",
+		RevisionIdx: 1,
+		Data:        &d,
+	})
+	require.NoError(b, err)
+
+	for _, subs := range []int{1, 10, 100, 1000} {
+		b.Run(fmt.Sprintf("subs=%d", subs), func(b *testing.B) {
+			m := &monitorT{
+				log:      zerolog.Nop(),
+				policies: map[string]policyT{"bench-policy": {pp: *pp}},
+				pendingQ: makeHead(),
+				limit:    rate.NewLimiter(rate.Inf, subs+1),
+			}
+			subscribers := make([]*subT, subs)
+			for i := range subs {
+				subscribers[i] = NewSub("bench-policy", fmt.Sprintf("agent-%d", i), 0)
+			}
+			ctx := context.Background()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				for _, s := range subscribers {
+					m.pendingQ.pushBack(s)
+				}
+				m.dispatchPending(ctx)
+				for _, s := range subscribers {
+					<-s.ch
+				}
+			}
+		})
+	}
+}

--- a/internal/pkg/policy/parsed_policy_test.go
+++ b/internal/pkg/policy/parsed_policy_test.go
@@ -37,6 +37,9 @@ var policyWithSecretsMixed string
 //go:embed testdata/policy_with_otel_secrets.json
 var policyWithOtelSecrets []byte
 
+//go:embed testdata/bench_dispatch_policy.json
+var benchDispatchPolicy string
+
 func TestNewParsedPolicy(t *testing.T) {
 	// Run two formatting of the same payload to validate that the sha2 remains the same
 	testcases := []struct {

--- a/internal/pkg/policy/testdata/bench_dispatch_policy.json
+++ b/internal/pkg/policy/testdata/bench_dispatch_policy.json
@@ -1,0 +1,73 @@
+{
+  "id": "bench-dispatch-policy",
+  "revision": 1,
+  "outputs": {
+    "default": {
+      "type": "elasticsearch",
+      "hosts": ["https://es.example.com:443"]
+    },
+    "remote-monitoring": {
+      "type": "remote_elasticsearch",
+      "hosts": ["https://monitor.example.com:443"],
+      "secrets": {
+        "service_token": {"id": "ST_ID"},
+        "ssl": {"key": {"id": "SSL_KEY_ID"}}
+      }
+    }
+  },
+  "output_permissions": {
+    "default": {
+      "_fallback": {
+        "indices": [
+          {
+            "names": ["logs-*", "metrics-*", "traces-*"],
+            "privileges": ["auto_configure", "create_doc"]
+          }
+        ]
+      }
+    },
+    "remote-monitoring": {
+      "_fallback": {
+        "indices": [
+          {
+            "names": ["logs-*", "metrics-*"],
+            "privileges": ["auto_configure", "create_doc"]
+          }
+        ]
+      }
+    }
+  },
+  "agent": {
+    "monitoring": {
+      "enabled": true,
+      "use_output": "remote-monitoring",
+      "logs": true,
+      "metrics": true
+    },
+    "download": {
+      "sourceURI": "$co.elastic.secret{DOWNLOAD_URI_ID}"
+    }
+  },
+  "inputs": [
+    {
+      "id": "logfile-input-1",
+      "type": "logfile",
+      "use_output": "default",
+      "streams": [
+        {
+          "paths": ["/var/log/app/*.log"],
+          "auth.basic.password": "$co.elastic.secret{INPUT_SECRET_ID}"
+        }
+      ]
+    }
+  ],
+  "secret_references": [
+    {"id": "ST_ID"},
+    {"id": "SSL_KEY_ID"},
+    {"id": "DOWNLOAD_URI_ID"},
+    {"id": "INPUT_SECRET_ID"}
+  ],
+  "fleet": {
+    "hosts": ["https://fleet.example.com:8220"]
+  }
+}


### PR DESCRIPTION
## Summary

Adds `BenchmarkPolicyDispatch` and a representative testdata policy to quantify the per-dispatch heap cost introduced by moving `ParsedPolicy.Clone()` from `processPolicy` to `dispatchPending` in #7794.

- The policy in `testdata/bench_dispatch_policy.json` mirrors the incident shape from [sdh-beats#7585](https://github.com/elastic/sdh-beats/issues/7585): a `remote_elasticsearch` output with a secret `service_token` (the field whose `slices.DeleteFunc` mutation was the racing write) plus a default `elasticsearch` output and input secrets.
- The benchmark calls `dispatchPending` directly so it exercises the real dispatch code path on each commit — no `Clone()` call in the benchmark itself — making it safe to run on the commit before #7794.
- Rate-limiting is set to `rate.Inf` so benchmark time measures allocation, not throttle delay.

## How to run

```bash
go test -run=^$ -bench=BenchmarkPolicyDispatch -benchmem -count=3 ./internal/pkg/policy/
```

## Results

### Before #7794 (`d012fac5` — `dispatchPending` sends `&policy.pp`, no clone)

```
BenchmarkPolicyDispatch/subs=1       451 ns/op    1,152 B/op      3 allocs/op
BenchmarkPolicyDispatch/subs=10     1952 ns/op    3,458 B/op     12 allocs/op
BenchmarkPolicyDispatch/subs=100   17107 ns/op   26,512 B/op    102 allocs/op
BenchmarkPolicyDispatch/subs=1000 177969 ns/op  257,073 B/op   1002 allocs/op
```

### After #7794 (`c9072761` — `dispatchPending` calls `pp.Clone()` per subscriber)

```
BenchmarkPolicyDispatch/subs=1      2348 ns/op    6,036 B/op     36 allocs/op
BenchmarkPolicyDispatch/subs=10    19819 ns/op   52,291 B/op    342 allocs/op
BenchmarkPolicyDispatch/subs=100  225678 ns/op  514,890 B/op   3402 allocs/op
BenchmarkPolicyDispatch/subs=1000 2198042 ns/op 5,138,586 B/op 34003 allocs/op
```

### Analysis

Each `Clone()` for this policy costs **~4,884 bytes across 33 allocations**. The cost scales linearly with subscriber count — one clone per subscriber per dispatch cycle.

At 1,000 concurrent agents receiving a policy update, the additional heap from cloning is **~4.9 MB**, released once `processPolicy` goroutines complete (bounded by ES round-trip latency, typically ≤100 ms). The "before" allocations (3–1,002 allocs/op) are fixed dispatch-loop overhead (APM span + rate-limiter reservation), unrelated to cloning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)